### PR TITLE
fix(ui): refine avail reporting and mobile admin layouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,16 @@
 
 * legacy device entries are no longer migrated into the new stream model
 
+### Features
+
+* **availnzb:** record successful playback reports only after real serving crosses byte or time thresholds
+* **history:** add richer AvailNZB reporting details and pending playback classification to NZB attempt details
+
+### Bug Fixes
+
+* **history:** show only serving providers for successful playback attempts and keep short playback sessions pending instead of failed
+* **ui:** improve NZB history readability and mobile layouts across dialogs, dashboard cards, stream management, and settings forms
+
 ### Notes
 
 * global configuration, providers, and indexers are kept during upgrade

--- a/frontend/src/components/AdvancedSettingsSection.jsx
+++ b/frontend/src/components/AdvancedSettingsSection.jsx
@@ -203,6 +203,11 @@ export const AdvancedSettingsSection = forwardRef(function AdvancedSettingsSecti
     baseClassName,
     showUnsavedHighlights && formState.dirtyFields?.[fieldName] && 'border-destructive ring-1 ring-destructive focus-visible:ring-destructive'
   )
+  const stackedFieldRowClass = "flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4"
+  const controlWideClass = "w-full min-w-0 sm:max-w-xs"
+  const controlMediumClass = "w-full min-w-0 sm:max-w-[10rem]"
+  const controlSelectClass = "flex h-9 w-full min-w-0 max-w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 overflow-hidden text-ellipsis whitespace-nowrap sm:max-w-[14rem]"
+  const labelClass = "min-w-0 text-sm font-medium"
 
   const handleCopyRecoverySecret = async () => {
     const recoverySecret = availNZBStatus?.recovery_secret?.trim?.() || ''
@@ -253,10 +258,10 @@ export const AdvancedSettingsSection = forwardRef(function AdvancedSettingsSecti
                   <div className="rounded-md border border-border/60">
                     <FormField control={control} name="log_level" render={({ field }) => (
                       <FormItem className="rounded-none border-0 p-3">
-                        <div className="flex items-center justify-between gap-4">
-                          <FormLabel className="text-sm font-medium flex items-center gap-1.5">Log Level <EnvOverrideIndicator show={envOverrides.includes('log_level')} /></FormLabel>
+                        <div className={stackedFieldRowClass}>
+                          <FormLabel className={cn(labelClass, 'flex items-center gap-1.5 sm:flex-1')}>Log Level <EnvOverrideIndicator show={envOverrides.includes('log_level')} /></FormLabel>
                           <FormControl>
-                            <select className={fieldClassName('log_level', 'flex h-9 w-40 rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2')} {...field}>
+                            <select className={fieldClassName('log_level', controlSelectClass)} {...field}>
                               <option value="DEBUG">DEBUG</option>
                               <option value="INFO">INFO</option>
                               <option value="WARN">WARN</option>
@@ -271,9 +276,9 @@ export const AdvancedSettingsSection = forwardRef(function AdvancedSettingsSecti
                     <FormField control={control} name="keep_log_files" render={({ field }) => (
                       <FormItem className="relative rounded-none border-0 p-3">
                         <div className="absolute left-3 right-3 top-0 border-t border-border/60" />
-                        <div className="flex items-center justify-between gap-4">
-                          <FormLabel className="text-sm font-medium flex items-center gap-1.5">Keep log files <EnvOverrideIndicator show={envOverrides.includes('keep_log_files')} /></FormLabel>
-                          <FormControl><Input type="number" min={1} max={50} className={fieldClassName('keep_log_files', 'h-9 w-28')} {...field} value={field.value ?? ''} onChange={e => { const v = e.target.value; field.onChange(v === '' ? 9 : Math.min(50, Math.max(1, Number(v) || 9))) }} /></FormControl>
+                        <div className={stackedFieldRowClass}>
+                          <FormLabel className={cn(labelClass, 'flex items-center gap-1.5 sm:flex-1')}>Keep log files <EnvOverrideIndicator show={envOverrides.includes('keep_log_files')} /></FormLabel>
+                          <FormControl><Input type="number" min={1} max={50} className={fieldClassName('keep_log_files', `h-9 ${controlMediumClass}`)} {...field} value={field.value ?? ''} onChange={e => { const v = e.target.value; field.onChange(v === '' ? 9 : Math.min(50, Math.max(1, Number(v) || 9))) }} /></FormControl>
                         </div>
                         <FormDescription className="mt-3">Number of log files to keep. Oldest rotated logs are purged on restart.</FormDescription>
                         <FormMessage />
@@ -284,9 +289,9 @@ export const AdvancedSettingsSection = forwardRef(function AdvancedSettingsSecti
                   <div className="rounded-md border border-border/60">
                     <FormField control={control} name="nzb_history_retention_days" render={({ field }) => (
                       <FormItem className="rounded-none border-0 p-3">
-                        <div className="flex items-center justify-between gap-4">
-                          <FormLabel className="text-sm font-medium">NZB history retention (days)</FormLabel>
-                          <FormControl><Input type="number" min={0} max={3650} className={fieldClassName('nzb_history_retention_days', 'h-9 w-28')} {...field} value={field.value ?? ''} onChange={e => { const v = e.target.value; const next = Number(v); field.onChange(v === '' ? 90 : Math.min(3650, Math.max(0, Number.isNaN(next) ? 90 : next))) }} /></FormControl>
+                        <div className={stackedFieldRowClass}>
+                          <FormLabel className={cn(labelClass, 'sm:flex-1')}>NZB history retention (days)</FormLabel>
+                          <FormControl><Input type="number" min={0} max={3650} className={fieldClassName('nzb_history_retention_days', `h-9 ${controlMediumClass}`)} {...field} value={field.value ?? ''} onChange={e => { const v = e.target.value; const next = Number(v); field.onChange(v === '' ? 90 : Math.min(3650, Math.max(0, Number.isNaN(next) ? 90 : next))) }} /></FormControl>
                         </div>
                         <FormDescription className="mt-3">Delete NZB history entries older than this many days on startup.</FormDescription>
                         <FormMessage />
@@ -311,9 +316,9 @@ export const AdvancedSettingsSection = forwardRef(function AdvancedSettingsSecti
                 <div className="rounded-md border border-border/60">
                   <FormField control={control} name="memory_limit_mb" render={({ field }) => (
                     <FormItem className="rounded-none border-0 p-3">
-                      <div className="flex items-center justify-between gap-4">
-                        <FormLabel className="text-sm font-medium">Memory limit (MB)</FormLabel>
-                        <FormControl><Input type="number" min={0} className={fieldClassName('memory_limit_mb', 'h-9 w-28')} {...field} value={field.value ?? ''} onChange={e => { const v = e.target.value; field.onChange(v === '' ? 0 : Number(v) || 0) }} /></FormControl>
+                      <div className={stackedFieldRowClass}>
+                        <FormLabel className={cn(labelClass, 'sm:flex-1')}>Memory limit (MB)</FormLabel>
+                        <FormControl><Input type="number" min={0} className={fieldClassName('memory_limit_mb', `h-9 ${controlMediumClass}`)} {...field} value={field.value ?? ''} onChange={e => { const v = e.target.value; field.onChange(v === '' ? 0 : Number(v) || 0) }} /></FormControl>
                       </div>
                       <FormDescription className="mt-3">Soft limit on total process memory (0 = no limit). Segment cache uses 80% of this. Restart required.</FormDescription>
                       <FormMessage />
@@ -398,8 +403,8 @@ export const AdvancedSettingsSection = forwardRef(function AdvancedSettingsSecti
                 <FormField control={control} name="availnzb_mode" render={({ field }) => (
                   <FormItem className="relative rounded-none border-0 p-3">
                     <div className="absolute left-3 right-3 top-0 border-t border-border/60" />
-                    <div className="flex items-center justify-between gap-4">
-                      <FormLabel className="flex items-center gap-2 text-sm font-medium">
+                    <div className={stackedFieldRowClass}>
+                      <FormLabel className={cn(labelClass, "flex items-center gap-2 sm:flex-1")}>
                         <span>AvailNZB mode</span>
                         <TooltipProvider delayDuration={150}>
                           <Tooltip>
@@ -421,7 +426,7 @@ export const AdvancedSettingsSection = forwardRef(function AdvancedSettingsSecti
                         </TooltipProvider>
                       </FormLabel>
                       <FormControl>
-                        <select className={fieldClassName('availnzb_mode', 'flex h-9 w-56 rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2')} {...field}>
+                        <select className={fieldClassName('availnzb_mode', controlSelectClass)} {...field}>
                           <option value="">GET status + POST report</option>
                           <option value="status_only">GET status only</option>
                           <option value="disabled">Disabled</option>

--- a/frontend/src/components/ConfirmDialog.jsx
+++ b/frontend/src/components/ConfirmDialog.jsx
@@ -20,11 +20,23 @@ export function ConfirmDialog({
           <DialogTitle>{title}</DialogTitle>
           {description ? <DialogDescription>{description}</DialogDescription> : null}
         </DialogHeader>
-        <DialogFooter>
-          <Button type="button" variant="ghost" onClick={() => onOpenChange(false)} disabled={confirming}>
+        <DialogFooter className="flex-row flex-wrap items-center justify-center gap-2 sm:justify-center sm:space-x-0">
+          <Button
+            type="button"
+            variant="outline"
+            className="min-w-28"
+            onClick={() => onOpenChange(false)}
+            disabled={confirming}
+          >
             {cancelLabel}
           </Button>
-          <Button type="button" variant={confirmVariant} onClick={onConfirm} disabled={confirming}>
+          <Button
+            type="button"
+            variant={confirmVariant}
+            className="min-w-28"
+            onClick={onConfirm}
+            disabled={confirming}
+          >
             {confirmLabel}
           </Button>
         </DialogFooter>

--- a/frontend/src/components/DashboardPage.jsx
+++ b/frontend/src/components/DashboardPage.jsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
 import {
   ChartContainer,
@@ -34,6 +35,7 @@ export function DashboardPage({ stats, chartData, sendCommand, config }) {
   const [availNZBStatus, setAvailNZBStatus] = useState(null)
   const [availNZBStatusLoading, setAvailNZBStatusLoading] = useState(false)
   const [availNZBStatusError, setAvailNZBStatusError] = useState('')
+  const [activeSessionToClose, setActiveSessionToClose] = useState(null)
   const availNZBEnabled = (config?.availnzb_mode || '') !== 'disabled'
   const indexerUrls = useMemo(() => {
     const urls = new Map()
@@ -148,10 +150,17 @@ export function DashboardPage({ stats, chartData, sendCommand, config }) {
         ? 'bg-chart-4'
         : 'bg-primary'
 
+  const confirmCloseActiveSession = () => {
+    if (!activeSessionToClose) return
+    sendCommand('close_session', { id: activeSessionToClose.id })
+    setActiveSessionToClose(null)
+  }
+
   return (
-    <div className="flex flex-col gap-4 py-4 md:gap-6 md:py-6 px-4 lg:px-6">
-      {/* KPI cards */}
-      <div className="grid grid-cols-2 gap-4 lg:grid-cols-5">
+    <>
+      <div className="flex flex-col gap-4 py-4 md:gap-6 md:py-6 px-4 lg:px-6">
+        {/* KPI cards */}
+        <div className="grid grid-cols-2 gap-4 lg:grid-cols-5">
         <Card className="overflow-hidden">
           <CardHeader>
             <div className="flex items-center justify-between gap-2">
@@ -223,8 +232,8 @@ export function DashboardPage({ stats, chartData, sendCommand, config }) {
         </Card>
       </div>
 
-      {/* Network chart */}
-      <Card className="overflow-hidden">
+        {/* Network chart */}
+        <Card className="overflow-hidden">
         <CardHeader>
           <CardTitle>Network activity</CardTitle>
           <CardDescription>Speed (Mbps) and active connections over time</CardDescription>
@@ -272,39 +281,50 @@ export function DashboardPage({ stats, chartData, sendCommand, config }) {
             </ComposedChart>
           </ChartContainer>
         </CardContent>
-      </Card>
+        </Card>
 
-      {/* Active sessions */}
-      {stats.active_sessions?.length > 0 && (
-        <div>
-          <div className="flex items-center gap-2 mb-2">
-            <Activity className="h-4 w-4 text-primary" />
-            <h2 className="text-sm font-semibold">Active streams</h2>
-          </div>
-          <div className="grid gap-2 md:grid-cols-2 lg:grid-cols-3">
-            {stats.active_sessions.map(sess => (
-              <Card key={sess.id} className="group relative min-w-0 pr-10">
-                <CardContent className="p-3">
-                  <div className="text-sm font-medium truncate pr-2 min-w-0" title={sess.title}>{sess.title}</div>
-                  <div className="text-xs text-muted-foreground truncate min-w-0">{sess.clients.join(', ')}</div>
-                </CardContent>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="absolute right-2 top-1/2 -translate-y-1/2 h-7 w-7 text-destructive hover:text-destructive hover:bg-destructive/10"
-                  onClick={() => sendCommand('close_session', { id: sess.id })}
-                  title="End stream"
-                >
-                  <X className="h-4 w-4" />
-                </Button>
-              </Card>
-            ))}
-          </div>
-        </div>
-      )}
+        {/* Active sessions */}
+        {stats.active_sessions?.length > 0 && (
+          <Card className="overflow-hidden">
+            <CardHeader>
+              <div className="flex items-center gap-2">
+                <Activity className="h-5 w-5 text-primary" />
+                <CardTitle className="text-lg font-semibold tracking-tight">Active streams</CardTitle>
+              </div>
+              <CardDescription>Streams that are currently being played.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-2">
+                {stats.active_sessions.map(sess => (
+                  <Card key={sess.id} className="group relative min-w-0 pr-10">
+                    <CardContent className="p-3">
+                      <div
+                        className="min-w-0 pr-2 text-sm font-medium leading-snug whitespace-normal break-words [overflow-wrap:anywhere] md:truncate md:whitespace-nowrap"
+                        title={sess.title}
+                      >
+                        {sess.title}
+                      </div>
+                      <div className="text-xs text-muted-foreground truncate min-w-0">{sess.clients.join(', ')}</div>
+                    </CardContent>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="absolute right-2 top-1/2 -translate-y-1/2 h-7 w-7 text-destructive hover:text-destructive hover:bg-destructive/10"
+                      onClick={() => setActiveSessionToClose(sess)}
+                      title="End stream"
+                      aria-label={`End stream ${sess.title}`}
+                    >
+                      <X className="h-4 w-4" />
+                    </Button>
+                  </Card>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        )}
 
-      {/* Providers & Indexers */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {/* Providers & Indexers */}
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         <Card className="overflow-hidden">
           <CardHeader>
             <div className="flex items-center gap-2">
@@ -455,7 +475,29 @@ export function DashboardPage({ stats, chartData, sendCommand, config }) {
             </div>
           </CardContent>
         </Card>
+        </div>
       </div>
-    </div>
+
+      <Dialog open={Boolean(activeSessionToClose)} onOpenChange={(open) => { if (!open) setActiveSessionToClose(null) }}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>End active stream?</DialogTitle>
+            <DialogDescription className="break-words [overflow-wrap:anywhere]">
+              {activeSessionToClose
+                ? `This will stop playback for "${activeSessionToClose.title}".`
+                : 'This will stop playback for the selected stream.'}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter className="flex-row flex-wrap items-center justify-center gap-2 sm:justify-center sm:space-x-0">
+            <Button type="button" variant="outline" className="min-w-28" onClick={() => setActiveSessionToClose(null)}>
+              Cancel
+            </Button>
+            <Button type="button" variant="destructive" className="min-w-28" onClick={confirmCloseActiveSession}>
+              End stream
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
   )
 }

--- a/frontend/src/components/IndexerSettings.jsx
+++ b/frontend/src/components/IndexerSettings.jsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Switch } from "@/components/ui/switch"
-import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, focusDialogCloseButton } from "@/components/ui/dialog"
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
 import { ConfirmDialog } from "@/components/ConfirmDialog"
@@ -244,7 +244,7 @@ function IndexerDialog({ open, onOpenChange, initialValue, onSave, onClearStatus
       }
       requestClose()
     }}>
-      <DialogContent className="flex max-h-[85vh] max-w-3xl flex-col overflow-hidden" onOpenAutoFocus={(event) => event.preventDefault()}>
+      <DialogContent className="flex max-h-[85vh] max-w-3xl flex-col overflow-hidden" onOpenAutoFocus={focusDialogCloseButton}>
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
           <DialogDescription>{description}</DialogDescription>

--- a/frontend/src/components/IndexerSettings.jsx
+++ b/frontend/src/components/IndexerSettings.jsx
@@ -244,7 +244,7 @@ function IndexerDialog({ open, onOpenChange, initialValue, onSave, onClearStatus
       }
       requestClose()
     }}>
-      <DialogContent className="flex max-h-[85vh] max-w-3xl flex-col overflow-hidden">
+      <DialogContent className="flex max-h-[85vh] max-w-3xl flex-col overflow-hidden" onOpenAutoFocus={(event) => event.preventDefault()}>
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
           <DialogDescription>{description}</DialogDescription>
@@ -443,11 +443,11 @@ function IndexerDialog({ open, onOpenChange, initialValue, onSave, onClearStatus
               </div>
             )}
           </div>
-          <div className="flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2">
-          <Button type="button" variant="ghost" onClick={requestClose}>Cancel</Button>
-          <Button type="button" variant="destructive" onClick={handleSave} disabled={saving}>
-            {saveLabel}
-          </Button>
+          <div className="flex flex-row items-center justify-end gap-2">
+            <Button type="button" variant="outline" onClick={requestClose}>Cancel</Button>
+            <Button type="button" variant="destructive" onClick={handleSave} disabled={saving}>
+              {saveLabel}
+            </Button>
           </div>
         </DialogFooter>
       </DialogContent>
@@ -570,14 +570,14 @@ export function IndexerSettings({ fields = [], append, update, remove, replace, 
       <div className="space-y-4">
         <Card>
           <CardHeader>
-            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-              <div className="space-y-0.5">
+            <div className="grid grid-cols-[minmax(0,1fr)_auto] items-start gap-3">
+              <div className="min-w-0 space-y-0.5">
                 <CardTitle>Indexers</CardTitle>
-                <CardDescription>Configure your search sources.</CardDescription>
+                <CardDescription className="break-words">Configure your search sources.</CardDescription>
               </div>
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <Button type="button" variant="destructive" size="icon" className="h-9 w-9" onClick={() => setShowAddDialog(true)} aria-label="Add indexer">
+                  <Button type="button" variant="destructive" size="icon" className="h-9 w-9 shrink-0" onClick={() => setShowAddDialog(true)} aria-label="Add indexer">
                     <Plus className="h-4 w-4" />
                   </Button>
                 </TooltipTrigger>
@@ -601,9 +601,8 @@ export function IndexerSettings({ fields = [], append, update, remove, replace, 
                   >
                     <CardContent className="pt-6">
                       <div className="min-w-0 flex-1 space-y-3">
-                          <div className="flex items-start justify-between gap-3">
-                            <div className="min-w-0 font-semibold">{normalized.name || normalized.url || `Indexer ${index + 1}`}</div>
-                            <div className="flex items-center gap-2">
+                          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                            <div className="flex items-center gap-2 self-end sm:order-2">
                               <Tooltip>
                                 <TooltipTrigger asChild>
                                   <div className="inline-flex h-9 w-20 items-center justify-center rounded-md border border-border/60 bg-muted/30 px-2">
@@ -639,6 +638,7 @@ export function IndexerSettings({ fields = [], append, update, remove, replace, 
                                 <TooltipContent>Delete indexer</TooltipContent>
                               </Tooltip>
                             </div>
+                            <div className="min-w-0 font-semibold sm:order-1">{normalized.name || normalized.url || `Indexer ${index + 1}`}</div>
                           </div>
                           <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3">
                             <div className="flex flex-wrap gap-2 text-xs text-muted-foreground min-w-0">

--- a/frontend/src/components/NZBHistoryPage.jsx
+++ b/frontend/src/components/NZBHistoryPage.jsx
@@ -1,9 +1,10 @@
-import { Fragment, useState, useEffect, useCallback, useMemo } from 'react'
+import { Fragment, useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { History, Loader2, ExternalLink, RefreshCw, Copy, Check, ChevronDown, ChevronRight, Info, Search as SearchIcon, SlidersHorizontal } from 'lucide-react'
 import { getApiUrl, apiFetch } from '../api'
 import { cn } from '@/lib/utils'
@@ -21,6 +22,12 @@ function formatSize(bytes) {
 function formatAttemptResult(attempt) {
   if (attempt.preload) return 'Pending'
   return attempt.success ? 'OK' : 'Failed'
+}
+
+function formatAttemptBadgeLabel(attempt) {
+  if (attempt.preload) return 'Pending'
+  if (attempt.success) return 'OK'
+  return shortReason(attempt.failure_reason) || 'Failed'
 }
 
 function shortReason(reason) {
@@ -55,6 +62,10 @@ function formatDateOnly(value) {
 
 function formatTimeOnly(value) {
   return new Date(value).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+}
+
+function formatTimeWithSeconds(value) {
+  return new Date(value).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })
 }
 
 function formatContentTypeLabel(contentType) {
@@ -232,10 +243,18 @@ function buildRequestGroups(attempts) {
 
 function formatGroupStatus(group) {
   if (group.okCount > 0) return 'OK'
+  if (group.preloadCount > 0 && group.failedCount === 0) return 'Pending'
   return 'Failed'
 }
 
+function formatAvailStatus(value) {
+  if (value === 'sent') return 'Sent'
+  if (value === 'skipped') return 'Skipped'
+  return '—'
+}
+
 function statusTone(group) {
+  if (group.preloadCount > 0 && group.failedCount === 0) return 'secondary'
   return group.okCount > 0 ? 'success' : 'destructive'
 }
 
@@ -251,6 +270,43 @@ function groupRequestsByDay(groups) {
     day,
     items,
   }))
+}
+
+function DetailSection({ title, children }) {
+  return (
+    <section className="mt-7 space-y-1.5 first:mt-0">
+      <div className="px-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">{title}</div>
+      <div className="overflow-hidden rounded-xl border border-border/60 bg-muted/20">
+        {children}
+      </div>
+    </section>
+  )
+}
+
+function DetailRow({ label, value, mono = false, tone = 'default', bordered = false }) {
+  return (
+    <div className="relative px-4 py-3 sm:px-5">
+      {bordered ? <div className="absolute left-4 right-4 top-0 border-t border-border/60 sm:left-5 sm:right-5" /> : null}
+      <div
+        className={cn(
+          'grid grid-cols-[5.5rem_minmax(0,1fr)] gap-3 text-sm',
+          'items-center',
+          tone === 'danger' && 'sm:grid-cols-[5.5rem_minmax(0,1fr)]'
+        )}
+      >
+        <div className="text-muted-foreground">{label}</div>
+        <div
+          className={cn(
+            'min-w-0 break-words leading-relaxed [overflow-wrap:anywhere]',
+            mono && 'rounded-md border border-border/50 bg-background/70 px-3 py-2 font-mono text-xs sm:text-sm',
+            tone === 'danger' && 'rounded-md border border-red-200/70 bg-red-50/70 px-3 py-2 text-red-700 dark:border-red-900/50 dark:bg-red-950/30 dark:text-red-300'
+          )}
+        >
+          {value || '—'}
+        </div>
+      </div>
+    </div>
+  )
 }
 
 function SummaryCard({ label, value, tone }) {
@@ -292,13 +348,14 @@ export function NZBHistoryPage({ refreshTrigger }) {
   const [error, setError] = useState(null)
   const [copyError, setCopyError] = useState(null)
   const [copiedAttemptId, setCopiedAttemptId] = useState(null)
-  const [expandedGroups, setExpandedGroups] = useState({})
+  const [expandedGroupKey, setExpandedGroupKey] = useState(null)
   const [selectedAttemptId, setSelectedAttemptId] = useState(null)
   const [timeframe, setTimeframe] = useState('7d')
   const [resultFilter, setResultFilter] = useState('all')
   const [streamFilter, setStreamFilter] = useState('all')
   const [search, setSearch] = useState('')
   const [filtersDialogOpen, setFiltersDialogOpen] = useState(false)
+  const attemptDetailScrollRef = useRef(null)
 
   const fetchAttempts = useCallback((showLoadingSpinner = true) => {
     if (showLoadingSpinner) setLoading(true)
@@ -351,7 +408,7 @@ export function NZBHistoryPage({ refreshTrigger }) {
   }), [filteredAttempts, requestGroups])
 
   const toggleGroup = useCallback((key) => {
-    setExpandedGroups((current) => ({ ...current, [key]: !current[key] }))
+    setExpandedGroupKey((current) => (current === key ? null : key))
   }, [])
 
   const requestsByDay = useMemo(() => groupRequestsByDay(requestGroups), [requestGroups])
@@ -374,6 +431,11 @@ export function NZBHistoryPage({ refreshTrigger }) {
     () => filteredAttempts.find((attempt) => attempt.id === selectedAttemptId) || null,
     [filteredAttempts, selectedAttemptId]
   )
+
+  useEffect(() => {
+    if (!selectedAttempt || !attemptDetailScrollRef.current) return
+    attemptDetailScrollRef.current.scrollTop = 0
+  }, [selectedAttempt])
 
   const resetFilters = useCallback(() => {
     setTimeframe('7d')
@@ -438,12 +500,19 @@ export function NZBHistoryPage({ refreshTrigger }) {
               <div className="flex items-center gap-2">
                 <div className="flex h-11 min-w-0 flex-1 items-center gap-2 rounded-lg border border-border/60 bg-background px-3 shadow-xs">
                   <SearchIcon className="size-4 shrink-0 text-muted-foreground" />
-                  <Input
-                    value={search}
-                    onChange={(event) => setSearch(event.target.value)}
-                    placeholder="Request, release, provider, ID or indexer"
-                    className="h-auto border-0 bg-transparent p-0 shadow-none focus-visible:ring-0"
-                  />
+                  <div className="relative min-w-0 flex-1">
+                    <Input
+                      value={search}
+                      onChange={(event) => setSearch(event.target.value)}
+                      placeholder=""
+                      className="h-auto min-w-0 border-0 bg-transparent p-0 shadow-none focus-visible:ring-0"
+                    />
+                    {!search ? (
+                      <span className="pointer-events-none absolute inset-0 overflow-hidden text-ellipsis whitespace-nowrap text-muted-foreground">
+                        Request, release, provider, ID or indexer
+                      </span>
+                    ) : null}
+                  </div>
                 </div>
                 <Button
                   type="button"
@@ -455,7 +524,7 @@ export function NZBHistoryPage({ refreshTrigger }) {
                 >
                   <SlidersHorizontal className="size-4" />
                   {activeFilterChips.length > 0 ? (
-                    <span className="absolute right-2 top-2 size-2 rounded-full bg-primary" />
+                    <span className="absolute -right-1 -top-1 size-3.5 rounded-full border-2 border-background bg-primary shadow-sm" />
                   ) : null}
                 </Button>
               </div>
@@ -486,120 +555,91 @@ export function NZBHistoryPage({ refreshTrigger }) {
                 No matching NZB attempts found for the current filters.
               </div>
             ) : (
-              <div className="flex min-w-0 flex-1 min-h-0 flex-col overflow-y-auto rounded-lg border border-border/60">
-                <table className="w-full table-fixed border-collapse text-sm">
-                  <thead className="sticky top-0 z-10 bg-background">
-                      <tr className="border-b border-border/60 text-left">
-                        <th className="w-[84px] px-3 py-3 font-medium text-muted-foreground">
-                          <div className="flex justify-center">Time</div>
-                        </th>
-                        <th className="px-3 py-3 font-medium text-muted-foreground">Request</th>
-                        <th className="w-[120px] px-2 py-3 font-medium text-muted-foreground text-center">
-                          <div className="mx-auto w-fit pl-5 text-center">Status</div>
-                        </th>
-                        <th className="w-[72px] px-2 py-3 font-medium text-muted-foreground" />
-                      </tr>
-                  </thead>
+              <div className="flex min-w-0 flex-1 min-h-0 flex-col overflow-y-auto rounded-lg border border-border/60 bg-background/40 p-3 md:p-4">
+                <div className="flex min-w-0 flex-col gap-5">
                   {requestsByDay.map((section) => (
-                    <tbody key={section.day}>
-                      <tr className="bg-background">
-                        <td colSpan={4} className="px-0 py-0">
-                          <div className="grid grid-cols-[84px_minmax(0,1fr)_120px_72px] border-y border-border/40 bg-muted/45 px-0 py-2">
-                            <div className="flex justify-center">
-                              <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                                {section.day}
-                              </span>
-                            </div>
-                            <div />
-                            <div />
-                            <div />
-                          </div>
-                        </td>
-                      </tr>
-                      {section.items.map((group) => {
-                        const expanded = Boolean(expandedGroups[group.key])
-                        const activeAttempt = group.active
-                        return (
-                          <Fragment key={group.key}>
-                            <tr className="border-b border-border/50 bg-background/80 hover:bg-muted/20">
-                              <td className="px-3 py-3 align-middle">
-                                <div className="flex justify-center">
-                                  <span className="text-xs font-normal text-muted-foreground">
-                                    {formatTimeOnly(group.requestTime)}
-                                  </span>
+                    <div key={section.day} className="space-y-3 pb-3 md:pb-4">
+                      <div className="rounded-lg border border-border/60 bg-muted/30 px-4 py-3 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                        {section.day}
+                      </div>
+                      <div className="space-y-3">
+                        {section.items.map((group) => {
+                          const expanded = expandedGroupKey === group.key
+                          return (
+                            <div
+                              key={group.key}
+                              className={cn(
+                                'overflow-hidden rounded-xl border bg-background/95 shadow-sm transition-all duration-200 hover:bg-muted/10',
+                                expanded
+                                  ? 'border-primary/40 ring-1 ring-primary/25 shadow-md bg-primary/[0.03]'
+                                  : 'border-border/60'
+                              )}
+                            >
+                              <button
+                                type="button"
+                                onClick={() => toggleGroup(group.key)}
+                                aria-label={`${expanded ? 'Collapse' : 'Expand'} attempts for ${group.title}`}
+                                aria-expanded={expanded}
+                                className="flex w-full min-w-0 flex-col gap-3 px-4 py-4 text-left md:px-5"
+                              >
+                                <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3">
+                                  <div className="min-w-0">
+                                    <div className="inline-flex items-center rounded-md border border-border/60 bg-muted/30 px-2.5 py-0.5 text-xs text-muted-foreground">
+                                      {formatTimeOnly(group.requestTime)}
+                                    </div>
+                                  </div>
+                                  <div className="flex items-center gap-2">
+                                    <Badge
+                                      variant={statusTone(group) === 'destructive' ? 'destructive' : 'secondary'}
+                                      className={cn(
+                                        'shrink-0',
+                                        statusTone(group) === 'success' && 'bg-green-600 text-white hover:bg-green-600 hover:text-white dark:text-black',
+                                        statusTone(group) === 'destructive' && 'bg-red-500 text-white hover:bg-red-500 hover:text-white dark:bg-red-500 dark:text-black'
+                                      )}
+                                    >
+                                      {formatGroupStatus(group)}
+                                    </Badge>
+                                    <span className="text-xs text-muted-foreground">
+                                      {group.attempts.length}
+                                    </span>
+                                    {expanded ? <ChevronDown className="size-4 shrink-0 text-muted-foreground" /> : <ChevronRight className="size-4 shrink-0 text-muted-foreground" />}
+                                  </div>
                                 </div>
-                              </td>
-                              <td className="px-3 py-3 align-top">
-                                <div className="min-w-0">
-                                  <div className="truncate font-medium">{group.title}</div>
-                                  <div className="truncate text-xs text-muted-foreground">
+                                <div className="space-y-1.5">
+                                  <div className="line-clamp-2 text-base font-semibold leading-snug md:text-lg">
+                                    {group.title}
+                                  </div>
+                                  <div className="text-xs text-muted-foreground [overflow-wrap:anywhere]">
                                     {[group.latest?.stream_name || 'default', formatContentTypeLabel(group.contentType), group.latest?.content_id || '—'].join(' • ')}
                                   </div>
                                 </div>
-                              </td>
-                              <td className="px-2 py-3 align-middle">
-                                <div className="flex w-full justify-center pl-5">
-                                  <Badge
-                                    variant={statusTone(group) === 'destructive' ? 'destructive' : 'secondary'}
-                                    className={cn(
-                                      statusTone(group) === 'success' && 'bg-green-600 text-white hover:bg-green-600 hover:text-white dark:text-black',
-                                      statusTone(group) === 'destructive' && 'bg-red-500 text-white hover:bg-red-500 hover:text-white dark:bg-red-500 dark:text-black',
-                                      statusTone(group) === 'default' && 'bg-blue-600 text-white hover:bg-blue-600'
-                                    )}
-                                  >
-                                    {formatGroupStatus(group)}
-                                  </Badge>
-                                </div>
-                              </td>
-                              <td className="w-[56px] px-2 py-3 align-middle text-right">
-                                <div className="inline-flex min-w-[40px] items-center justify-end gap-1.5">
-                                  {!expanded ? (
-                                    <span className="text-xs font-medium text-muted-foreground">
-                                      {group.attempts.length}
-                                    </span>
-                                  ) : null}
-                                  <button
-                                    type="button"
-                                    onClick={() => toggleGroup(group.key)}
-                                    aria-label={`${expanded ? 'Collapse' : 'Expand'} attempts for ${group.title}`}
-                                    aria-expanded={expanded}
-                                    className="inline-flex items-center justify-center rounded-sm text-muted-foreground transition-colors hover:text-foreground"
-                                  >
-                                    {expanded ? <ChevronDown className="size-4" /> : <ChevronRight className="size-4" />}
-                                  </button>
-                                </div>
-                              </td>
-                            </tr>
-                            {expanded && (
-                              <tr className="border-b border-border/50 bg-muted/10">
-                                <td colSpan={4} className="bg-muted/25 px-4 py-5">
-                                  <div className="animate-in slide-in-from-top-1 fade-in-0 rounded-lg border border-border/70 bg-background/95 shadow-sm duration-200">
-                                    <table className="w-full table-fixed border-collapse text-sm">
-                                      <tbody>
-                                        {group.attempts.map((attempt) => {
-                                          const reasonLabel = shortReason(attempt.failure_reason)
-                                          const attemptBadgeLabel = attempt.success ? 'OK' : (reasonLabel || (attempt.preload ? 'Pending' : 'Failed'))
-                                          return (
-                                            <Fragment key={attempt.id}>
-                                              <tr className="border-b border-border/50">
-                                                <td className="px-3 py-3 align-top">
-                                                  <div className="truncate font-medium">{attempt.release_title || '—'}</div>
-                                                  <div className="mt-1 truncate text-xs text-muted-foreground">
-                                                    {[attempt.indexer_name || '—', attempt.provider_name || '—', formatSize(attempt.release_size)].join(' • ')}
-                                                  </div>
-                                                </td>
-                                                <td className="w-[120px] px-2 py-3 align-middle">
-                                                  <div className="flex items-center justify-center pl-5">
-                                                    <Badge
-                                                      variant={attempt.success ? 'default' : attempt.preload ? 'secondary' : 'destructive'}
-                                                      className={attemptBadgeClass(attempt, reasonLabel)}
-                                                    >
-                                                      {attemptBadgeLabel}
-                                                    </Badge>
-                                                  </div>
-                                                </td>
-                                                <td className="w-[72px] px-3 py-3 align-middle text-right">
-                                                  <div className="flex w-full justify-end">
+                              </button>
+
+                              {expanded && (
+                                <div className="border-t border-border/60 bg-muted/20 px-3 py-3 md:px-5 md:py-4">
+                                  <div className="animate-in slide-in-from-top-1 fade-in-0 space-y-2 duration-200">
+                                    {group.attempts.map((attempt) => {
+                                      const reasonLabel = shortReason(attempt.failure_reason)
+                                      const attemptBadgeLabel = formatAttemptBadgeLabel(attempt)
+                                      return (
+                                        <div
+                                          key={attempt.id}
+                                          className="grid grid-cols-1 gap-3 rounded-lg border border-border/60 bg-background/95 px-3 py-3"
+                                        >
+                                          <div className="flex items-center justify-between gap-3">
+                                            <div className="inline-flex items-center rounded-md border border-border/60 bg-muted/30 px-2.5 py-0.5 text-xs text-muted-foreground">
+                                              {formatTimeWithSeconds(attempt.tried_at)}
+                                            </div>
+                                            <div className="flex items-center gap-2">
+                                              <Badge
+                                                variant={attempt.success ? 'default' : attempt.preload ? 'secondary' : 'destructive'}
+                                                className={attemptBadgeClass(attempt, reasonLabel)}
+                                              >
+                                                {attemptBadgeLabel}
+                                              </Badge>
+                                              <TooltipProvider delayDuration={100}>
+                                                <Tooltip>
+                                                  <TooltipTrigger asChild>
                                                     <button
                                                       type="button"
                                                       onClick={() => setSelectedAttemptId(attempt.id)}
@@ -608,24 +648,33 @@ export function NZBHistoryPage({ refreshTrigger }) {
                                                     >
                                                       <Info className="size-4" />
                                                     </button>
-                                                  </div>
-                                                </td>
-                                              </tr>
-                                            </Fragment>
-                                          )
-                                        })}
-                                      </tbody>
-                                    </table>
+                                                  </TooltipTrigger>
+                                                  <TooltipContent>Details</TooltipContent>
+                                                </Tooltip>
+                                              </TooltipProvider>
+                                            </div>
+                                          </div>
+                                          <div className="min-w-0 space-y-1">
+                                            <div className="line-clamp-3 break-words font-medium leading-snug">
+                                              {attempt.release_title || '—'}
+                                            </div>
+                                            <div className="text-xs text-muted-foreground [overflow-wrap:anywhere]">
+                                              {[attempt.indexer_name || '—', attempt.provider_name || '—', formatSize(attempt.release_size)].join(' • ')}
+                                            </div>
+                                          </div>
+                                        </div>
+                                      )
+                                    })}
                                   </div>
-                                </td>
-                              </tr>
-                            )}
-                          </Fragment>
-                        )
-                      })}
-                    </tbody>
+                                </div>
+                              )}
+                            </div>
+                          )
+                        })}
+                      </div>
+                    </div>
                   ))}
-                </table>
+                </div>
               </div>
             )
           )}
@@ -633,49 +682,98 @@ export function NZBHistoryPage({ refreshTrigger }) {
           <Dialog open={Boolean(selectedAttempt)} onOpenChange={(open) => {
             if (!open) setSelectedAttemptId(null)
           }}>
-            <DialogContent className="max-h-[85vh] w-[calc(100vw-2rem)] max-w-3xl overflow-x-hidden overflow-y-auto rounded-2xl px-5 sm:px-6">
+            <DialogContent
+              className="flex max-h-[85vh] max-w-3xl flex-col overflow-hidden"
+              onOpenAutoFocus={(event) => event.preventDefault()}
+            >
               {selectedAttempt ? (
                 <>
-                  <DialogHeader>
-                    <DialogTitle className="pr-10 text-left text-xl leading-tight [overflow-wrap:anywhere] sm:text-2xl">
+                  <DialogHeader className="space-y-1 pb-1">
+                    <DialogTitle className="pr-10 text-left text-lg leading-tight break-words [overflow-wrap:anywhere] sm:text-2xl">
                       {selectedAttempt.release_title || 'Attempt details'}
                     </DialogTitle>
-                    <DialogDescription className="text-left">
-                      {formatDateTime(selectedAttempt.tried_at)}
-                    </DialogDescription>
-                  </DialogHeader>
-                  <div className="space-y-2 text-sm">
-                    <div><span className="text-muted-foreground">Stream:</span> {selectedAttempt.stream_name || 'default'}</div>
-                    <div><span className="text-muted-foreground">Content:</span> {selectedAttempt.content_title || '—'}</div>
-                    <div><span className="text-muted-foreground">Content ID:</span> {selectedAttempt.content_id || '—'}</div>
-                    <div><span className="text-muted-foreground">Indexer:</span> {selectedAttempt.indexer_name || '—'}</div>
-                    <div><span className="text-muted-foreground">Provider:</span> {selectedAttempt.provider_name || '—'}</div>
-                    <div><span className="text-muted-foreground">Served file:</span> {selectedAttempt.served_file || '—'}</div>
-                    <div><span className="text-muted-foreground">Size:</span> {formatSize(selectedAttempt.release_size)}</div>
-                    <div><span className="text-muted-foreground">Reason:</span> {selectedAttempt.failure_reason || '—'}</div>
-                    <div className="[overflow-wrap:anywhere]"><span className="text-muted-foreground">Slot path:</span> {selectedAttempt.slot_path || '—'}</div>
-                  </div>
-                  <DialogFooter className="grid min-w-0 grid-cols-2 gap-2 sm:justify-start">
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      className="w-full min-w-0"
-                      onClick={() => handleCopyBadMatch(selectedAttempt)}
-                    >
-                      {copiedAttemptId === selectedAttempt.id ? <Check className="size-4" /> : <Copy className="size-4" />}
-                      {copiedAttemptId === selectedAttempt.id ? 'Copied' : 'Copy bad match'}
-                    </Button>
-                    {getSafeReleaseUrl(selectedAttempt.release_url) ? (
-                      <a
-                        href={getSafeReleaseUrl(selectedAttempt.release_url)}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="inline-flex w-full min-w-0 items-center justify-center gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm font-medium shadow-xs hover:bg-accent hover:text-accent-foreground"
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Badge variant="outline" className="rounded-md px-2.5 py-1 text-xs font-medium text-muted-foreground">
+                        {formatDateTime(selectedAttempt.tried_at)}
+                      </Badge>
+                      <Badge
+                        variant={selectedAttempt.success ? 'default' : selectedAttempt.preload ? 'secondary' : 'destructive'}
+                        className={attemptBadgeClass(selectedAttempt, shortReason(selectedAttempt.failure_reason))}
                       >
-                        <ExternalLink className="size-4" />
-                        Open release
-                      </a>
+                        {formatAttemptBadgeLabel(selectedAttempt)}
+                      </Badge>
+                    </div>
+                  </DialogHeader>
+                  <div ref={attemptDetailScrollRef} className="min-h-0 flex-1 overflow-y-auto pr-1">
+                    <div className="pb-6">
+                      <DetailSection title="Content">
+                        <div>
+                          <DetailRow label="Stream" value={selectedAttempt.stream_name || 'default'} />
+                          <DetailRow label="Title" value={selectedAttempt.content_title || '—'} bordered />
+                          <DetailRow label="Content ID" value={selectedAttempt.content_id || '—'} bordered />
+                          <DetailRow label="Size" value={formatSize(selectedAttempt.release_size)} bordered />
+                        </div>
+                      </DetailSection>
+                      <DetailSection title="Source">
+                        <div>
+                          <DetailRow label="Indexer" value={selectedAttempt.indexer_name || '—'} />
+                          <DetailRow label="Provider" value={selectedAttempt.provider_name || '—'} bordered />
+                        </div>
+                      </DetailSection>
+                      <DetailSection title="File">
+                        <div>
+                          <DetailRow label="Served file" value={selectedAttempt.served_file || '—'} mono />
+                        </div>
+                      </DetailSection>
+                      <DetailSection title="Debug">
+                        <div>
+                          <DetailRow label="Reason" value={selectedAttempt.failure_reason || '—'} tone={selectedAttempt.failure_reason ? 'danger' : 'default'} />
+                          <DetailRow label="Slot path" value={selectedAttempt.slot_path || '—'} mono bordered />
+                        </div>
+                      </DetailSection>
+                      <DetailSection title="AvailNZB">
+                        <div>
+                          <DetailRow label="Report" value={formatAvailStatus(selectedAttempt.avail_status)} />
+                          <DetailRow label="Reason" value={selectedAttempt.avail_reason || '—'} bordered />
+                        </div>
+                      </DetailSection>
+                    </div>
+                  </div>
+                  <DialogFooter className="flex-row flex-wrap items-center justify-end gap-2 pt-1">
+                    <TooltipProvider delayDuration={100}>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            className="min-w-24"
+                            onClick={() => handleCopyBadMatch(selectedAttempt)}
+                          >
+                            {copiedAttemptId === selectedAttempt.id ? <Check className="size-4" /> : <Copy className="size-4" />}
+                            {copiedAttemptId === selectedAttempt.id ? 'Copied' : 'Copy'}
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>Copy bad match</TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
+                    {getSafeReleaseUrl(selectedAttempt.release_url) ? (
+                      <TooltipProvider delayDuration={100}>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <a
+                              href={getSafeReleaseUrl(selectedAttempt.release_url)}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="inline-flex min-w-24 items-center justify-center gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm font-medium shadow-xs hover:bg-accent hover:text-accent-foreground"
+                            >
+                              <ExternalLink className="size-4" />
+                              Open
+                            </a>
+                          </TooltipTrigger>
+                          <TooltipContent>Open release</TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
                     ) : null}
                   </DialogFooter>
                 </>
@@ -683,8 +781,8 @@ export function NZBHistoryPage({ refreshTrigger }) {
             </DialogContent>
           </Dialog>
 
-          <Dialog open={filtersDialogOpen} onOpenChange={setFiltersDialogOpen}>
-            <DialogContent className="w-[calc(100vw-2rem)] max-w-lg rounded-2xl px-5 sm:px-6">
+            <Dialog open={filtersDialogOpen} onOpenChange={setFiltersDialogOpen}>
+            <DialogContent className="w-[calc(100vw-2rem)] max-w-lg rounded-2xl px-5 sm:px-6" onOpenAutoFocus={(event) => event.preventDefault()}>
               <DialogHeader>
                 <DialogTitle className="text-left text-xl">Filters</DialogTitle>
                 <DialogDescription className="text-left">

--- a/frontend/src/components/NZBHistoryPage.jsx
+++ b/frontend/src/components/NZBHistoryPage.jsx
@@ -2,7 +2,7 @@ import { Fragment, useState, useEffect, useCallback, useMemo, useRef } from 'rea
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, focusDialogCloseButton } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { History, Loader2, ExternalLink, RefreshCw, Copy, Check, ChevronDown, ChevronRight, Info, Search as SearchIcon, SlidersHorizontal } from 'lucide-react'
@@ -254,8 +254,9 @@ function formatAvailStatus(value) {
 }
 
 function statusTone(group) {
+  if (group.okCount > 0) return 'success'
   if (group.preloadCount > 0 && group.failedCount === 0) return 'secondary'
-  return group.okCount > 0 ? 'success' : 'destructive'
+  return 'destructive'
 }
 
 function groupRequestsByDay(groups) {
@@ -684,7 +685,7 @@ export function NZBHistoryPage({ refreshTrigger }) {
           }}>
             <DialogContent
               className="flex max-h-[85vh] max-w-3xl flex-col overflow-hidden"
-              onOpenAutoFocus={(event) => event.preventDefault()}
+              onOpenAutoFocus={focusDialogCloseButton}
             >
               {selectedAttempt ? (
                 <>
@@ -782,7 +783,7 @@ export function NZBHistoryPage({ refreshTrigger }) {
           </Dialog>
 
             <Dialog open={filtersDialogOpen} onOpenChange={setFiltersDialogOpen}>
-            <DialogContent className="w-[calc(100vw-2rem)] max-w-lg rounded-2xl px-5 sm:px-6" onOpenAutoFocus={(event) => event.preventDefault()}>
+            <DialogContent className="w-[calc(100vw-2rem)] max-w-lg rounded-2xl px-5 sm:px-6" onOpenAutoFocus={focusDialogCloseButton}>
               <DialogHeader>
                 <DialogTitle className="text-left text-xl">Filters</DialogTitle>
                 <DialogDescription className="text-left">

--- a/frontend/src/components/NetworkSettingsSection.jsx
+++ b/frontend/src/components/NetworkSettingsSection.jsx
@@ -161,6 +161,10 @@ export const NetworkSettingsSection = forwardRef(function NetworkSettingsSection
     baseClassName,
     showUnsavedHighlights && formState.dirtyFields?.[fieldName] && 'border-destructive ring-1 ring-destructive focus-visible:ring-destructive'
   )
+  const stackedFieldRowClass = "flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4"
+  const controlWideClass = "w-full min-w-0 sm:max-w-xs"
+  const controlMediumClass = "w-full min-w-0 sm:max-w-[10rem]"
+  const labelClass = "min-w-0 text-sm font-medium"
 
   return (
     <Form {...form}>
@@ -180,9 +184,9 @@ export const NetworkSettingsSection = forwardRef(function NetworkSettingsSection
               <div className="rounded-md border border-border/60">
                 <FormField control={control} name="addon_base_url" render={({ field }) => (
                   <FormItem className="rounded-none border-0 p-3">
-                    <div className="flex items-center justify-between gap-4">
-                      <FormLabel className="text-sm font-medium flex items-center gap-1.5">Base URL <EnvOverrideIndicator show={envOverrides.includes('addon_base_url')} /></FormLabel>
-                      <FormControl><Input placeholder="http://localhost:7000" className={fieldClassName('addon_base_url', 'h-9 w-64')} {...field} /></FormControl>
+                    <div className={stackedFieldRowClass}>
+                      <FormLabel className={cn(labelClass, 'flex items-center gap-1.5 sm:flex-1')}>Base URL <EnvOverrideIndicator show={envOverrides.includes('addon_base_url')} /></FormLabel>
+                      <FormControl><Input placeholder="http://localhost:7000" className={fieldClassName('addon_base_url', `h-9 ${controlWideClass}`)} {...field} /></FormControl>
                     </div>
                     <FormDescription className="mt-3">The public base URL clients use to reach your StreamNZB addon.</FormDescription>
                     <FormMessage />
@@ -191,9 +195,9 @@ export const NetworkSettingsSection = forwardRef(function NetworkSettingsSection
                 <FormField control={control} name="addon_port" render={({ field }) => (
                   <FormItem className="relative rounded-none border-0 p-3">
                     <div className="absolute left-3 right-3 top-0 border-t border-border/60" />
-                    <div className="flex items-center justify-between gap-4">
-                      <FormLabel className="text-sm font-medium flex items-center gap-1.5">Port <EnvOverrideIndicator show={envOverrides.includes('addon_port')} /></FormLabel>
-                      <FormControl><Input type="number" className={fieldClassName('addon_port', 'h-9 w-28')} {...field} onChange={e => field.onChange(e.target.valueAsNumber)} /></FormControl>
+                    <div className={stackedFieldRowClass}>
+                      <FormLabel className={cn(labelClass, 'flex items-center gap-1.5 sm:flex-1')}>Port <EnvOverrideIndicator show={envOverrides.includes('addon_port')} /></FormLabel>
+                      <FormControl><Input type="number" className={fieldClassName('addon_port', `h-9 ${controlMediumClass}`)} {...field} onChange={e => field.onChange(e.target.valueAsNumber)} /></FormControl>
                     </div>
                     <FormDescription className="mt-3">The local port where the addon server listens.</FormDescription>
                     <FormMessage />
@@ -222,8 +226,8 @@ export const NetworkSettingsSection = forwardRef(function NetworkSettingsSection
               <div className="mb-4">
                 <FormField control={control} name="proxy_enabled" render={({ field }) => (
                   <FormItem className="rounded-md border border-border/60 p-3">
-                    <div className="flex items-center justify-between gap-4">
-                      <FormLabel className="text-sm font-medium">Enable NNTP Proxy</FormLabel>
+                    <div className={stackedFieldRowClass}>
+                      <FormLabel className={labelClass}>Enable NNTP Proxy</FormLabel>
                       <FormControl><Switch checked={field.value !== false} onCheckedChange={field.onChange} className={showUnsavedHighlights && formState.dirtyFields?.proxy_enabled ? 'ring-2 ring-destructive ring-offset-2 ring-offset-background' : ''} /></FormControl>
                     </div>
                     <FormDescription className="mt-3">Turn the local NNTP proxy server on or off.</FormDescription>
@@ -233,9 +237,9 @@ export const NetworkSettingsSection = forwardRef(function NetworkSettingsSection
               <div className="rounded-md border border-border/60">
                 <FormField control={control} name="proxy_host" render={({ field }) => (
                   <FormItem className="rounded-none border-0 p-3">
-                    <div className="flex items-center justify-between gap-4">
-                      <FormLabel className="text-sm font-medium">Bind Host</FormLabel>
-                      <FormControl><Input placeholder="0.0.0.0" disabled={!proxyEnabled} className={fieldClassName('proxy_host', 'h-9 w-40')} {...field} /></FormControl>
+                    <div className={stackedFieldRowClass}>
+                      <FormLabel className={cn(labelClass, 'sm:flex-1')}>Bind Host</FormLabel>
+                      <FormControl><Input placeholder="0.0.0.0" disabled={!proxyEnabled} className={fieldClassName('proxy_host', `h-9 ${controlWideClass}`)} {...field} /></FormControl>
                     </div>
                     <FormDescription className="mt-3">Which local address the proxy server should bind to.</FormDescription>
                     <FormMessage />
@@ -244,9 +248,9 @@ export const NetworkSettingsSection = forwardRef(function NetworkSettingsSection
                 <FormField control={control} name="proxy_port" render={({ field }) => (
                   <FormItem className="relative rounded-none border-0 p-3">
                     <div className="absolute left-3 right-3 top-0 border-t border-border/60" />
-                    <div className="flex items-center justify-between gap-4">
-                      <FormLabel className="text-sm font-medium">Port</FormLabel>
-                      <FormControl><Input type="number" disabled={!proxyEnabled} className={fieldClassName('proxy_port', 'h-9 w-28')} {...field} onChange={e => field.onChange(e.target.valueAsNumber)} /></FormControl>
+                    <div className={stackedFieldRowClass}>
+                      <FormLabel className={cn(labelClass, 'sm:flex-1')}>Port</FormLabel>
+                      <FormControl><Input type="number" disabled={!proxyEnabled} className={fieldClassName('proxy_port', `h-9 ${controlMediumClass}`)} {...field} onChange={e => field.onChange(e.target.valueAsNumber)} /></FormControl>
                     </div>
                     <FormDescription className="mt-3">The port other apps use when connecting to the local NNTP proxy.</FormDescription>
                     <FormMessage />
@@ -255,9 +259,9 @@ export const NetworkSettingsSection = forwardRef(function NetworkSettingsSection
                 <FormField control={control} name="proxy_auth_user" render={({ field }) => (
                   <FormItem className="relative rounded-none border-0 p-3">
                     <div className="absolute left-3 right-3 top-0 border-t border-border/60" />
-                    <div className="flex items-center justify-between gap-4">
-                      <FormLabel className="text-sm font-medium">Proxy Username</FormLabel>
-                      <FormControl><Input disabled={!proxyEnabled} className={fieldClassName('proxy_auth_user', 'h-9 w-40')} {...field} /></FormControl>
+                    <div className={stackedFieldRowClass}>
+                      <FormLabel className={cn(labelClass, 'sm:flex-1')}>Proxy Username</FormLabel>
+                      <FormControl><Input disabled={!proxyEnabled} className={fieldClassName('proxy_auth_user', `h-9 ${controlWideClass}`)} {...field} /></FormControl>
                     </div>
                     <FormDescription className="mt-3">Optional username clients must provide when using the proxy.</FormDescription>
                     <FormMessage />
@@ -266,9 +270,9 @@ export const NetworkSettingsSection = forwardRef(function NetworkSettingsSection
                 <FormField control={control} name="proxy_auth_pass" render={({ field }) => (
                   <FormItem className="relative rounded-none border-0 p-3">
                     <div className="absolute left-3 right-3 top-0 border-t border-border/60" />
-                    <div className="flex items-center justify-between gap-4">
-                      <FormLabel className="text-sm font-medium">Proxy Password</FormLabel>
-                      <FormControl><PasswordInput disabled={!proxyEnabled} className={fieldClassName('proxy_auth_pass', 'h-9 w-40')} {...field} /></FormControl>
+                    <div className={stackedFieldRowClass}>
+                      <FormLabel className={cn(labelClass, 'sm:flex-1')}>Proxy Password</FormLabel>
+                      <FormControl><PasswordInput disabled={!proxyEnabled} className={fieldClassName('proxy_auth_pass', `h-9 ${controlWideClass}`)} {...field} /></FormControl>
                     </div>
                     <FormDescription className="mt-3">Optional password clients must provide when using the proxy.</FormDescription>
                     <FormMessage />
@@ -293,9 +297,9 @@ export const NetworkSettingsSection = forwardRef(function NetworkSettingsSection
             <div className="rounded-md border border-border/60">
               <FormField control={control} name="indexer_query_header" render={({ field }) => (
                 <FormItem className="rounded-none border-0 p-3">
-                  <div className="flex items-center justify-between gap-4">
-                    <FormLabel className="text-sm font-medium flex items-center gap-1.5">Indexer Query Header <EnvOverrideIndicator show={envOverrides.includes('indexer_query_header')} /></FormLabel>
-                    <FormControl><Input className={fieldClassName('indexer_query_header', 'h-9 w-64')} {...field} value={field.value || ''} placeholder="Prowlarr/2.3.0.5236" /></FormControl>
+                  <div className={stackedFieldRowClass}>
+                    <FormLabel className={cn(labelClass, 'flex items-center gap-1.5 sm:flex-1')}>Indexer Query Header <EnvOverrideIndicator show={envOverrides.includes('indexer_query_header')} /></FormLabel>
+                    <FormControl><Input className={fieldClassName('indexer_query_header', `h-9 ${controlWideClass}`)} {...field} value={field.value || ''} placeholder="Prowlarr/2.3.0.5236" /></FormControl>
                   </div>
                   <FormDescription className="mt-3">Used for indexer search and capability requests.</FormDescription>
                   <FormMessage />
@@ -304,9 +308,9 @@ export const NetworkSettingsSection = forwardRef(function NetworkSettingsSection
               <FormField control={control} name="indexer_grab_header" render={({ field }) => (
                 <FormItem className="relative rounded-none border-0 p-3">
                   <div className="absolute left-3 right-3 top-0 border-t border-border/60" />
-                  <div className="flex items-center justify-between gap-4">
-                    <FormLabel className="text-sm font-medium flex items-center gap-1.5">Indexer Grab Header <EnvOverrideIndicator show={envOverrides.includes('indexer_grab_header')} /></FormLabel>
-                    <FormControl><Input className={fieldClassName('indexer_grab_header', 'h-9 w-64')} {...field} value={field.value || ''} placeholder="SABnzbd/4.5.5" /></FormControl>
+                  <div className={stackedFieldRowClass}>
+                    <FormLabel className={cn(labelClass, 'flex items-center gap-1.5 sm:flex-1')}>Indexer Grab Header <EnvOverrideIndicator show={envOverrides.includes('indexer_grab_header')} /></FormLabel>
+                    <FormControl><Input className={fieldClassName('indexer_grab_header', `h-9 ${controlWideClass}`)} {...field} value={field.value || ''} placeholder="SABnzbd/4.5.5" /></FormControl>
                   </div>
                   <FormDescription className="mt-3">Used when grabbing NZBs from indexers.</FormDescription>
                   <FormMessage />
@@ -315,9 +319,9 @@ export const NetworkSettingsSection = forwardRef(function NetworkSettingsSection
               <FormField control={control} name="provider_header" render={({ field }) => (
                 <FormItem className="relative rounded-none border-0 p-3">
                   <div className="absolute left-3 right-3 top-0 border-t border-border/60" />
-                  <div className="flex items-center justify-between gap-4">
-                    <FormLabel className="text-sm font-medium flex items-center gap-1.5">Provider Header <EnvOverrideIndicator show={envOverrides.includes('provider_header')} /></FormLabel>
-                    <FormControl><Input className={fieldClassName('provider_header', 'h-9 w-64')} {...field} value={field.value || ''} placeholder="VLC/1.2.3.4" /></FormControl>
+                  <div className={stackedFieldRowClass}>
+                    <FormLabel className={cn(labelClass, 'flex items-center gap-1.5 sm:flex-1')}>Provider Header <EnvOverrideIndicator show={envOverrides.includes('provider_header')} /></FormLabel>
+                    <FormControl><Input className={fieldClassName('provider_header', `h-9 ${controlWideClass}`)} {...field} value={field.value || ''} placeholder="VLC/1.2.3.4" /></FormControl>
                   </div>
                   <FormDescription className="mt-3">Custom provider-facing User-Agent header.</FormDescription>
                   <FormMessage />

--- a/frontend/src/components/ProviderSettings.jsx
+++ b/frontend/src/components/ProviderSettings.jsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Switch } from "@/components/ui/switch"
-import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, focusDialogCloseButton } from "@/components/ui/dialog"
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
 import { ConfirmDialog } from "@/components/ConfirmDialog"
@@ -271,7 +271,7 @@ function ProviderDialog({ open, onOpenChange, initialValue, onSave, onClearStatu
       }
       requestClose()
     }}>
-      <DialogContent className="flex max-h-[85vh] max-w-3xl flex-col overflow-hidden" onOpenAutoFocus={(event) => event.preventDefault()}>
+      <DialogContent className="flex max-h-[85vh] max-w-3xl flex-col overflow-hidden" onOpenAutoFocus={focusDialogCloseButton}>
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
           <DialogDescription>{description}</DialogDescription>

--- a/frontend/src/components/ProviderSettings.jsx
+++ b/frontend/src/components/ProviderSettings.jsx
@@ -271,7 +271,7 @@ function ProviderDialog({ open, onOpenChange, initialValue, onSave, onClearStatu
       }
       requestClose()
     }}>
-      <DialogContent className="flex max-h-[85vh] max-w-3xl flex-col overflow-hidden">
+      <DialogContent className="flex max-h-[85vh] max-w-3xl flex-col overflow-hidden" onOpenAutoFocus={(event) => event.preventDefault()}>
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
           <DialogDescription>{description}</DialogDescription>
@@ -442,11 +442,11 @@ function ProviderDialog({ open, onOpenChange, initialValue, onSave, onClearStatu
               </div>
             )}
           </div>
-          <div className="flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2">
-          <Button type="button" variant="ghost" onClick={requestClose}>Cancel</Button>
-          <Button type="button" variant="destructive" onClick={handleSave} disabled={saving}>
-            {saveLabel}
-          </Button>
+          <div className="flex flex-row items-center justify-end gap-2">
+            <Button type="button" variant="outline" onClick={requestClose}>Cancel</Button>
+            <Button type="button" variant="destructive" onClick={handleSave} disabled={saving}>
+              {saveLabel}
+            </Button>
           </div>
         </DialogFooter>
       </DialogContent>
@@ -594,14 +594,14 @@ export function ProviderSettings({ fields = [], append, remove, replace, onPersi
       <div className="space-y-4">
         <Card>
           <CardHeader>
-            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-              <div className="space-y-0.5">
+            <div className="grid grid-cols-[minmax(0,1fr)_auto] items-start gap-3">
+              <div className="min-w-0 space-y-0.5">
                 <CardTitle>Providers</CardTitle>
-                <CardDescription>Configure your Usenet provider connections.</CardDescription>
+                <CardDescription className="break-words">Configure your Usenet provider connections.</CardDescription>
               </div>
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <Button type="button" variant="destructive" size="icon" className="h-9 w-9" onClick={() => setShowAddDialog(true)}>
+                  <Button type="button" variant="destructive" size="icon" className="h-9 w-9 shrink-0" onClick={() => setShowAddDialog(true)}>
                     <Plus className="h-4 w-4" />
                   </Button>
                 </TooltipTrigger>
@@ -625,9 +625,8 @@ export function ProviderSettings({ fields = [], append, remove, replace, onPersi
                   >
                     <CardContent className="pt-6">
                       <div className="min-w-0 flex-1 space-y-3">
-                          <div className="flex items-start justify-between gap-3">
-                            <div className="min-w-0 font-semibold">{normalized.name || normalized.host || `Provider ${index + 1}`}</div>
-                            <div className="flex items-center gap-2">
+                          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                            <div className="flex items-center gap-2 self-end sm:order-2">
                               <Tooltip>
                                 <TooltipTrigger asChild>
                                   <div className="inline-flex h-9 w-20 items-center justify-center rounded-md border border-border/60 bg-muted/30 px-2">
@@ -662,6 +661,7 @@ export function ProviderSettings({ fields = [], append, remove, replace, onPersi
                                 <TooltipContent>Delete provider</TooltipContent>
                               </Tooltip>
                             </div>
+                            <div className="min-w-0 font-semibold sm:order-1">{normalized.name || normalized.host || `Provider ${index + 1}`}</div>
                           </div>
                           <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3">
                             <div className="flex flex-wrap gap-2 text-xs text-muted-foreground min-w-0">

--- a/frontend/src/components/SearchQuerySettings.jsx
+++ b/frontend/src/components/SearchQuerySettings.jsx
@@ -412,7 +412,7 @@ function QueryDialog({ open, onOpenChange, kind, initialValue, existingNames = [
       }
       requestClose()
     }}>
-      <DialogContent className="flex max-h-[85vh] max-w-3xl flex-col overflow-hidden">
+      <DialogContent className="flex max-h-[85vh] max-w-3xl flex-col overflow-hidden" onOpenAutoFocus={(event) => event.preventDefault()}>
         <DialogHeader>
           <DialogTitle>{dialogTitle(kind, editing)}</DialogTitle>
           <DialogDescription>{dialogDescription(kind)}</DialogDescription>
@@ -426,11 +426,11 @@ function QueryDialog({ open, onOpenChange, kind, initialValue, existingNames = [
               <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">{validationError}</div>
             )}
           </div>
-          <div className="flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2">
-          <Button type="button" variant="ghost" onClick={requestClose} disabled={saving}>Cancel</Button>
-          <Button type="button" variant="destructive" onClick={() => void handleSave()} disabled={saving}>
-            {saving ? 'Saving...' : saveLabel}
-          </Button>
+          <div className="flex flex-row items-center justify-end gap-2">
+            <Button type="button" variant="outline" onClick={requestClose} disabled={saving}>Cancel</Button>
+            <Button type="button" variant="destructive" onClick={() => void handleSave()} disabled={saving}>
+              {saving ? 'Saving...' : saveLabel}
+            </Button>
           </div>
         </DialogFooter>
       </DialogContent>
@@ -502,10 +502,10 @@ function QuerySection({ title, description, kind, items, names, update, remove, 
   return (
     <Card>
       <CardHeader>
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-          <div className="space-y-0.5">
+        <div className="grid grid-cols-[minmax(0,1fr)_auto] items-start gap-3">
+          <div className="min-w-0 space-y-0.5">
             <CardTitle>{title}</CardTitle>
-            <CardDescription>{description}</CardDescription>
+            <CardDescription className="break-words">{description}</CardDescription>
           </div>
           <AddQueryButton
             kind={kind}
@@ -534,9 +534,8 @@ function QuerySection({ title, description, kind, items, names, update, remove, 
               <Card className={deleteBlockedName && deleteBlockedName === query.name ? 'border-destructive/60 ring-1 ring-destructive/30' : ''} key={field.id}>
                 <CardContent className="pt-6">
                   <div className="space-y-3">
-                    <div className="flex items-center justify-between gap-3">
-                      <div className="min-w-0 font-semibold">{query.name || defaultQueryName(kind, index)}</div>
-                      <div className="flex items-center gap-2">
+                    <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                      <div className="flex items-center gap-2 self-end sm:order-2">
                         <Tooltip>
                           <TooltipTrigger asChild>
                             <Button type="button" variant="outline" size="icon" className="h-9 w-9" onClick={() => {
@@ -575,6 +574,7 @@ function QuerySection({ title, description, kind, items, names, update, remove, 
                           <TooltipContent>Delete query</TooltipContent>
                         </Tooltip>
                       </div>
+                      <div className="min-w-0 font-semibold sm:order-1">{query.name || defaultQueryName(kind, index)}</div>
                     </div>
                     {summary.length === 0 ? (
                       <p className="text-sm text-muted-foreground">No values set.</p>
@@ -676,7 +676,7 @@ function AddQueryButton({ kind, title, existingNames, existingQueries, onCreate,
     <>
       <Tooltip>
         <TooltipTrigger asChild>
-          <Button type="button" variant="destructive" size="icon" className="h-9 w-9" onClick={() => setOpen(true)}>
+          <Button type="button" variant="destructive" size="icon" className="h-9 w-9 shrink-0" onClick={() => setOpen(true)}>
             <Plus className="h-4 w-4" />
           </Button>
         </TooltipTrigger>

--- a/frontend/src/components/SearchQuerySettings.jsx
+++ b/frontend/src/components/SearchQuerySettings.jsx
@@ -3,7 +3,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
-import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, focusDialogCloseButton } from "@/components/ui/dialog"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
 import { ConfirmDialog } from "@/components/ConfirmDialog"
 import { apiFetch } from "@/api"
@@ -412,7 +412,7 @@ function QueryDialog({ open, onOpenChange, kind, initialValue, existingNames = [
       }
       requestClose()
     }}>
-      <DialogContent className="flex max-h-[85vh] max-w-3xl flex-col overflow-hidden" onOpenAutoFocus={(event) => event.preventDefault()}>
+      <DialogContent className="flex max-h-[85vh] max-w-3xl flex-col overflow-hidden" onOpenAutoFocus={focusDialogCloseButton}>
         <DialogHeader>
           <DialogTitle>{dialogTitle(kind, editing)}</DialogTitle>
           <DialogDescription>{dialogDescription(kind)}</DialogDescription>

--- a/frontend/src/components/StreamManagement.jsx
+++ b/frontend/src/components/StreamManagement.jsx
@@ -4,7 +4,7 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Switch } from "@/components/ui/switch"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
-import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, focusDialogCloseButton } from "@/components/ui/dialog"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
 import { ConfirmDialog } from "@/components/ConfirmDialog"
@@ -436,7 +436,7 @@ function StreamDialog({ open, onOpenChange, initialStream, mode = 'edit', provid
       }
       requestClose()
     }}>
-      <DialogContent className="flex h-[85vh] max-h-[85vh] max-w-3xl flex-col overflow-visible" onOpenAutoFocus={(event) => event.preventDefault()}>
+      <DialogContent className="flex h-[85vh] max-h-[85vh] max-w-3xl flex-col overflow-visible" onOpenAutoFocus={focusDialogCloseButton}>
         <DialogHeader>
           <DialogTitle>{isEditing ? 'Change Stream' : 'Add Stream'}</DialogTitle>
           <DialogDescription>Create a stream or manage its provider, indexer, and search request assignments.</DialogDescription>

--- a/frontend/src/components/StreamManagement.jsx
+++ b/frontend/src/components/StreamManagement.jsx
@@ -436,7 +436,7 @@ function StreamDialog({ open, onOpenChange, initialStream, mode = 'edit', provid
       }
       requestClose()
     }}>
-      <DialogContent className="flex h-[85vh] max-h-[85vh] max-w-3xl flex-col overflow-visible">
+      <DialogContent className="flex h-[85vh] max-h-[85vh] max-w-3xl flex-col overflow-visible" onOpenAutoFocus={(event) => event.preventDefault()}>
         <DialogHeader>
           <DialogTitle>{isEditing ? 'Change Stream' : 'Add Stream'}</DialogTitle>
           <DialogDescription>Create a stream or manage its provider, indexer, and search request assignments.</DialogDescription>
@@ -669,8 +669,8 @@ function StreamDialog({ open, onOpenChange, initialStream, mode = 'edit', provid
               </div>
             )}
           </div>
-          <div className="flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2">
-            <Button type="button" variant="ghost" onClick={requestClose}>Cancel</Button>
+          <div className="flex flex-row items-center justify-end gap-2">
+            <Button type="button" variant="outline" onClick={requestClose}>Cancel</Button>
             <Button type="button" variant="destructive" onClick={handleSave} disabled={saving}>
               {saving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
               Save
@@ -710,6 +710,7 @@ function StreamManagement({ globalConfig, movieSearchQueries = [], seriesSearchQ
   const [visibleFooterStatus, setVisibleFooterStatus] = useState(null)
   const [footerStatusVisible, setFooterStatusVisible] = useState(false)
   const [deleteTarget, setDeleteTarget] = useState('')
+  const [regenerateTarget, setRegenerateTarget] = useState('')
   const [expandedStreams, setExpandedStreams] = useState({})
 
   const indexerNames = useMemo(
@@ -990,10 +991,10 @@ function StreamManagement({ globalConfig, movieSearchQueries = [], seriesSearchQ
     <TooltipProvider delayDuration={100}>
       <Card>
         <CardHeader>
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-            <div className="space-y-0.5">
+          <div className="grid grid-cols-[minmax(0,1fr)_auto] items-start gap-3">
+            <div className="min-w-0 space-y-0.5">
               <CardTitle>Streams</CardTitle>
-              <CardDescription>Configure stream-specific manifests and their provider, indexer and search order.</CardDescription>
+              <CardDescription className="break-words">Configure stream-specific manifests and their provider, indexer and search order.</CardDescription>
             </div>
             <Tooltip>
               <TooltipTrigger asChild>
@@ -1001,7 +1002,7 @@ function StreamManagement({ globalConfig, movieSearchQueries = [], seriesSearchQ
                   type="button"
                   variant="destructive"
                   size="icon"
-                  className="h-9 w-9"
+                  className="h-9 w-9 shrink-0"
                   onClick={() => {
                     setAddDialogDraft({ username: nextStreamName(streams) })
                     setShowAddDialog(true)
@@ -1071,9 +1072,9 @@ function StreamManagement({ globalConfig, movieSearchQueries = [], seriesSearchQ
                       <div className="min-w-0 flex-1 rounded-md border border-border/70 bg-muted/20 px-3 py-2">
                         <div className="space-y-1.5">
                           <Label className="block text-xs text-muted-foreground">Manifest</Label>
-                          <div className="flex items-start gap-2">
+                          <div className="flex items-center gap-2">
                             <code className="block min-w-0 flex-1 break-all rounded bg-muted px-2.5 py-1.5 text-[11px] leading-5">{getManifestUrl(stream.token)}</code>
-                            <div className="flex items-center gap-2">
+                            <div className="flex shrink-0 items-center gap-2 self-center">
                               <Tooltip>
                                 <TooltipTrigger asChild>
                                   <Button type="button" variant="ghost" size="icon" onClick={() => copyManifestUrl(stream.token)} className="h-8 w-8 shrink-0 bg-muted hover:bg-muted" aria-label={`Copy manifest URL for ${stream.username}`}>
@@ -1084,7 +1085,7 @@ function StreamManagement({ globalConfig, movieSearchQueries = [], seriesSearchQ
                               </Tooltip>
                               <Tooltip>
                                 <TooltipTrigger asChild>
-                                  <Button type="button" variant="outline" size="icon" onClick={() => handleRegenerateToken(stream.username)} disabled={actionLoading !== null || loading} className="h-8 w-8 shrink-0" aria-label={`Regenerate token for ${stream.username}`}>
+                                  <Button type="button" variant="outline" size="icon" onClick={() => setRegenerateTarget(stream.username)} disabled={actionLoading !== null || loading} className="h-8 w-8 shrink-0" aria-label={`Regenerate token for ${stream.username}`}>
                                     {actionLoading === `regenerate-${stream.username}` ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <RefreshCw className="h-3.5 w-3.5" />}
                                   </Button>
                                 </TooltipTrigger>
@@ -1106,13 +1107,13 @@ function StreamManagement({ globalConfig, movieSearchQueries = [], seriesSearchQ
                             <SummaryRow label="Filter/Sorting" icon={ArrowUpDown} values={filterSortingSummaryValues(stream)} />
                           </div>
                         ) : (
-                          <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-6">
-                            <div className="space-y-1">
-                              <div className="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                          <div className="grid grid-cols-3 gap-3 md:grid-cols-2 xl:grid-cols-6">
+                            <div className="space-y-1 text-center sm:text-left">
+                              <div className="flex items-center justify-center gap-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground sm:justify-start">
                                 <Settings className="h-3.5 w-3.5" />
-                                <span>General</span>
+                                <span className="hidden sm:inline">General</span>
                               </div>
-                              <div className="flex flex-wrap items-center gap-2">
+                              <div className="flex flex-wrap items-center justify-center gap-2 sm:justify-start">
                                 {generalCompactValues(stream).map((value) => (
                                   <div key={value} className="inline-flex items-center justify-center rounded-full border border-border px-2 py-1 text-xs text-muted-foreground">
                                     {value}
@@ -1120,40 +1121,40 @@ function StreamManagement({ globalConfig, movieSearchQueries = [], seriesSearchQ
                                 ))}
                               </div>
                             </div>
-                            <div className="space-y-1">
-                              <div className="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                            <div className="space-y-1 text-center sm:text-left">
+                              <div className="flex items-center justify-center gap-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground sm:justify-start">
                                 <Globe className="h-3.5 w-3.5" />
-                                <span>Providers</span>
+                                <span className="hidden sm:inline">Providers</span>
                               </div>
                               <div className="inline-flex items-center justify-center rounded-full border border-border px-2 py-1 text-xs text-muted-foreground">{(stream.provider_selections || []).length}</div>
                             </div>
-                            <div className="space-y-1">
-                              <div className="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                            <div className="space-y-1 text-center sm:text-left">
+                              <div className="flex items-center justify-center gap-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground sm:justify-start">
                                 <Server className="h-3.5 w-3.5" />
-                                <span>Indexers</span>
+                                <span className="hidden sm:inline">Indexers</span>
                               </div>
                               <div className="inline-flex items-center justify-center rounded-full border border-border px-2 py-1 text-xs text-muted-foreground">{(stream.indexer_selections || Object.keys(stream.indexer_overrides || {})).length}</div>
                             </div>
-                            <div className="space-y-1">
-                              <div className="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                            <div className="space-y-1 text-center sm:text-left">
+                              <div className="flex items-center justify-center gap-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground sm:justify-start">
                                 <Search className="h-3.5 w-3.5" />
-                                <span>Movie</span>
+                                <span className="hidden sm:inline">Movie</span>
                               </div>
                               <div className="inline-flex items-center justify-center rounded-full border border-border px-2 py-1 text-xs text-muted-foreground">{(stream.movie_search_queries || []).length}</div>
                             </div>
-                            <div className="space-y-1">
-                              <div className="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                            <div className="space-y-1 text-center sm:text-left">
+                              <div className="flex items-center justify-center gap-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground sm:justify-start">
                                 <Search className="h-3.5 w-3.5" />
-                                <span>TV</span>
+                                <span className="hidden sm:inline">TV</span>
                               </div>
                               <div className="inline-flex items-center justify-center rounded-full border border-border px-2 py-1 text-xs text-muted-foreground">{(stream.series_search_queries || []).length}</div>
                             </div>
-                            <div className="space-y-1">
-                              <div className="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                            <div className="space-y-1 text-center sm:text-left">
+                              <div className="flex items-center justify-center gap-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground sm:justify-start">
                                 <ArrowUpDown className="h-3.5 w-3.5" />
-                                <span>Filter/Sorting</span>
+                                <span className="hidden sm:inline">Filter/Sorting</span>
                               </div>
-                              <div className="flex flex-wrap items-center gap-2">
+                              <div className="flex flex-wrap items-center justify-center gap-2 sm:justify-start">
                                 {filterSortingSummaryValues(stream).map((value) => (
                                   <div key={value} className="inline-flex items-center justify-center rounded-full border border-border px-2 py-1 text-xs text-muted-foreground">
                                     {value}
@@ -1248,6 +1249,22 @@ function StreamManagement({ globalConfig, movieSearchQueries = [], seriesSearchQ
           setDeleteTarget('')
           if (username) {
             void handleDeleteStream(username)
+          }
+        }}
+      />
+      <ConfirmDialog
+        open={Boolean(regenerateTarget)}
+        onOpenChange={(nextOpen) => {
+          if (!nextOpen) setRegenerateTarget('')
+        }}
+        title="Regenerate token?"
+        description={regenerateTarget ? `Are you sure you want to regenerate the manifest token for stream "${regenerateTarget}"? Existing links using the old token will stop working.` : ''}
+        confirmLabel="Regenerate"
+        onConfirm={() => {
+          const username = regenerateTarget
+          setRegenerateTarget('')
+          if (username) {
+            void handleRegenerateToken(username)
           }
         }}
       />

--- a/frontend/src/components/ui/dialog.jsx
+++ b/frontend/src/components/ui/dialog.jsx
@@ -31,7 +31,7 @@ const DialogContent = React.forwardRef(({ className, children, ...props }, ref) 
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid max-h-[calc(100vh-1rem)] w-[calc(100vw-1rem)] max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 overflow-hidden rounded-lg border bg-background p-4 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:max-h-[calc(100vh-2rem)] sm:w-full sm:p-6",
         className
       )}
       {...props}>

--- a/frontend/src/components/ui/dialog.jsx
+++ b/frontend/src/components/ui/dialog.jsx
@@ -14,6 +14,16 @@ const DialogPortal = DialogPrimitive.Portal
 
 const DialogClose = DialogPrimitive.Close
 
+function focusDialogCloseButton(event) {
+  event.preventDefault()
+  const container = event.currentTarget
+  if (!(container instanceof HTMLElement)) return
+  const closeButton = container.querySelector("[data-dialog-close]")
+  if (closeButton instanceof HTMLElement) {
+    closeButton.focus()
+  }
+}
+
 const DialogOverlay = React.forwardRef(({ className, ...props }, ref) => (
   <DialogPrimitive.Overlay
     ref={ref}
@@ -37,6 +47,7 @@ const DialogContent = React.forwardRef(({ className, children, ...props }, ref) 
       {...props}>
       {children}
       <DialogPrimitive.Close
+        data-dialog-close
         className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
@@ -89,6 +100,7 @@ export {
   DialogTrigger,
   DialogClose,
   DialogContent,
+  focusDialogCloseButton,
   DialogHeader,
   DialogFooter,
   DialogTitle,

--- a/frontend/src/components/ui/input.jsx
+++ b/frontend/src/components/ui/input.jsx
@@ -7,7 +7,7 @@ const Input = React.forwardRef(({ className, type, ...props }, ref) => {
     <input
       type={type}
       className={cn(
-        "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "flex h-10 w-full min-w-0 rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         className
       )}
       ref={ref}

--- a/frontend/src/components/ui/password-input.jsx
+++ b/frontend/src/components/ui/password-input.jsx
@@ -6,7 +6,7 @@ import { cn } from "@/lib/utils"
 const PasswordInput = React.forwardRef(({ className, ...props }, ref) => {
   const [show, setShow] = React.useState(false)
   return (
-    <div className="relative">
+    <div className="relative w-full min-w-0">
       <Input
         type={show ? "text" : "password"}
         className={cn("pr-10", className)}

--- a/pkg/core/persistence/attempts.go
+++ b/pkg/core/persistence/attempts.go
@@ -21,6 +21,8 @@ type NZBAttempt struct {
 	ServedFile    string    `json:"served_file,omitempty"`
 	Success       bool      `json:"success"`
 	FailureReason string    `json:"failure_reason,omitempty"`
+	AvailStatus   string    `json:"avail_status,omitempty"`
+	AvailReason   string    `json:"avail_reason,omitempty"`
 	SlotPath      string    `json:"slot_path,omitempty"`
 	Preload       bool      `json:"preload"` // true = attempt started, result not yet known
 }
@@ -39,6 +41,8 @@ type RecordAttemptParams struct {
 	ServedFile    string
 	Success       bool
 	FailureReason string
+	AvailStatus   string
+	AvailReason   string
 	SlotPath      string
 }
 
@@ -52,8 +56,8 @@ func (m *StateManager) RecordPreloadAttempt(p RecordAttemptParams) {
 	}
 	// INSERT only when no active (preload=1) row exists for this slot yet.
 	_ = m.withWriteLock(func(db *sql.DB) error {
-		_, err := db.Exec(`INSERT INTO nzb_attempts (tried_at, stream_name, provider_name, content_type, content_id, content_title, indexer_name, release_title, release_url, release_size, served_file, success, failure_reason, slot_path, preload)
-				SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, '', ?, 1
+		_, err := db.Exec(`INSERT INTO nzb_attempts (tried_at, stream_name, provider_name, content_type, content_id, content_title, indexer_name, release_title, release_url, release_size, served_file, success, failure_reason, avail_status, avail_reason, slot_path, preload)
+				SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, '', '', '', ?, 1
 			WHERE NOT EXISTS (SELECT 1 FROM nzb_attempts WHERE slot_path = ? AND preload = 1)`,
 			time.Now().UnixMilli(),
 			p.StreamName,
@@ -69,6 +73,28 @@ func (m *StateManager) RecordPreloadAttempt(p RecordAttemptParams) {
 			p.SlotPath,
 			p.SlotPath, // for the NOT EXISTS sub-query
 		)
+		return err
+	})
+}
+
+// UpdatePendingAttempt refreshes the currently unresolved preload row for a slot while keeping it pending.
+// Used when playback ended too early to classify the release as good or bad.
+func (m *StateManager) UpdatePendingAttempt(p RecordAttemptParams) {
+	if m == nil || m.db == nil || p.SlotPath == "" {
+		return
+	}
+	_ = m.withWriteLock(func(db *sql.DB) error {
+		_, err := db.Exec(`UPDATE nzb_attempts
+			SET served_file = COALESCE(NULLIF(?, ''), served_file),
+				indexer_name = COALESCE(NULLIF(?, ''), indexer_name),
+				stream_name = COALESCE(NULLIF(?, ''), stream_name),
+				provider_name = COALESCE(NULLIF(?, ''), provider_name),
+				content_title = COALESCE(NULLIF(?, ''), content_title),
+				failure_reason = COALESCE(NULLIF(?, ''), failure_reason),
+				avail_status = COALESCE(NULLIF(?, ''), avail_status),
+				avail_reason = COALESCE(NULLIF(?, ''), avail_reason)
+			WHERE slot_path = ? AND preload = 1`,
+			p.ServedFile, p.IndexerName, p.StreamName, p.ProviderName, p.ContentTitle, p.FailureReason, p.AvailStatus, p.AvailReason, p.SlotPath)
 		return err
 	})
 }
@@ -94,9 +120,11 @@ func (m *StateManager) RecordAttempt(p RecordAttemptParams) {
 					indexer_name = COALESCE(NULLIF(?, ''), indexer_name),
 					stream_name = COALESCE(NULLIF(?, ''), stream_name),
 					provider_name = COALESCE(NULLIF(?, ''), provider_name),
-					content_title = COALESCE(NULLIF(?, ''), content_title)
+					content_title = COALESCE(NULLIF(?, ''), content_title),
+					avail_status = COALESCE(NULLIF(?, ''), avail_status),
+					avail_reason = COALESCE(NULLIF(?, ''), avail_reason)
 				WHERE slot_path = ? AND preload = 1`,
-				success, p.FailureReason, p.ServedFile, p.IndexerName, p.StreamName, p.ProviderName, p.ContentTitle, p.SlotPath)
+				success, p.FailureReason, p.ServedFile, p.IndexerName, p.StreamName, p.ProviderName, p.ContentTitle, p.AvailStatus, p.AvailReason, p.SlotPath)
 			if err == nil {
 				affected, _ := res.RowsAffected()
 				if affected > 0 {
@@ -105,8 +133,8 @@ func (m *StateManager) RecordAttempt(p RecordAttemptParams) {
 			}
 		}
 
-		_, err := db.Exec(`INSERT INTO nzb_attempts (tried_at, stream_name, provider_name, content_type, content_id, content_title, indexer_name, release_title, release_url, release_size, served_file, success, failure_reason, slot_path, preload)
-				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0)`,
+		_, err := db.Exec(`INSERT INTO nzb_attempts (tried_at, stream_name, provider_name, content_type, content_id, content_title, indexer_name, release_title, release_url, release_size, served_file, success, failure_reason, avail_status, avail_reason, slot_path, preload)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0)`,
 			time.Now().UnixMilli(),
 			p.StreamName,
 			p.ProviderName,
@@ -120,6 +148,8 @@ func (m *StateManager) RecordAttempt(p RecordAttemptParams) {
 			p.ServedFile,
 			success,
 			p.FailureReason,
+			p.AvailStatus,
+			p.AvailReason,
 			p.SlotPath,
 		)
 		return err
@@ -156,7 +186,7 @@ func (m *StateManager) ListAttempts(opts ListAttemptsOptions) ([]NZBAttempt, err
 		offset = 0
 	}
 
-	query := `SELECT id, tried_at, stream_name, provider_name, content_type, content_id, content_title, indexer_name, release_title, release_url, release_size, served_file, success, failure_reason, slot_path, COALESCE(preload, 0)
+	query := `SELECT id, tried_at, stream_name, provider_name, content_type, content_id, content_title, indexer_name, release_title, release_url, release_size, served_file, success, failure_reason, avail_status, avail_reason, slot_path, COALESCE(preload, 0)
 		FROM nzb_attempts WHERE 1=1`
 	args := []interface{}{}
 	if opts.ContentType != "" {
@@ -186,10 +216,10 @@ func (m *StateManager) ListAttempts(opts ListAttemptsOptions) ([]NZBAttempt, err
 		var triedAtMs int64
 		var success int
 		var preload int
-		var releaseURL, servedFile, failureReason, slotPath, indexerName, streamName, providerName sql.NullString
+		var releaseURL, servedFile, failureReason, availStatus, availReason, slotPath, indexerName, streamName, providerName sql.NullString
 		var contentTitle sql.NullString
 		var releaseSize sql.NullInt64
-		err := rows.Scan(&a.ID, &triedAtMs, &streamName, &providerName, &a.ContentType, &a.ContentID, &contentTitle, &indexerName, &a.ReleaseTitle, &releaseURL, &releaseSize, &servedFile, &success, &failureReason, &slotPath, &preload)
+		err := rows.Scan(&a.ID, &triedAtMs, &streamName, &providerName, &a.ContentType, &a.ContentID, &contentTitle, &indexerName, &a.ReleaseTitle, &releaseURL, &releaseSize, &servedFile, &success, &failureReason, &availStatus, &availReason, &slotPath, &preload)
 		if err != nil {
 			return nil, err
 		}
@@ -204,6 +234,12 @@ func (m *StateManager) ListAttempts(opts ListAttemptsOptions) ([]NZBAttempt, err
 		}
 		if failureReason.Valid {
 			a.FailureReason = failureReason.String
+		}
+		if availStatus.Valid {
+			a.AvailStatus = availStatus.String
+		}
+		if availReason.Valid {
+			a.AvailReason = availReason.String
 		}
 		if slotPath.Valid {
 			a.SlotPath = slotPath.String

--- a/pkg/core/persistence/attempts_test.go
+++ b/pkg/core/persistence/attempts_test.go
@@ -123,6 +123,46 @@ func TestRecordAttemptPersistsServedFile(t *testing.T) {
 	}
 }
 
+func TestUpdatePendingAttemptKeepsPreloadAndAddsReason(t *testing.T) {
+	mgr := newTestStateManager(t)
+	mgr.RecordPreloadAttempt(RecordAttemptParams{SlotPath: "slot-pending", ReleaseTitle: "Early stop"})
+
+	mgr.UpdatePendingAttempt(RecordAttemptParams{
+		SlotPath:      "slot-pending",
+		ProviderName:  "news.example.net",
+		ServedFile:    "Example.mkv",
+		FailureReason: "Playback ended too early to classify this release as good.",
+		AvailStatus:   "skipped",
+		AvailReason:   "Playback ended before the good threshold was reached.",
+	})
+
+	list, err := mgr.ListAttempts(ListAttemptsOptions{Limit: 10})
+	if err != nil {
+		t.Fatalf("ListAttempts: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("expected one pending attempt, got %d", len(list))
+	}
+	if !list[0].Preload {
+		t.Fatal("expected preload row to remain pending")
+	}
+	if got := list[0].ProviderName; got != "news.example.net" {
+		t.Fatalf("ProviderName = %q, want %q", got, "news.example.net")
+	}
+	if got := list[0].ServedFile; got != "Example.mkv" {
+		t.Fatalf("ServedFile = %q, want %q", got, "Example.mkv")
+	}
+	if got := list[0].FailureReason; got != "Playback ended too early to classify this release as good." {
+		t.Fatalf("FailureReason = %q", got)
+	}
+	if got := list[0].AvailStatus; got != "skipped" {
+		t.Fatalf("AvailStatus = %q, want %q", got, "skipped")
+	}
+	if got := list[0].AvailReason; got != "Playback ended before the good threshold was reached." {
+		t.Fatalf("AvailReason = %q", got)
+	}
+}
+
 func TestDeleteAttemptsBeforeRemovesOlderRows(t *testing.T) {
 	mgr := newTestStateManager(t)
 

--- a/pkg/core/persistence/sqlite.go
+++ b/pkg/core/persistence/sqlite.go
@@ -38,6 +38,8 @@ const (
 		served_file TEXT,
 		success INTEGER NOT NULL,
 		failure_reason TEXT,
+		avail_status TEXT,
+		avail_reason TEXT,
 		slot_path TEXT,
 		preload INTEGER NOT NULL DEFAULT 0
 	);`
@@ -88,6 +90,12 @@ func initSchema(db *sql.DB) error {
 	if err := migrateNzbAttemptsProviderName(db); err != nil {
 		return err
 	}
+	if err := migrateNzbAttemptsAvailStatus(db); err != nil {
+		return err
+	}
+	if err := migrateNzbAttemptsAvailReason(db); err != nil {
+		return err
+	}
 	for _, stmt := range []string{nzbAttemptsIndexStream, nzbAttemptsIndexProvider, nzbAttemptsIndexIndexer} {
 		if _, err := db.Exec(stmt); err != nil {
 			return fmt.Errorf("schema: %w", err)
@@ -133,6 +141,22 @@ func migrateNzbAttemptsProviderName(db *sql.DB) error {
 	_, err := db.Exec(`ALTER TABLE nzb_attempts ADD COLUMN provider_name TEXT`)
 	if err != nil && !strings.Contains(err.Error(), "duplicate column") {
 		return fmt.Errorf("migrate nzb_attempts.provider_name: %w", err)
+	}
+	return nil
+}
+
+func migrateNzbAttemptsAvailStatus(db *sql.DB) error {
+	_, err := db.Exec(`ALTER TABLE nzb_attempts ADD COLUMN avail_status TEXT`)
+	if err != nil && !strings.Contains(err.Error(), "duplicate column") {
+		return fmt.Errorf("migrate nzb_attempts.avail_status: %w", err)
+	}
+	return nil
+}
+
+func migrateNzbAttemptsAvailReason(db *sql.DB) error {
+	_, err := db.Exec(`ALTER TABLE nzb_attempts ADD COLUMN avail_reason TEXT`)
+	if err != nil && !strings.Contains(err.Error(), "duplicate column") {
+		return fmt.Errorf("migrate nzb_attempts.avail_reason: %w", err)
 	}
 	return nil
 }

--- a/pkg/server/stremio/handlers_attempts_test.go
+++ b/pkg/server/stremio/handlers_attempts_test.go
@@ -7,7 +7,7 @@ import (
 	"streamnzb/pkg/session"
 )
 
-func TestRecordAttemptParamsIncludesServedFile(t *testing.T) {
+func TestRecordAttemptParamsSuccessUsesServedProviders(t *testing.T) {
 	server := &Server{}
 	sess := &session.Session{
 		ID:           "stream:global:series:tt2261227:2:2:2",
@@ -17,8 +17,11 @@ func TestRecordAttemptParamsIncludesServedFile(t *testing.T) {
 		ContentTitle: "Altered Carbon",
 	}
 	sess.SetSelectedPlaybackFile("Altered.Carbon.S02E03.1080p.mkv")
+	sess.RecordUsedProviderHost("news-a.example.net")
+	sess.RecordUsedProviderHost("news-b.example.net")
+	sess.RecordServedProviderHost("news-b.example.net")
 
-	params := server.recordAttemptParams(sess)
+	params := server.recordAttemptParamsForOutcome(sess, true)
 	if got := params.ServedFile; got != "Altered.Carbon.S02E03.1080p.mkv" {
 		t.Fatalf("ServedFile = %q, want %q", got, "Altered.Carbon.S02E03.1080p.mkv")
 	}
@@ -27,6 +30,22 @@ func TestRecordAttemptParamsIncludesServedFile(t *testing.T) {
 	}
 	if got := params.ContentTitle; got != "Altered Carbon" {
 		t.Fatalf("ContentTitle = %q, want %q", got, "Altered Carbon")
+	}
+	if got := params.ProviderName; got != "news-b.example.net" {
+		t.Fatalf("ProviderName = %q, want %q", got, "news-b.example.net")
+	}
+}
+
+func TestRecordAttemptParamsFailureUsesUsedProviders(t *testing.T) {
+	server := &Server{}
+	sess := &session.Session{}
+	sess.RecordUsedProviderHost("news-a.example.net")
+	sess.RecordUsedProviderHost("news-b.example.net")
+	sess.RecordServedProviderHost("news-b.example.net")
+
+	params := server.recordAttemptParamsForOutcome(sess, false)
+	if got := params.ProviderName; got != "news-a.example.net, news-b.example.net" {
+		t.Fatalf("ProviderName = %q, want %q", got, "news-a.example.net, news-b.example.net")
 	}
 }
 
@@ -40,5 +59,13 @@ func TestCacheReturnedPlaybackBlueprintReplacesStaleBlueprint(t *testing.T) {
 
 	if got := sess.Blueprint; got != fresh {
 		t.Fatalf("expected session blueprint to be replaced, got %#v", got)
+	}
+}
+
+func TestNormalizeAttemptReasonEOF(t *testing.T) {
+	got := normalizeAttemptReason("EOF")
+	want := "No playable media stream could be opened from this release (EOF)."
+	if got != want {
+		t.Fatalf("normalizeAttemptReason(EOF) = %q, want %q", got, want)
 	}
 }

--- a/pkg/server/stremio/handlers_playback.go
+++ b/pkg/server/stremio/handlers_playback.go
@@ -29,6 +29,7 @@ import (
 	"streamnzb/pkg/media/nzb"
 	"streamnzb/pkg/media/seek"
 	"streamnzb/pkg/media/unpack"
+	"streamnzb/pkg/services/availnzb"
 	"streamnzb/pkg/session"
 )
 
@@ -1087,13 +1088,14 @@ func (s *Server) handlePlay(w http.ResponseWriter, r *http.Request, streamConfig
 				s.sessionManager.SetSlotFailedDuringPlayback(sessionID)
 				s.ClearSearchCaches()
 			}
-			if (isSegmentUnavailableErr(prepareErr) || isDataCorruptErr(prepareErr)) && s.availReporter != nil {
-				s.availReporter.ReportBad(sess, prepareErr.Error())
+			availOutcome := availOutcomeForFailure(prepareErr)
+			if shouldReportBadRelease(prepareErr) && s.availReporter != nil {
+				availOutcome = s.availReporter.ReportBad(sess, prepareErr.Error())
 			}
 			// Gate failure recording: concurrent goroutines for the same session (Stremio's automatic
 			// re-requests) must not each insert a Failure row. Only the first one wins.
 			if _, alreadyFailed := s.recordedFailureSessionIDs.LoadOrStore(sessionID, struct{}{}); !alreadyFailed {
-				s.recordAttempt(sess, false, prepareErr.Error())
+				s.recordAttempt(sess, false, prepareErr.Error(), availOutcome)
 				go func(id string, done <-chan struct{}) {
 					<-done
 					s.recordedFailureSessionIDs.Delete(id)
@@ -1187,11 +1189,12 @@ func (s *Server) handlePlay(w http.ResponseWriter, r *http.Request, streamConfig
 		s.ClearSearchCaches()
 		if errSess, _ := s.sessionManager.GetSession(playbackSessionID); errSess != nil {
 			errSess.ResetPlaybackStream()
+			availOutcome := availOutcomeForFailure(readErr)
 			if s.availReporter != nil {
-				s.availReporter.ReportBad(errSess, readErr.Error())
+				availOutcome = s.availReporter.ReportBad(errSess, readErr.Error())
 			}
 			if _, alreadyFailed := s.recordedFailureSessionIDs.LoadOrStore(playbackSessionID, struct{}{}); !alreadyFailed {
-				s.recordAttempt(errSess, false, readErr.Error())
+				s.recordAttempt(errSess, false, readErr.Error(), availOutcome)
 				go func(id string, done <-chan struct{}) {
 					<-done
 					s.recordedFailureSessionIDs.Delete(id)
@@ -1232,7 +1235,9 @@ func (s *Server) handlePlay(w http.ResponseWriter, r *http.Request, streamConfig
 		"failed_over", failedOver,
 		"stream_mode", streamMode,
 	)
+	sess.BeginServeProviderTracking()
 	defer func() {
+		sess.EndServeProviderTracking()
 		closeStream("handler exit")
 		bufW.Flush()
 
@@ -1304,11 +1309,39 @@ func (s *Server) handlePlay(w http.ResponseWriter, r *http.Request, streamConfig
 			)
 			return
 		}
+		serveDuration := time.Since(serveStartedAt)
+		minBytes := availnzb.DefaultMinBytesToReportGood
+		minDuration := availnzb.DefaultMinDurationToReportGood
 		if s.availReporter != nil {
-			s.availReporter.ReportGood(sess)
+			minBytes = s.availReporter.MinBytesToReportGood
+			minDuration = s.availReporter.MinDurationToReportGood
+		}
+		if !availnzb.QualifiesGood(sess, serveDuration, minBytes, minDuration) {
+			reason := fmt.Sprintf(
+				"Playback ended too early to classify this release as good. Threshold not reached (%d/%d bytes, %ds/%ds).",
+				sess.BytesRead(),
+				minBytes,
+				int(serveDuration/time.Second),
+				int(minDuration/time.Second),
+			)
+			logger.Debug("Skipping success bookkeeping below good threshold",
+				"session", sessionID,
+				"requested_session", requestedSessionID,
+				"bytes_read", sess.BytesRead(),
+				"serve_duration", serveDuration,
+				"min_bytes", minBytes,
+				"min_duration", minDuration,
+				"reason", reason,
+			)
+			s.recordPendingAttempt(sess, reason, availnzb.SkippedOutcome("Playback ended before the good threshold was reached."))
+			return
+		}
+		availOutcome := availnzb.ReportOutcome{}
+		if s.availReporter != nil {
+			availOutcome = s.availReporter.ReportGood(sess, serveDuration)
 		}
 		if _, already := s.recordedSuccessSessionIDs.LoadOrStore(sessionID, struct{}{}); !already {
-			s.recordAttempt(sess, true, "")
+			s.recordAttempt(sess, true, "", availOutcome)
 			// When session is gone, allow recording success again for a future play of the same release.
 			go func() {
 				<-sess.Done()
@@ -1544,7 +1577,6 @@ func (s *Server) openPlaybackSource(ctx context.Context, sess *session.Session) 
 		for _, f := range files {
 			if f.IsFailed() {
 				logger.Error("Session file has too many failures", "session", sessionID, "file", f.Name())
-				s.reportBadRelease(sess, unpack.ErrTooManyZeroFills)
 				if sess.NZB != nil {
 					s.validator.InvalidateCache(sess.NZB.Hash())
 				}
@@ -1569,7 +1601,6 @@ func (s *Server) openPlaybackSource(ctx context.Context, sess *session.Session) 
 	cacheReturnedPlaybackBlueprint(sess, bp)
 	if err != nil {
 		logger.Error("Failed to open media stream", "id", sessionID, "err", err)
-		s.reportBadRelease(sess, err)
 		if sess.NZB != nil {
 			s.validator.InvalidateCache(sess.NZB.Hash())
 		}
@@ -1712,24 +1743,53 @@ func (s *Server) getOrResolveSession(ctx context.Context, sessionID string, stre
 	return nil, err
 }
 
-func (s *Server) reportBadRelease(sess *session.Session, streamErr error) {
+func shouldReportBadRelease(streamErr error) bool {
 	errMsg := streamErr.Error()
 	if !strings.Contains(errMsg, "compressed") && !strings.Contains(errMsg, "encrypted") &&
 		!strings.Contains(errMsg, "EOF") && !errors.Is(streamErr, unpack.ErrTooManyZeroFills) &&
 		!errors.Is(streamErr, unpack.ErrEpisodeTargetNotFound) {
-		return
+		return false
 	}
-	if s.availReporter != nil {
-		s.availReporter.ReportBad(sess, errMsg)
+	return true
+}
+
+func normalizeAttemptReason(reason string) string {
+	trimmed := strings.TrimSpace(reason)
+	if trimmed == "" {
+		return ""
 	}
-	// Do NOT call recordAttempt here. The caller (tryPlaySlot → handlePlay) always calls
-	// recordAttempt after tryPlaySlot returns an error, so calling it here too would insert
-	// a duplicate Failure row (the first call updates preload=1→0, the second falls through
-	// to INSERT because no preload=1 row remains).
+	lower := strings.ToLower(trimmed)
+	switch {
+	case lower == "eof":
+		return "No playable media stream could be opened from this release (EOF)."
+	case strings.Contains(lower, "playback ended too early to classify this release"):
+		return trimmed
+	default:
+		return trimmed
+	}
+}
+
+func availOutcomeForFailure(err error) availnzb.ReportOutcome {
+	if err == nil {
+		return availnzb.ReportOutcome{}
+	}
+	errMsg := strings.TrimSpace(err.Error())
+	switch {
+	case strings.Contains(strings.ToLower(errMsg), "playback startup timeout"):
+		return availnzb.SkippedOutcome("Not reported to AvailNZB because this startup timeout may be temporary and does not prove the release is bad.")
+	case isIndexerLimitErr(err):
+		return availnzb.SkippedOutcome("Not reported to AvailNZB because the failure was caused by an indexer or provider limit.")
+	default:
+		return availnzb.ReportOutcome{}
+	}
 }
 
 // recordAttemptParams builds persistence params from a session.
 func (s *Server) recordAttemptParams(sess *session.Session) persistence.RecordAttemptParams {
+	return s.recordAttemptParamsForOutcome(sess, false)
+}
+
+func (s *Server) recordAttemptParamsForOutcome(sess *session.Session, success bool) persistence.RecordAttemptParams {
 	contentType := sess.ContentType
 	if contentType == "" {
 		contentType = "movie"
@@ -1746,7 +1806,11 @@ func (s *Server) recordAttemptParams(sess *session.Session) persistence.RecordAt
 		}
 	}
 	providerName := ""
-	if hosts := sess.ProviderHosts(); len(hosts) > 0 {
+	hosts := sess.UsedProviderHosts()
+	if success {
+		hosts = sess.ServedProviderHosts()
+	}
+	if len(hosts) > 0 {
 		providerName = strings.Join(hosts, ", ")
 	}
 	return persistence.RecordAttemptParams{
@@ -1769,7 +1833,7 @@ func (s *Server) recordPreloadAttempt(sess *session.Session) {
 	if s.attemptRecorder == nil || sess == nil {
 		return
 	}
-	p := s.recordAttemptParams(sess)
+	p := s.recordAttemptParamsForOutcome(sess, false)
 	s.attemptRecorder.RecordPreloadAttempt(p)
 	if s.onAttemptRecorded != nil {
 		s.onAttemptRecorded()
@@ -1777,14 +1841,30 @@ func (s *Server) recordPreloadAttempt(sess *session.Session) {
 }
 
 // recordAttempt writes one NZB attempt to the persistence layer when attemptRecorder is set (or updates existing preload row).
-func (s *Server) recordAttempt(sess *session.Session, success bool, failureReason string) {
+func (s *Server) recordAttempt(sess *session.Session, success bool, failureReason string, availOutcome availnzb.ReportOutcome) {
 	if s.attemptRecorder == nil || sess == nil {
 		return
 	}
-	p := s.recordAttemptParams(sess)
+	p := s.recordAttemptParamsForOutcome(sess, success)
 	p.Success = success
-	p.FailureReason = failureReason
+	p.FailureReason = normalizeAttemptReason(failureReason)
+	p.AvailStatus = availOutcome.Status
+	p.AvailReason = availOutcome.Reason
 	s.attemptRecorder.RecordAttempt(p)
+	if s.onAttemptRecorded != nil {
+		s.onAttemptRecorded()
+	}
+}
+
+func (s *Server) recordPendingAttempt(sess *session.Session, reason string, availOutcome availnzb.ReportOutcome) {
+	if s.attemptRecorder == nil || sess == nil {
+		return
+	}
+	p := s.recordAttemptParamsForOutcome(sess, true)
+	p.FailureReason = normalizeAttemptReason(reason)
+	p.AvailStatus = availOutcome.Status
+	p.AvailReason = availOutcome.Reason
+	s.attemptRecorder.UpdatePendingAttempt(p)
 	if s.onAttemptRecorded != nil {
 		s.onAttemptRecorded()
 	}

--- a/pkg/services/availnzb/reporter.go
+++ b/pkg/services/availnzb/reporter.go
@@ -6,113 +6,136 @@ import (
 	"streamnzb/pkg/session"
 	"strings"
 	"sync"
+	"time"
 )
 
 // DefaultMinBytesToReportGood is the minimum bytes read during playback before reporting a release as good.
-// Set to 0: the stream is already validated by unpack.ProbeMediaStream before handlePlay reaches the
-// serve path, and mid-stream failures are caught by onReadError (ErrTooManyZeroFills / segment unavailable
-// / data corruption) which calls ReportBad. A separate bytes threshold is therefore redundant.
-const DefaultMinBytesToReportGood = 0
+const DefaultMinBytesToReportGood int64 = 64 << 20
+
+// DefaultMinDurationToReportGood is the minimum real serve time before reporting a release as good.
+const DefaultMinDurationToReportGood = 20 * time.Second
 
 type ProviderHostsSource interface {
 	GetProviderHosts() []string
 }
 
-type sessionProviderHostSource interface {
-	ProviderHosts() []string
+type ReportOutcome struct {
+	Status string
+	Reason string
+}
+
+func SentOutcome(available bool) ReportOutcome {
+	if available {
+		return ReportOutcome{Status: "sent", Reason: "Reported as good to AvailNZB."}
+	}
+	return ReportOutcome{Status: "sent", Reason: "Reported as bad to AvailNZB."}
+}
+
+func SkippedOutcome(reason string) ReportOutcome {
+	return ReportOutcome{Status: "skipped", Reason: reason}
 }
 
 type Reporter struct {
-	client               *Client
-	providerSrc          ProviderHostsSource
-	reported             sync.Map
-	MinBytesToReportGood int64 // minimum bytes read before reporting good; 0 = no threshold
-	Disabled             bool  // when true, all reporting is silently skipped
+	client                  *Client
+	providerSrc             ProviderHostsSource
+	reported                sync.Map
+	MinBytesToReportGood    int64
+	MinDurationToReportGood time.Duration
+	Disabled                bool // when true, all reporting is silently skipped
 }
 
 func NewReporter(client *Client, providerSrc ProviderHostsSource) *Reporter {
 	return &Reporter{
-		client:               client,
-		providerSrc:          providerSrc,
-		MinBytesToReportGood: DefaultMinBytesToReportGood,
+		client:                  client,
+		providerSrc:             providerSrc,
+		MinBytesToReportGood:    DefaultMinBytesToReportGood,
+		MinDurationToReportGood: DefaultMinDurationToReportGood,
 	}
 }
 
-func (r *Reporter) ReportGood(sess *session.Session) {
-	if r.MinBytesToReportGood > 0 && sess.BytesRead() < r.MinBytesToReportGood {
-		return
+func QualifiesGood(sess *session.Session, serveDuration time.Duration, minBytes int64, minDuration time.Duration) bool {
+	if sess == nil {
+		return false
+	}
+	bytesOk := minBytes <= 0 || sess.BytesRead() >= minBytes
+	durationOk := minDuration <= 0 || serveDuration >= minDuration
+	return bytesOk || durationOk
+}
+
+func (r *Reporter) ReportGood(sess *session.Session, serveDuration time.Duration) ReportOutcome {
+	if !QualifiesGood(sess, serveDuration, r.MinBytesToReportGood, r.MinDurationToReportGood) {
+		return SkippedOutcome("Playback ended before the good threshold was reached.")
 	}
 	if _, loaded := r.reported.LoadOrStore(sess.ID, struct{}{}); loaded {
-		return
+		return SkippedOutcome("This session was already reported to AvailNZB.")
 	}
 	logger.Info("Reporting good/streamable release to AvailNZB", "session", sess.ID)
-	r.report(sess, true)
+	return r.report(sess, true, true)
 }
 
-func (r *Reporter) ReportBad(sess *session.Session, reason string) {
+func (r *Reporter) ReportBad(sess *session.Session, reason string) ReportOutcome {
 	if reason != "" {
 		logger.Info("Reporting bad/unstreamable release to AvailNZB", "session", sess.ID, "reason", reason)
 	}
-	r.report(sess, false)
+	return r.report(sess, false, false)
 }
 
-func (r *Reporter) ReportRAR(sess *session.Session) {
+func (r *Reporter) ReportRAR(sess *session.Session) ReportOutcome {
 	logger.Info("Reporting RAR release to AvailNZB (compression_type)", "session", sess.ID)
-	r.report(sess, true)
+	return r.report(sess, true, false)
 }
 
-func (r *Reporter) report(sess *session.Session, available bool) {
+func (r *Reporter) report(sess *session.Session, available bool, servedOnly bool) ReportOutcome {
 	if r.Disabled {
 		logger.Debug("AvailNZB reporting disabled by configuration, skipping report")
-		return
+		return SkippedOutcome("AvailNZB reporting is disabled.")
 	}
 	if r.client == nil || r.client.BaseURL == "" {
-		return
+		return SkippedOutcome("AvailNZB is not configured.")
+	}
+	releaseURL := sess.ReleaseURL()
+	if releaseURL == "" || release.IsPrivateReleaseURL(releaseURL) {
+		logger.Debug("Skipping AvailNZB report: no public details URL", "url", releaseURL)
+		return SkippedOutcome("No public details URL is available for this release.")
+	}
+	meta := ReportMeta{ReleaseName: sess.ReportReleaseName(), Size: sess.ReportSize()}
+	if ids := sess.ContentIDs; ids != nil {
+		meta.TmdbID = ids.TmdbID
+
+		if ids.TvdbID != "" && (ids.Season > 0 || ids.Episode > 0) {
+			meta.TvdbID = ids.TvdbID
+			meta.Season = ids.Season
+			meta.Episode = ids.Episode
+		} else if ids.ImdbID != "" {
+			meta.ImdbID = ids.ImdbID
+		} else if ids.TvdbID != "" {
+			meta.TvdbID = ids.TvdbID
+			meta.Season = ids.Season
+			meta.Episode = ids.Episode
+		}
+	}
+	if meta.ImdbID == "" && meta.TmdbID == "" && meta.TvdbID == "" {
+		return SkippedOutcome("Required metadata for AvailNZB is missing.")
+	}
+	if meta.ReleaseName == "" {
+		return SkippedOutcome("Release name is missing for AvailNZB.")
+	}
+	if sess.NZB != nil {
+		meta.CompressionType = sess.NZB.CompressionType()
+	}
+	hosts := sess.UsedProviderHosts()
+	if servedOnly {
+		hosts = sess.ServedProviderHosts()
+	}
+	if len(hosts) == 0 {
+		if servedOnly {
+			logger.Debug("Skipping AvailNZB report without served provider hosts", "session", sess.ID)
+			return SkippedOutcome("No serving provider could be confirmed for this attempt.")
+		}
+		return SkippedOutcome("No provider could be confirmed for this attempt.")
 	}
 	go func() {
-		releaseURL := sess.ReleaseURL()
-		if releaseURL == "" {
-			return
-		}
-		if release.IsPrivateReleaseURL(releaseURL) {
-			logger.Debug("Skipping AvailNZB report: release URL is private", "url", releaseURL)
-			return
-		}
-		meta := ReportMeta{ReleaseName: sess.ReportReleaseName(), Size: sess.ReportSize()}
-		if ids := sess.ContentIDs; ids != nil {
-			meta.TmdbID = ids.TmdbID
-
-			if ids.TvdbID != "" && (ids.Season > 0 || ids.Episode > 0) {
-				meta.TvdbID = ids.TvdbID
-				meta.Season = ids.Season
-				meta.Episode = ids.Episode
-			} else if ids.ImdbID != "" {
-				meta.ImdbID = ids.ImdbID
-			} else if ids.TvdbID != "" {
-				meta.TvdbID = ids.TvdbID
-				meta.Season = ids.Season
-				meta.Episode = ids.Episode
-			}
-		}
-		if meta.ImdbID == "" && meta.TmdbID == "" && meta.TvdbID == "" {
-			return
-		}
-		if meta.ReleaseName == "" {
-			return
-		}
-		if sess.NZB != nil {
-			meta.CompressionType = sess.NZB.CompressionType()
-		}
-		var hosts []string
-		if sessWithHosts, ok := interface{}(sess).(sessionProviderHostSource); ok {
-			hosts = sessWithHosts.ProviderHosts()
-		}
-		if len(hosts) == 0 {
-			hosts = r.providerSrc.GetProviderHosts()
-		}
-		if len(hosts) == 0 {
-			return
-		}
 		_ = r.client.ReportAvailability(releaseURL, strings.Join(hosts, ","), available, meta)
 	}()
+	return SentOutcome(available)
 }

--- a/pkg/services/availnzb/reporter.go
+++ b/pkg/services/availnzb/reporter.go
@@ -66,11 +66,15 @@ func (r *Reporter) ReportGood(sess *session.Session, serveDuration time.Duration
 	if !QualifiesGood(sess, serveDuration, r.MinBytesToReportGood, r.MinDurationToReportGood) {
 		return SkippedOutcome("Playback ended before the good threshold was reached.")
 	}
-	if _, loaded := r.reported.LoadOrStore(sess.ID, struct{}{}); loaded {
+	if _, loaded := r.reported.Load(sess.ID); loaded {
 		return SkippedOutcome("This session was already reported to AvailNZB.")
 	}
 	logger.Info("Reporting good/streamable release to AvailNZB", "session", sess.ID)
-	return r.report(sess, true, true)
+	outcome := r.report(sess, true, true)
+	if outcome.Status == "sent" {
+		r.reported.Store(sess.ID, struct{}{})
+	}
+	return outcome
 }
 
 func (r *Reporter) ReportBad(sess *session.Session, reason string) ReportOutcome {

--- a/pkg/services/availnzb/reporter.go
+++ b/pkg/services/availnzb/reporter.go
@@ -134,8 +134,9 @@ func (r *Reporter) report(sess *session.Session, available bool, servedOnly bool
 		}
 		return SkippedOutcome("No provider could be confirmed for this attempt.")
 	}
-	go func() {
-		_ = r.client.ReportAvailability(releaseURL, strings.Join(hosts, ","), available, meta)
-	}()
+	if err := r.client.ReportAvailability(releaseURL, strings.Join(hosts, ","), available, meta); err != nil {
+		logger.Warn("AvailNZB report delivery failed", "session", sess.ID, "err", err)
+		return SkippedOutcome("AvailNZB report could not be delivered.")
+	}
 	return SentOutcome(available)
 }

--- a/pkg/services/availnzb/reporter_test.go
+++ b/pkg/services/availnzb/reporter_test.go
@@ -98,3 +98,41 @@ func TestReportGoodReturnsSkippedWhenDeliveryFails(t *testing.T) {
 		t.Fatalf("unexpected skip reason: %q", outcome.Reason)
 	}
 }
+
+func TestReportGoodAllowsRetryAfterSkippedAttempt(t *testing.T) {
+	reportCalls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reportCalls++
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-key")
+	reporter := NewReporter(client, nil)
+	reporter.MinBytesToReportGood = 1
+	reporter.MinDurationToReportGood = 0
+
+	sess := &session.Session{
+		ID:      "sess-good-retry",
+		Release: &release.Release{Title: "Example.Release.2026", DetailsURL: "https://example.invalid/details/123", Size: 1234},
+		ContentIDs: &session.AvailReportMeta{
+			ImdbID: "tt1234567",
+		},
+	}
+	sess.AddBytesRead(2)
+
+	first := reporter.ReportGood(sess, time.Second)
+	if first.Status != "skipped" {
+		t.Fatalf("expected first outcome skipped, got %+v", first)
+	}
+
+	sess.RecordServedProviderHost("news.example.net")
+
+	second := reporter.ReportGood(sess, time.Second)
+	if second.Status != "sent" {
+		t.Fatalf("expected second outcome sent, got %+v", second)
+	}
+	if reportCalls != 1 {
+		t.Fatalf("expected one successful report call after retry, got %d", reportCalls)
+	}
+}

--- a/pkg/services/availnzb/reporter_test.go
+++ b/pkg/services/availnzb/reporter_test.go
@@ -1,0 +1,35 @@
+package availnzb
+
+import (
+	"testing"
+	"time"
+
+	"streamnzb/pkg/session"
+)
+
+func TestQualifiesGoodByBytes(t *testing.T) {
+	sess := &session.Session{}
+	sess.AddBytesRead(64 << 20)
+
+	if !QualifiesGood(sess, 2*time.Second, 64<<20, 20*time.Second) {
+		t.Fatal("expected playback to qualify by bytes")
+	}
+}
+
+func TestQualifiesGoodByDuration(t *testing.T) {
+	sess := &session.Session{}
+	sess.AddBytesRead(8 << 20)
+
+	if !QualifiesGood(sess, 20*time.Second, 64<<20, 20*time.Second) {
+		t.Fatal("expected playback to qualify by duration")
+	}
+}
+
+func TestQualifiesGoodRejectsShortSmallPlayback(t *testing.T) {
+	sess := &session.Session{}
+	sess.AddBytesRead(8 << 20)
+
+	if QualifiesGood(sess, 5*time.Second, 64<<20, 20*time.Second) {
+		t.Fatal("expected short small playback not to qualify")
+	}
+}

--- a/pkg/services/availnzb/reporter_test.go
+++ b/pkg/services/availnzb/reporter_test.go
@@ -1,9 +1,12 @@
 package availnzb
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
+	"streamnzb/pkg/release"
 	"streamnzb/pkg/session"
 )
 
@@ -31,5 +34,67 @@ func TestQualifiesGoodRejectsShortSmallPlayback(t *testing.T) {
 
 	if QualifiesGood(sess, 5*time.Second, 64<<20, 20*time.Second) {
 		t.Fatal("expected short small playback not to qualify")
+	}
+}
+
+func TestReportGoodReturnsSentOnlyAfterSuccessfulDelivery(t *testing.T) {
+	reportCalls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reportCalls++
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-key")
+	reporter := NewReporter(client, nil)
+	reporter.MinBytesToReportGood = 1
+	reporter.MinDurationToReportGood = 0
+
+	sess := &session.Session{
+		ID:      "sess-good-sent",
+		Release: &release.Release{Title: "Example.Release.2026", DetailsURL: "https://example.invalid/details/123", Size: 1234},
+		ContentIDs: &session.AvailReportMeta{
+			ImdbID: "tt1234567",
+		},
+	}
+	sess.AddBytesRead(2)
+	sess.RecordServedProviderHost("news.example.net")
+
+	outcome := reporter.ReportGood(sess, time.Second)
+	if outcome.Status != "sent" {
+		t.Fatalf("expected sent outcome, got %+v", outcome)
+	}
+	if reportCalls != 1 {
+		t.Fatalf("expected one report call, got %d", reportCalls)
+	}
+}
+
+func TestReportGoodReturnsSkippedWhenDeliveryFails(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-key")
+	reporter := NewReporter(client, nil)
+	reporter.MinBytesToReportGood = 1
+	reporter.MinDurationToReportGood = 0
+
+	sess := &session.Session{
+		ID:      "sess-good-failed",
+		Release: &release.Release{Title: "Example.Release.2026", DetailsURL: "https://example.invalid/details/123", Size: 1234},
+		ContentIDs: &session.AvailReportMeta{
+			ImdbID: "tt1234567",
+		},
+	}
+	sess.AddBytesRead(2)
+	sess.RecordServedProviderHost("news.example.net")
+
+	outcome := reporter.ReportGood(sess, time.Second)
+	if outcome.Status != "skipped" {
+		t.Fatalf("expected skipped outcome, got %+v", outcome)
+	}
+	if outcome.Reason != "AvailNZB report could not be delivered." {
+		t.Fatalf("unexpected skip reason: %q", outcome.Reason)
 	}
 }

--- a/pkg/session/manager.go
+++ b/pkg/session/manager.go
@@ -86,8 +86,11 @@ type Session struct {
 	downloadURL string
 	indexer     indexer.Indexer
 
-	segmentFetcher loader.SegmentFetcher
-	providerHosts  []string
+	segmentFetcher       loader.SegmentFetcher
+	providerHosts        []string
+	usedProviders        map[string]struct{}
+	servedProviders      map[string]struct{}
+	trackServedProviders bool
 
 	bytesRead atomic.Int64 // bytes read during playback; used for AvailNZB good-report threshold
 	playback  *playbackStreamState
@@ -144,6 +147,142 @@ func (s *Session) ProviderHosts() []string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return append([]string(nil), s.providerHosts...)
+}
+
+func (s *Session) UsedProviderHosts() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.usedProviders) == 0 {
+		return nil
+	}
+	hosts := make([]string, 0, len(s.usedProviders))
+	for host := range s.usedProviders {
+		hosts = append(hosts, host)
+	}
+	sort.Strings(hosts)
+	return hosts
+}
+
+func (s *Session) ServedProviderHosts() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.servedProviders) == 0 {
+		return nil
+	}
+	hosts := make([]string, 0, len(s.servedProviders))
+	for host := range s.servedProviders {
+		hosts = append(hosts, host)
+	}
+	sort.Strings(hosts)
+	return hosts
+}
+
+func (s *Session) RecordUsedProviderHost(host string) {
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.usedProviders == nil {
+		s.usedProviders = make(map[string]struct{})
+	}
+	s.usedProviders[host] = struct{}{}
+}
+
+func (s *Session) RecordServedProviderHost(host string) {
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.servedProviders == nil {
+		s.servedProviders = make(map[string]struct{})
+	}
+	s.servedProviders[host] = struct{}{}
+}
+
+func (s *Session) BeginServeProviderTracking() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.trackServedProviders = true
+}
+
+func (s *Session) EndServeProviderTracking() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.trackServedProviders = false
+}
+
+func (s *Session) IsServeProviderTrackingEnabled() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.trackServedProviders
+}
+
+type sessionTrackingFetcher struct {
+	session *Session
+	base    loader.SegmentFetcher
+}
+
+func (f *sessionTrackingFetcher) record(data pool.SegmentData) {
+	if f == nil || f.session == nil {
+		return
+	}
+	f.session.RecordUsedProviderHost(data.ProviderHost)
+	if f.session.IsServeProviderTrackingEnabled() {
+		f.session.RecordServedProviderHost(data.ProviderHost)
+	}
+}
+
+func (f *sessionTrackingFetcher) FetchSegment(ctx context.Context, segment *nzb.Segment, groups []string) (pool.SegmentData, error) {
+	if f == nil || f.base == nil {
+		return pool.SegmentData{}, fmt.Errorf("segment fetcher unavailable")
+	}
+	data, err := f.base.FetchSegment(ctx, segment, groups)
+	if err == nil {
+		f.record(data)
+	}
+	return data, err
+}
+
+func (f *sessionTrackingFetcher) FetchSegmentFirst(ctx context.Context, segment *nzb.Segment, groups []string) (pool.SegmentData, error) {
+	if f == nil || f.base == nil {
+		return pool.SegmentData{}, fmt.Errorf("segment fetcher unavailable")
+	}
+	first, ok := f.base.(loader.SegmentFirstFetcher)
+	if !ok {
+		return f.FetchSegment(ctx, segment, groups)
+	}
+	data, err := first.FetchSegmentFirst(ctx, segment, groups)
+	if err == nil {
+		f.record(data)
+	}
+	return data, err
+}
+
+type sessionTrackingFetcherWithStat struct {
+	*sessionTrackingFetcher
+	statter loader.SegmentStatter
+}
+
+func (f *sessionTrackingFetcherWithStat) StatSegment(ctx context.Context, messageID string, groups []string) (bool, error) {
+	if f == nil || f.statter == nil {
+		return false, fmt.Errorf("segment statter unavailable")
+	}
+	return f.statter.StatSegment(ctx, messageID, groups)
+}
+
+func attachProviderTracking(session *Session, fetcher loader.SegmentFetcher) loader.SegmentFetcher {
+	if session == nil || fetcher == nil {
+		return fetcher
+	}
+	wrapped := &sessionTrackingFetcher{session: session, base: fetcher}
+	if statter, ok := fetcher.(loader.SegmentStatter); ok {
+		return &sessionTrackingFetcherWithStat{sessionTrackingFetcher: wrapped, statter: statter}
+	}
+	return wrapped
 }
 
 // BytesRead returns the number of bytes read from this session during playback.
@@ -510,13 +649,9 @@ func (m *Manager) CreateSessionWithFetcher(sessionID string, nzbData *nzb.NZB, r
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	loaderFiles := buildLoaderFiles(ctx, sessionID, contentFiles, pools, segmentFetcher, estimator)
-
 	session := &Session{
 		ID:             sessionID,
 		NZB:            nzbData,
-		Files:          loaderFiles,
-		File:           loaderFiles[0],
 		Release:        rel,
 		ContentIDs:     contentIDs,
 		CreatedAt:      time.Now(),
@@ -527,6 +662,10 @@ func (m *Manager) CreateSessionWithFetcher(sessionID string, nzbData *nzb.NZB, r
 		segmentFetcher: segmentFetcher,
 		providerHosts:  append([]string(nil), providerHosts...),
 	}
+	session.segmentFetcher = attachProviderTracking(session, session.segmentFetcher)
+	loaderFiles := buildLoaderFiles(ctx, sessionID, contentFiles, pools, session.segmentFetcher, estimator)
+	session.Files = loaderFiles
+	session.File = loaderFiles[0]
 
 	logger.Debug("session CreateSession", "id", sessionID, "files", len(loaderFiles))
 	m.mu.Lock()
@@ -588,6 +727,7 @@ func (m *Manager) CreateDeferredSessionWithFetcher(sessionID, downloadURL string
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
+	trackedFetcher := segmentFetcher
 	session := &Session{
 		ID:             sessionID,
 		StreamName:     streamName,
@@ -604,9 +744,10 @@ func (m *Manager) CreateDeferredSessionWithFetcher(sessionID, downloadURL string
 		Clients:        make(map[string]time.Time),
 		ctx:            ctx,
 		cancel:         cancel,
-		segmentFetcher: segmentFetcher,
+		segmentFetcher: trackedFetcher,
 		providerHosts:  append([]string(nil), providerHosts...),
 	}
+	session.segmentFetcher = attachProviderTracking(session, trackedFetcher)
 	m.sessions[sessionID] = session
 	logger.Trace("session CreateDeferredSession done", "id", sessionID)
 	return session, nil

--- a/pkg/session/manager.go
+++ b/pkg/session/manager.go
@@ -86,11 +86,11 @@ type Session struct {
 	downloadURL string
 	indexer     indexer.Indexer
 
-	segmentFetcher       loader.SegmentFetcher
-	providerHosts        []string
-	usedProviders        map[string]struct{}
-	servedProviders      map[string]struct{}
-	trackServedProviders bool
+	segmentFetcher     loader.SegmentFetcher
+	providerHosts      []string
+	usedProviders      map[string]struct{}
+	servedProviders    map[string]struct{}
+	serveTrackingDepth int
 
 	bytesRead atomic.Int64 // bytes read during playback; used for AvailNZB good-report threshold
 	playback  *playbackStreamState
@@ -206,19 +206,21 @@ func (s *Session) RecordServedProviderHost(host string) {
 func (s *Session) BeginServeProviderTracking() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.trackServedProviders = true
+	s.serveTrackingDepth++
 }
 
 func (s *Session) EndServeProviderTracking() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.trackServedProviders = false
+	if s.serveTrackingDepth > 0 {
+		s.serveTrackingDepth--
+	}
 }
 
 func (s *Session) IsServeProviderTrackingEnabled() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.trackServedProviders
+	return s.serveTrackingDepth > 0
 }
 
 type sessionTrackingFetcher struct {

--- a/pkg/session/manager_test.go
+++ b/pkg/session/manager_test.go
@@ -290,6 +290,26 @@ func TestCreateDeferredSessionTracksUsedProviderHosts(t *testing.T) {
 	}
 }
 
+func TestServeProviderTrackingUsesDepthCounter(t *testing.T) {
+	s := &Session{}
+
+	s.BeginServeProviderTracking()
+	s.BeginServeProviderTracking()
+	if !s.IsServeProviderTrackingEnabled() {
+		t.Fatal("expected serve provider tracking to be enabled")
+	}
+
+	s.EndServeProviderTracking()
+	if !s.IsServeProviderTrackingEnabled() {
+		t.Fatal("expected serve provider tracking to remain enabled while another serve window is still active")
+	}
+
+	s.EndServeProviderTracking()
+	if s.IsServeProviderTrackingEnabled() {
+		t.Fatal("expected serve provider tracking to be disabled after the final serve window ends")
+	}
+}
+
 func TestCreateSessionKeepsBroadCandidatesWhenEpisodeMatchUnknown(t *testing.T) {
 	logger.Init("ERROR")
 

--- a/pkg/session/manager_test.go
+++ b/pkg/session/manager_test.go
@@ -14,6 +14,7 @@ import (
 	"streamnzb/pkg/media/nzb"
 	"streamnzb/pkg/media/seek"
 	"streamnzb/pkg/release"
+	"streamnzb/pkg/usenet/pool"
 )
 
 type fakePlaybackStream struct {
@@ -72,6 +73,19 @@ func (f *fakeIndexer) Type() string {
 		return f.typeName
 	}
 	return "newznab"
+}
+
+type fakeSegmentFetcher struct {
+	data pool.SegmentData
+	err  error
+}
+
+func (f *fakeSegmentFetcher) FetchSegment(_ context.Context, _ *nzb.Segment, _ []string) (pool.SegmentData, error) {
+	return f.data, f.err
+}
+
+func (f *fakeSegmentFetcher) FetchSegmentFirst(ctx context.Context, segment *nzb.Segment, groups []string) (pool.SegmentData, error) {
+	return f.FetchSegment(ctx, segment, groups)
 }
 
 func TestSessionCloseClearsHeavyReferences(t *testing.T) {
@@ -215,6 +229,65 @@ func TestGetOrDownloadNZBSelectsRequestedEpisode(t *testing.T) {
 		t.Fatalf("expected one selected file after lazy load, got %d", len(s.Files))
 	}
 	s.Close()
+}
+
+func TestCreateDeferredSessionTracksUsedProviderHosts(t *testing.T) {
+	logger.Init("ERROR")
+
+	m := &Manager{sessions: make(map[string]*Session)}
+	fetcher := &fakeSegmentFetcher{
+		data: pool.SegmentData{
+			Body:         []byte("segment-data"),
+			Size:         int64(len("segment-data")),
+			ProviderHost: "news.example.net",
+		},
+	}
+	s, err := m.CreateDeferredSessionWithFetcher(
+		"sess-provider-hosts",
+		"https://example.invalid/get?nzb=1",
+		nil,
+		&fakeIndexer{},
+		nil,
+		"movie",
+		"tt1375666",
+		"Inception",
+		"Stream01",
+		fetcher,
+		[]string{"configured.example.net"},
+	)
+	if err != nil {
+		t.Fatalf("CreateDeferredSessionWithFetcher returned error: %v", err)
+	}
+
+	data, err := s.segmentFetcher.FetchSegment(context.Background(), &nzb.Segment{ID: "<seg1>"}, nil)
+	if err != nil {
+		t.Fatalf("FetchSegment returned error: %v", err)
+	}
+	if got := data.ProviderHost; got != "news.example.net" {
+		t.Fatalf("ProviderHost = %q, want %q", got, "news.example.net")
+	}
+
+	used := s.UsedProviderHosts()
+	if len(used) != 1 || used[0] != "news.example.net" {
+		t.Fatalf("UsedProviderHosts = %v, want [news.example.net]", used)
+	}
+	if configured := s.ProviderHosts(); len(configured) != 1 || configured[0] != "configured.example.net" {
+		t.Fatalf("ProviderHosts = %v, want [configured.example.net]", configured)
+	}
+	if served := s.ServedProviderHosts(); len(served) != 0 {
+		t.Fatalf("ServedProviderHosts = %v, want none before serve tracking", served)
+	}
+
+	s.BeginServeProviderTracking()
+	if _, err := s.segmentFetcher.FetchSegment(context.Background(), &nzb.Segment{ID: "<seg2>"}, nil); err != nil {
+		t.Fatalf("FetchSegment during serve tracking returned error: %v", err)
+	}
+	s.EndServeProviderTracking()
+
+	served := s.ServedProviderHosts()
+	if len(served) != 1 || served[0] != "news.example.net" {
+		t.Fatalf("ServedProviderHosts = %v, want [news.example.net]", served)
+	}
 }
 
 func TestCreateSessionKeepsBroadCandidatesWhenEpisodeMatchUnknown(t *testing.T) {

--- a/pkg/usenet/pool/pool.go
+++ b/pkg/usenet/pool/pool.go
@@ -235,7 +235,11 @@ func (p *Pool) FetchSegmentFirst(ctx context.Context, segment *nzb.Segment, grou
 				ch <- segResult{err: err}
 				return
 			}
-			ch <- segResult{data: SegmentData{Body: frame.Data, Size: int64(len(frame.Data))}}
+			ch <- segResult{data: SegmentData{
+				Body:         frame.Data,
+				Size:         int64(len(frame.Data)),
+				ProviderHost: p.Host(providerID),
+			}}
 		}(exclude)
 	}
 
@@ -247,7 +251,9 @@ func (p *Pool) FetchSegmentFirst(ctx context.Context, segment *nzb.Segment, grou
 				cancel()
 				return SegmentData{}, fetchCtx.Err()
 			}
-			p.cache.Set(messageID, res.data)
+			cached := res.data
+			cached.ProviderHost = ""
+			p.cache.Set(messageID, cached)
 			cancel()
 			logger.Trace("fetch segment ok (parallel)", "message_id", messageID, "size", res.data.Size)
 			return res.data, nil
@@ -332,8 +338,9 @@ func (p *Pool) fetchSegmentOnce(ctx context.Context, messageID string, segment *
 			}
 
 			return SegmentData{
-				Body: frame.Data,
-				Size: int64(len(frame.Data)),
+				Body:         frame.Data,
+				Size:         int64(len(frame.Data)),
+				ProviderHost: p.Host(providerID),
 			}, false, nil
 		}()
 		if err != nil {
@@ -348,7 +355,9 @@ func (p *Pool) fetchSegmentOnce(ctx context.Context, messageID string, segment *
 		if !shouldCacheFetchedSegment(fetchCtx) {
 			return SegmentData{}, fetchCtx.Err()
 		}
-		p.cache.Set(messageID, data)
+		cached := data
+		cached.ProviderHost = ""
+		p.cache.Set(messageID, cached)
 		logger.Trace("fetch segment ok", "message_id", messageID, "size", data.Size)
 		return data, nil
 	}

--- a/pkg/usenet/pool/segment_cache.go
+++ b/pkg/usenet/pool/segment_cache.go
@@ -7,8 +7,9 @@ import (
 )
 
 type SegmentData struct {
-	Body []byte
-	Size int64
+	Body         []byte
+	Size         int64
+	ProviderHost string
 }
 
 // SegmentCacheBudget limits total segment cache memory across all sessions (0 = no limit).


### PR DESCRIPTION
## Summary
- refine AvailNZB reporting so good reports are only sent after real serving crosses byte or time thresholds
- classify short playback sessions as pending and improve attempt reasons for threshold and EOF cases
- record only serving providers for successful NZB history attempts and surface AvailNZB report state in the info dialog
- improve NZB history interactions and mobile readability, including single-open request expansion, clearer active request highlighting, and more polished detail cards
- improve small-screen admin layouts across settings, confirm dialogs, stream management, and dashboard active streams

## Testing
- go test ./pkg/core/persistence ./pkg/services/availnzb ./pkg/session ./pkg/server/stremio

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced AvailNZB reporting with playback qualification thresholds; reports only recorded after meeting minimum byte and duration requirements.
  * Richer NZB attempt history with improved availability status tracking and pending playback classification.

* **Bug Fixes**
  * Improved NZB history readability with redesigned card layout and expanded attempt details.
  * Enhanced mobile responsiveness across settings dialogs and dashboard components.
  * Fixed history display to show only serving providers for successful playback attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->