### PR TITLE
fix(persistence): recover nzb history after db path drift

### DIFF
--- a/pkg/core/config/config.go
+++ b/pkg/core/config/config.go
@@ -631,6 +631,7 @@ func (c *Config) LoadFile(path string) error {
 	if c.Streams == nil && raw.LegacyDevices != nil {
 		c.Streams = raw.LegacyDevices
 	}
+	c.LoadedPath = path
 	return nil
 }
 
@@ -725,7 +726,11 @@ func (c *Config) SaveFile(path string) error {
 
 	encoder := json.NewEncoder(file)
 	encoder.SetIndent("", "  ")
-	return encoder.Encode(c)
+	if err := encoder.Encode(c); err != nil {
+		return err
+	}
+	c.LoadedPath = path
+	return nil
 }
 
 func keySet(list []string, s string) bool {

--- a/pkg/core/config/config_test.go
+++ b/pkg/core/config/config_test.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -143,5 +145,36 @@ func TestApplyStreamModelUpgradeDefaultsCreatesQueriesAndDefaultStream(t *testin
 
 	if cfg.applyStreamModelUpgradeDefaults() {
 		t.Fatalf("expected second upgrade application to be a no-op")
+	}
+}
+
+func TestLoadFilePreservesLoadedPath(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config.json")
+	if err := os.WriteFile(configPath, []byte(`{"addon_port":7001}`), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg := &Config{}
+	if err := cfg.LoadFile(configPath); err != nil {
+		t.Fatalf("LoadFile: %v", err)
+	}
+
+	if cfg.LoadedPath != configPath {
+		t.Fatalf("LoadedPath = %q, want %q", cfg.LoadedPath, configPath)
+	}
+}
+
+func TestSaveFileUpdatesLoadedPath(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config.json")
+
+	cfg := &Config{AddonPort: 7001}
+	if err := cfg.SaveFile(configPath); err != nil {
+		t.Fatalf("SaveFile: %v", err)
+	}
+
+	if cfg.LoadedPath != configPath {
+		t.Fatalf("LoadedPath = %q, want %q", cfg.LoadedPath, configPath)
 	}
 }

--- a/pkg/core/persistence/manager.go
+++ b/pkg/core/persistence/manager.go
@@ -4,8 +4,12 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"sync"
 	"time"
+
+	"streamnzb/pkg/core/logger"
 )
 
 const saveDebounceInterval = 2 * time.Second
@@ -40,10 +44,271 @@ func GetManager(dataDir string) (*StateManager, error) {
 		db.Close()
 		return nil, fmt.Errorf("migrate state: %w", err)
 	}
+	if err := mergeMisplacedDatabases(db, dataDir); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("merge misplaced databases: %w", err)
+	}
 
 	m := &StateManager{db: db}
 	globalManager = m
 	return m, nil
+}
+
+func mergeMisplacedDatabases(target *sql.DB, dataDir string) error {
+	for _, sourcePath := range misplacedDatabasePaths(dataDir) {
+		mergedAttempts, mergedKV, err := mergeDatabaseFile(target, sourcePath)
+		if err != nil {
+			logger.Warn("Failed to merge misplaced sqlite database", "path", sourcePath, "err", err)
+			continue
+		}
+		if mergedAttempts > 0 || mergedKV > 0 {
+			logger.Info("Merged misplaced sqlite database", "path", sourcePath, "attempts", mergedAttempts, "kv", mergedKV)
+		}
+	}
+	return nil
+}
+
+func misplacedDatabasePaths(dataDir string) []string {
+	targetPath, _ := filepath.Abs(filepath.Join(dataDir, dbFilename))
+	seen := map[string]struct{}{}
+	var candidates []string
+
+	add := func(path string) {
+		if path == "" {
+			return
+		}
+		absPath, err := filepath.Abs(path)
+		if err != nil || absPath == targetPath {
+			return
+		}
+		if _, ok := seen[absPath]; ok {
+			return
+		}
+		if _, err := os.Stat(absPath); err != nil {
+			return
+		}
+		seen[absPath] = struct{}{}
+		candidates = append(candidates, absPath)
+	}
+
+	if filepath.Base(dataDir) == "data" {
+		add(filepath.Join(filepath.Dir(dataDir), dbFilename))
+	}
+	if cwd, err := os.Getwd(); err == nil {
+		add(filepath.Join(cwd, dbFilename))
+	}
+	return candidates
+}
+
+func mergeDatabaseFile(target *sql.DB, sourcePath string) (int64, int64, error) {
+	source, err := sql.Open("sqlite", sourcePath)
+	if err != nil {
+		return 0, 0, err
+	}
+	defer source.Close()
+	if err := source.Ping(); err != nil {
+		return 0, 0, err
+	}
+
+	mergedKV, err := mergeKVRows(target, source)
+	if err != nil {
+		return 0, 0, err
+	}
+	mergedAttempts, err := mergeAttemptRows(target, source)
+	if err != nil {
+		return 0, mergedKV, err
+	}
+	return mergedAttempts, mergedKV, nil
+}
+
+func tableExists(db *sql.DB, table string) (bool, error) {
+	var name string
+	err := db.QueryRow(`SELECT name FROM sqlite_master WHERE type='table' AND name = ?`, table).Scan(&name)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func tableColumns(db *sql.DB, table string) (map[string]struct{}, error) {
+	rows, err := db.Query(`PRAGMA table_info(` + table + `)`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	cols := make(map[string]struct{})
+	for rows.Next() {
+		var (
+			cid       int
+			name      string
+			colType   string
+			notNull   int
+			defaultV  sql.NullString
+			primaryKV int
+		)
+		if err := rows.Scan(&cid, &name, &colType, &notNull, &defaultV, &primaryKV); err != nil {
+			return nil, err
+		}
+		cols[name] = struct{}{}
+	}
+	return cols, rows.Err()
+}
+
+func mergeKVRows(target, source *sql.DB) (int64, error) {
+	ok, err := tableExists(source, "kv")
+	if err != nil || !ok {
+		return 0, err
+	}
+	rows, err := source.Query(`SELECT key, value, updated_at FROM kv`)
+	if err != nil {
+		return 0, err
+	}
+	defer rows.Close()
+
+	var merged int64
+	for rows.Next() {
+		var (
+			key       string
+			value     []byte
+			updatedAt sql.NullInt64
+		)
+		if err := rows.Scan(&key, &value, &updatedAt); err != nil {
+			return merged, err
+		}
+		res, err := target.Exec(`INSERT OR IGNORE INTO kv (key, value, updated_at) VALUES (?, ?, ?)`, key, value, updatedAt)
+		if err != nil {
+			return merged, err
+		}
+		if affected, _ := res.RowsAffected(); affected > 0 {
+			merged += affected
+		}
+	}
+	return merged, rows.Err()
+}
+
+func mergeAttemptRows(target, source *sql.DB) (int64, error) {
+	ok, err := tableExists(source, "nzb_attempts")
+	if err != nil || !ok {
+		return 0, err
+	}
+	cols, err := tableColumns(source, "nzb_attempts")
+	if err != nil {
+		return 0, err
+	}
+
+	colOr := func(name, fallback string) string {
+		if _, ok := cols[name]; ok {
+			return name
+		}
+		return fallback + " AS " + name
+	}
+
+	query := fmt.Sprintf(`SELECT
+		tried_at,
+		%s,
+		%s,
+		content_type,
+		content_id,
+		%s,
+		%s,
+		release_title,
+		%s,
+		%s,
+		%s,
+		success,
+		%s,
+		%s,
+		%s
+		FROM nzb_attempts`,
+		colOr("stream_name", "''"),
+		colOr("provider_name", "''"),
+		colOr("content_title", "''"),
+		colOr("indexer_name", "''"),
+		colOr("release_url", "''"),
+		colOr("release_size", "0"),
+		colOr("served_file", "''"),
+		colOr("failure_reason", "''"),
+		colOr("slot_path", "''"),
+		colOr("preload", "0"),
+	)
+
+	rows, err := source.Query(query)
+	if err != nil {
+		return 0, err
+	}
+	defer rows.Close()
+
+	var merged int64
+	for rows.Next() {
+		var a NZBAttempt
+		var triedAtMs int64
+		var success int
+		var preload int
+		if err := rows.Scan(
+			&triedAtMs,
+			&a.StreamName,
+			&a.ProviderName,
+			&a.ContentType,
+			&a.ContentID,
+			&a.ContentTitle,
+			&a.IndexerName,
+			&a.ReleaseTitle,
+			&a.ReleaseURL,
+			&a.ReleaseSize,
+			&a.ServedFile,
+			&success,
+			&a.FailureReason,
+			&a.SlotPath,
+			&preload,
+		); err != nil {
+			return merged, err
+		}
+		a.TriedAt = time.UnixMilli(triedAtMs)
+		a.Success = success != 0
+		a.Preload = preload != 0
+
+		res, err := target.Exec(`INSERT INTO nzb_attempts (
+			tried_at, stream_name, provider_name, content_type, content_id, content_title,
+			indexer_name, release_title, release_url, release_size, served_file, success,
+			failure_reason, slot_path, preload
+		)
+		SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+		WHERE NOT EXISTS (
+			SELECT 1 FROM nzb_attempts
+			WHERE tried_at = ?
+			  AND content_type = ?
+			  AND content_id = ?
+			  AND release_title = ?
+			  AND COALESCE(release_url, '') = ?
+			  AND COALESCE(slot_path, '') = ?
+			  AND COALESCE(preload, 0) = ?
+			  AND success = ?
+			  AND COALESCE(failure_reason, '') = ?
+		)`,
+			a.TriedAt.UnixMilli(), a.StreamName, a.ProviderName, a.ContentType, a.ContentID, a.ContentTitle,
+			a.IndexerName, a.ReleaseTitle, a.ReleaseURL, a.ReleaseSize, a.ServedFile, boolToInt(a.Success),
+			a.FailureReason, a.SlotPath, boolToInt(a.Preload),
+			a.TriedAt.UnixMilli(), a.ContentType, a.ContentID, a.ReleaseTitle, a.ReleaseURL, a.SlotPath, boolToInt(a.Preload), boolToInt(a.Success), a.FailureReason,
+		)
+		if err != nil {
+			return merged, err
+		}
+		if affected, _ := res.RowsAffected(); affected > 0 {
+			merged += affected
+		}
+	}
+	return merged, rows.Err()
+}
+
+func boolToInt(v bool) int {
+	if v {
+		return 1
+	}
+	return 0
 }
 
 func (m *StateManager) Get(key string, target interface{}) (bool, error) {

--- a/pkg/core/persistence/manager.go
+++ b/pkg/core/persistence/manager.go
@@ -44,17 +44,14 @@ func GetManager(dataDir string) (*StateManager, error) {
 		db.Close()
 		return nil, fmt.Errorf("migrate state: %w", err)
 	}
-	if err := mergeMisplacedDatabases(db, dataDir); err != nil {
-		db.Close()
-		return nil, fmt.Errorf("merge misplaced databases: %w", err)
-	}
+	mergeMisplacedDatabases(db, dataDir)
 
 	m := &StateManager{db: db}
 	globalManager = m
 	return m, nil
 }
 
-func mergeMisplacedDatabases(target *sql.DB, dataDir string) error {
+func mergeMisplacedDatabases(target *sql.DB, dataDir string) {
 	for _, sourcePath := range misplacedDatabasePaths(dataDir) {
 		mergedAttempts, mergedKV, err := mergeDatabaseFile(target, sourcePath)
 		if err != nil {
@@ -63,9 +60,17 @@ func mergeMisplacedDatabases(target *sql.DB, dataDir string) error {
 		}
 		if mergedAttempts > 0 || mergedKV > 0 {
 			logger.Info("Merged misplaced sqlite database", "path", sourcePath, "attempts", mergedAttempts, "kv", mergedKV)
+			if err := archiveMergedDatabase(sourcePath); err != nil {
+				logger.Warn("Failed to archive merged sqlite database", "path", sourcePath, "err", err)
+			}
 		}
 	}
-	return nil
+}
+
+func archiveMergedDatabase(sourcePath string) error {
+	archivedPath := sourcePath + ".merged"
+	_ = os.Remove(archivedPath)
+	return os.Rename(sourcePath, archivedPath)
 }
 
 func misplacedDatabasePaths(dataDir string) []string {

--- a/pkg/core/persistence/manager_test.go
+++ b/pkg/core/persistence/manager_test.go
@@ -1,6 +1,7 @@
 package persistence
 
 import (
+	"database/sql"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -102,5 +103,83 @@ func TestMigration(t *testing.T) {
 
 	if _, err := os.Stat(usagePath); !os.IsNotExist(err) {
 		t.Error("usage.json should have been deleted after migration")
+	}
+}
+
+func TestGetManagerMergesMisplacedSiblingDatabase(t *testing.T) {
+	logger.Init("DEBUG")
+	rootDir := t.TempDir()
+	dataDir := filepath.Join(rootDir, "data")
+	if err := os.MkdirAll(dataDir, 0755); err != nil {
+		t.Fatalf("mkdir data dir: %v", err)
+	}
+
+	sourceDB, err := sql.Open("sqlite", filepath.Join(rootDir, dbFilename))
+	if err != nil {
+		t.Fatalf("open source db: %v", err)
+	}
+	t.Cleanup(func() { _ = sourceDB.Close() })
+	if _, err := sourceDB.Exec(`CREATE TABLE kv (
+		key TEXT PRIMARY KEY,
+		value BLOB NOT NULL,
+		updated_at INTEGER
+	);`); err != nil {
+		t.Fatalf("create kv: %v", err)
+	}
+	if _, err := sourceDB.Exec(`CREATE TABLE nzb_attempts (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		tried_at INTEGER NOT NULL,
+		content_type TEXT NOT NULL,
+		content_id TEXT NOT NULL,
+		content_title TEXT,
+		release_title TEXT NOT NULL,
+		release_url TEXT,
+		release_size INTEGER,
+		served_file TEXT,
+		success INTEGER NOT NULL,
+		failure_reason TEXT,
+		slot_path TEXT,
+		preload INTEGER NOT NULL DEFAULT 0,
+		indexer_name TEXT
+	);`); err != nil {
+		t.Fatalf("create attempts: %v", err)
+	}
+	if _, err := sourceDB.Exec(`INSERT INTO nzb_attempts
+		(tried_at, content_type, content_id, content_title, release_title, release_url, release_size, served_file, success, failure_reason, slot_path, preload, indexer_name)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		1740000000000, "movie", "tt123", "Example", "Example.Release", "https://example.invalid", 1234, "movie.mkv", 1, "", "slot-1", 0, "Indexer"); err != nil {
+		t.Fatalf("insert attempt: %v", err)
+	}
+	if err := setKV(sourceDB, "provider_usage", []byte(`{"example":1}`)); err != nil {
+		t.Fatalf("insert kv: %v", err)
+	}
+
+	globalManager = nil
+	mgr, err := GetManager(dataDir)
+	if err != nil {
+		t.Fatalf("GetManager: %v", err)
+	}
+
+	list, err := mgr.ListAttempts(ListAttemptsOptions{Limit: 10})
+	if err != nil {
+		t.Fatalf("ListAttempts: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("expected 1 merged attempt, got %d", len(list))
+	}
+	if got := list[0].ReleaseTitle; got != "Example.Release" {
+		t.Fatalf("ReleaseTitle = %q, want %q", got, "Example.Release")
+	}
+
+	var providerUsage map[string]int
+	found, err := mgr.Get("provider_usage", &providerUsage)
+	if err != nil {
+		t.Fatalf("Get(provider_usage): %v", err)
+	}
+	if !found {
+		t.Fatal("expected provider_usage to be merged")
+	}
+	if providerUsage["example"] != 1 {
+		t.Fatalf("provider_usage = %#v", providerUsage)
 	}
 }

--- a/pkg/core/persistence/manager_test.go
+++ b/pkg/core/persistence/manager_test.go
@@ -118,7 +118,6 @@ func TestGetManagerMergesMisplacedSiblingDatabase(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open source db: %v", err)
 	}
-	t.Cleanup(func() { _ = sourceDB.Close() })
 	if _, err := sourceDB.Exec(`CREATE TABLE kv (
 		key TEXT PRIMARY KEY,
 		value BLOB NOT NULL,
@@ -153,6 +152,9 @@ func TestGetManagerMergesMisplacedSiblingDatabase(t *testing.T) {
 	if err := setKV(sourceDB, "provider_usage", []byte(`{"example":1}`)); err != nil {
 		t.Fatalf("insert kv: %v", err)
 	}
+	if err := sourceDB.Close(); err != nil {
+		t.Fatalf("close source db: %v", err)
+	}
 
 	globalManager = nil
 	mgr, err := GetManager(dataDir)
@@ -181,5 +183,12 @@ func TestGetManagerMergesMisplacedSiblingDatabase(t *testing.T) {
 	}
 	if providerUsage["example"] != 1 {
 		t.Fatalf("provider_usage = %#v", providerUsage)
+	}
+
+	if _, err := os.Stat(filepath.Join(rootDir, dbFilename)); !os.IsNotExist(err) {
+		t.Fatalf("expected misplaced db to be archived, stat err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(rootDir, dbFilename+".merged")); err != nil {
+		t.Fatalf("expected archived misplaced db to exist: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- fix SQLite path drift so runtime state keeps using the persistent data directory
- preserve `LoadedPath` during config load/save instead of falling back to a relative app path
- automatically merge misplaced NZB history/state from a stray sibling database back into the canonical data-dir database on startup
- add regression tests covering config path preservation and misplaced database recovery

## Why
After the last update, some deployments started writing new history into a non-persistent SQLite file (for example `/app/streamnzb.db`) while the original history still remained in the persistent database (for example `/app/data/streamnzb.db`). This made NZB history appear wiped even though the data was still present.

This change restores the correct persistent DB path and recovers history written into the wrong location.

## Testing
- `go test ./pkg/core/config`
- `go test ./pkg/core/persistence`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Application now automatically scans for and merges data from SQLite database files stored in non-standard locations.

* **Bug Fixes**
  * Configuration file paths are now properly tracked during load and save operations.

* **Tests**
  * Added test coverage for configuration file persistence and automatic database file discovery and merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->