### PR TITLE
fix(playback): refine failover reporting and startup handling

### DIFF
--- a/cmd/streamnzb/main.go
+++ b/cmd/streamnzb/main.go
@@ -55,6 +55,7 @@ func main() {
 		initialization.WaitForInputAndExit(fmt.Errorf("configuration error: %w", err))
 	}
 	logger.SetLevel(cfg.LogLevel)
+	logger.SetVerboseNNTPLogging(cfg.VerboseNNTPLogging)
 	logger.PurgeOldLogs(cfg.KeepLogFiles)
 
 	if cfg.MemoryLimitMB > 0 {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, useCallback } from 'react'
 import Settings from './Settings'
 import Login from './components/Login'
 import ChangePassword from './components/ChangePassword'
@@ -10,6 +10,7 @@ import { LogsPage } from "@/components/LogsPage"
 import { NZBHistoryPage } from "@/components/NZBHistoryPage"
 import { ProfilePage } from "@/components/ProfilePage"
 import StreamManagement from './components/StreamManagement'
+import { apiFetch } from './api'
 import { AlertCircle, Loader2 } from "lucide-react"
 
 import { useAdminRuntime } from './hooks/useAdminRuntime'
@@ -23,6 +24,11 @@ function App() {
   const [theme, setTheme] = useState(localStorage.getItem('theme') || 'system')
   const hasLoggedOutRef = useRef(false)
   const [activePage, setActivePage] = useState('dashboard')
+  const [availNZBStatus, setAvailNZBStatus] = useState(null)
+  const [availNZBStatusLoading, setAvailNZBStatusLoading] = useState(false)
+  const [availNZBStatusError, setAvailNZBStatusError] = useState('')
+  const availNZBStatusLoadedRef = useRef(false)
+  const availNZBStatusLoadingRef = useRef(false)
 
   const {
     stats,
@@ -147,6 +153,43 @@ function App() {
     localStorage.setItem('theme', theme);
   }, [theme]);
 
+  const isSettingsPage = activePage === 'settings'
+  const availNZBEnabled = (config?.availnzb_mode || '') !== 'disabled'
+
+  const fetchAvailNZBStatus = useCallback(async (force = false) => {
+    if (!authenticated || !config || !availNZBEnabled) return
+    if (availNZBStatusLoadingRef.current) return
+    if (!force && availNZBStatusLoadedRef.current) return
+
+    availNZBStatusLoadingRef.current = true
+    setAvailNZBStatusLoading(true)
+    setAvailNZBStatusError('')
+    try {
+      const data = await apiFetch('/api/availnzb/status')
+      setAvailNZBStatus(data || null)
+      availNZBStatusLoadedRef.current = true
+    } catch (error) {
+      setAvailNZBStatus(null)
+      setAvailNZBStatusError(error.message || 'Failed to load AvailNZB status.')
+      availNZBStatusLoadedRef.current = true
+    } finally {
+      availNZBStatusLoadingRef.current = false
+      setAvailNZBStatusLoading(false)
+    }
+  }, [authenticated, config, availNZBEnabled])
+
+  useEffect(() => {
+    if (!authenticated || !config || !availNZBEnabled) {
+      availNZBStatusLoadedRef.current = false
+      availNZBStatusLoadingRef.current = false
+      setAvailNZBStatus(null)
+      setAvailNZBStatusError('')
+      setAvailNZBStatusLoading(false)
+      return
+    }
+    void fetchAvailNZBStatus(false)
+  }, [authenticated, config, availNZBEnabled, fetchAvailNZBStatus])
+
   if (!authChecked) {
     return (
       <div className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-background/80 backdrop-blur-sm gap-4">
@@ -186,8 +229,6 @@ function App() {
     </div>
   )
 
-  const isSettingsPage = activePage === 'settings'
-
   return (
     <SidebarProvider>
       <AppSidebar
@@ -208,6 +249,9 @@ function App() {
               chartData={chartData}
               sendCommand={sendCommand}
               config={config}
+              availNZBStatus={availNZBStatus}
+              availNZBStatusLoading={availNZBStatusLoading}
+              availNZBStatusError={availNZBStatusError}
             />
           )}
           {activePage === 'nzb-history' && (
@@ -245,6 +289,10 @@ function App() {
                 saveStatus={saveStatus}
                 clearSaveStatus={clearSaveStatus}
                 isSaving={isSaving}
+                availNZBStatus={availNZBStatus}
+                availNZBStatusLoading={availNZBStatusLoading}
+                availNZBStatusError={availNZBStatusError}
+                onRefreshAvailNZBStatus={() => fetchAvailNZBStatus(true)}
                 adminToken={currentUser && currentUser !== 'legacy' ? authToken : null}
                 indexerCaps={indexerCaps}
                 stats={stats}

--- a/frontend/src/Settings.jsx
+++ b/frontend/src/Settings.jsx
@@ -19,7 +19,20 @@ const TABS = [
 
 const ACTIVE_TAB_STORAGE_KEY = 'streamnzb.settings.activeTab'
 
-function Settings({ initialConfig, sendCommand, saveStatus, clearSaveStatus, isSaving, adminToken, indexerCaps, stats }) {
+function Settings({
+  initialConfig,
+  sendCommand,
+  saveStatus,
+  clearSaveStatus,
+  isSaving,
+  availNZBStatus,
+  availNZBStatusLoading,
+  availNZBStatusError,
+  onRefreshAvailNZBStatus,
+  adminToken,
+  indexerCaps,
+  stats,
+}) {
   const [activeTab, setActiveTab] = useState(() => {
     if (typeof window === 'undefined') return 'network'
     const savedTab = window.sessionStorage.getItem(ACTIVE_TAB_STORAGE_KEY) || 'network'
@@ -260,10 +273,14 @@ function Settings({ initialConfig, sendCommand, saveStatus, clearSaveStatus, isS
           initialValues={advancedInitialValues}
           envOverrides={envOverrides}
           isSaving={isSaving}
+          availNZBStatus={availNZBStatus}
+          availNZBStatusLoading={availNZBStatusLoading}
+          availNZBStatusError={availNZBStatusError}
           onDirtyChange={handleAdvancedDirtyChange}
           onProceedTabChange={handleAdvancedProceedTabChange}
           onPersist={handleAdvancedPersist}
-            onClearCache={handleClearCache}
+          onClearCache={handleClearCache}
+          onRefreshAvailNZBStatus={onRefreshAvailNZBStatus}
           />
         )}
 

--- a/frontend/src/components/AdvancedSettingsSection.jsx
+++ b/frontend/src/components/AdvancedSettingsSection.jsx
@@ -3,17 +3,18 @@ import { useForm, useWatch } from 'react-hook-form'
 import { Loader2, Info, AlertTriangle, Eye, EyeOff, Copy, Check, Lock, LockOpen, Save, Paintbrush } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
+import { Switch } from "@/components/ui/switch"
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
 import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage, FormDescription } from "@/components/ui/form"
 import { PasswordInput } from "@/components/ui/password-input"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
 import { ConfirmDialog } from "@/components/ConfirmDialog"
-import { apiFetch } from "@/api"
 import { cn } from "@/lib/utils"
 
 const CARD_FIELDS = {
-  admin: ['log_level', 'keep_log_files', 'nzb_history_retention_days'],
+  admin: ['log_level', 'verbose_nntp_logging', 'keep_log_files', 'nzb_history_retention_days'],
   memory: ['memory_limit_mb'],
+  playback: ['playback_startup_timeout_seconds'],
   availnzb: ['availnzb_api_key', 'availnzb_mode'],
   metadata: ['tmdb_api_key', 'tvdb_api_key'],
 }
@@ -22,11 +23,16 @@ function pickInitialValues(values = {}) {
   const parsedRetentionDays = values.nzb_history_retention_days == null
     ? 90
     : Number(values.nzb_history_retention_days)
+  const parsedPlaybackStartupTimeout = values.playback_startup_timeout_seconds == null
+    ? 5
+    : Number(values.playback_startup_timeout_seconds)
   return {
     log_level: values.log_level ?? 'INFO',
+    verbose_nntp_logging: values.verbose_nntp_logging === true,
     keep_log_files: Number(values.keep_log_files ?? 9) || 9,
     nzb_history_retention_days: Number.isFinite(parsedRetentionDays) ? parsedRetentionDays : 90,
     memory_limit_mb: Number(values.memory_limit_mb ?? 512),
+    playback_startup_timeout_seconds: Number.isFinite(parsedPlaybackStartupTimeout) ? parsedPlaybackStartupTimeout : 5,
     availnzb_api_key: values.availnzb_api_key ?? '',
     availnzb_mode: values.availnzb_mode ?? '',
     tmdb_api_key: values.tmdb_api_key ?? '',
@@ -58,8 +64,12 @@ export const AdvancedSettingsSection = forwardRef(function AdvancedSettingsSecti
   initialValues,
   envOverrides,
   isSaving,
+  availNZBStatus,
+  availNZBStatusLoading,
+  availNZBStatusError,
   onPersist,
   onClearCache,
+  onRefreshAvailNZBStatus,
   onDirtyChange,
   onProceedTabChange,
 }, ref) {
@@ -76,9 +86,6 @@ export const AdvancedSettingsSection = forwardRef(function AdvancedSettingsSecti
   const [showDiscardConfirm, setShowDiscardConfirm] = useState(false)
   const [pendingTabChange, setPendingTabChange] = useState('')
   const [showUnsavedHighlights, setShowUnsavedHighlights] = useState(false)
-  const [availNZBStatus, setAvailNZBStatus] = useState(null)
-  const [availNZBStatusLoading, setAvailNZBStatusLoading] = useState(false)
-  const [availNZBStatusError, setAvailNZBStatusError] = useState('')
   const dirtyRef = useRef(false)
 
   const form = useForm({ defaultValues: defaults })
@@ -98,34 +105,6 @@ export const AdvancedSettingsSection = forwardRef(function AdvancedSettingsSecti
     dirtyRef.current = false
     onDirtyChange?.(false)
   }, [defaults, onDirtyChange, reset])
-
-  useEffect(() => {
-    let cancelled = false
-
-    const fetchAvailNZBStatus = async () => {
-      setAvailNZBStatusLoading(true)
-      setAvailNZBStatusError('')
-      try {
-        const data = await apiFetch('/api/availnzb/status')
-        if (cancelled) return
-        setAvailNZBStatus(data || null)
-      } catch (error) {
-        if (cancelled) return
-        setAvailNZBStatus(null)
-        setAvailNZBStatusError(error.message || 'Failed to load AvailNZB key status.')
-      } finally {
-        if (!cancelled) {
-          setAvailNZBStatusLoading(false)
-        }
-      }
-    }
-
-    fetchAvailNZBStatus()
-
-    return () => {
-      cancelled = true
-    }
-  }, [])
 
   useImperativeHandle(ref, () => ({
     hasUnsavedChanges() {
@@ -164,6 +143,9 @@ export const AdvancedSettingsSection = forwardRef(function AdvancedSettingsSecti
       dirtyRef.current = false
       onDirtyChange?.(false)
       setShowUnsavedHighlights(false)
+      if (cardId === 'availnzb') {
+        void onRefreshAvailNZBStatus?.()
+      }
     } finally {
       setSavingCard('')
     }
@@ -273,6 +255,25 @@ export const AdvancedSettingsSection = forwardRef(function AdvancedSettingsSecti
                         <FormMessage />
                       </FormItem>
                     )} />
+                    <FormField control={control} name="verbose_nntp_logging" render={({ field }) => (
+                      <FormItem className="relative rounded-none border-0 p-3">
+                        <div className="absolute left-3 right-3 top-0 border-t border-border/60" />
+                        <div className={stackedFieldRowClass}>
+                          <div className="sm:flex-1">
+                            <FormLabel className={labelClass}>Verbose NNTP logging</FormLabel>
+                          </div>
+                          <FormControl>
+                            <Switch
+                              checked={field.value === true}
+                              onCheckedChange={field.onChange}
+                              className={showUnsavedHighlights && formState.dirtyFields?.verbose_nntp_logging ? 'ring-2 ring-destructive ring-offset-2 ring-offset-background' : ''}
+                            />
+                          </FormControl>
+                        </div>
+                        <FormDescription className="mt-3">Include low-level NNTP connection and pool logs in DEBUG output.</FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    )} />
                     <FormField control={control} name="keep_log_files" render={({ field }) => (
                       <FormItem className="relative rounded-none border-0 p-3">
                         <div className="absolute left-3 right-3 top-0 border-t border-border/60" />
@@ -336,6 +337,32 @@ export const AdvancedSettingsSection = forwardRef(function AdvancedSettingsSecti
                     </Button>
                   </div>
                   <div className="mt-3 text-sm text-muted-foreground">Clears the in-memory playlist and raw search caches immediately.</div>
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0 flex-1 max-w-[30rem] space-y-0.5">
+                    <CardTitle>Playback</CardTitle>
+                    <CardDescription>Startup behavior before the first playable response is sent.</CardDescription>
+                  </div>
+                  <div className="shrink-0">{renderSaveButton('playback')}</div>
+                </div>
+              </CardHeader>
+              <CardContent>
+                <div className="rounded-md border border-border/60">
+                  <FormField control={control} name="playback_startup_timeout_seconds" render={({ field }) => (
+                    <FormItem className="rounded-none border-0 p-3">
+                      <div className={stackedFieldRowClass}>
+                        <FormLabel className={cn(labelClass, 'sm:flex-1')}>Playback startup timeout (s)</FormLabel>
+                        <FormControl><Input type="number" min={1} max={60} className={fieldClassName('playback_startup_timeout_seconds', `h-9 ${controlMediumClass}`)} {...field} value={field.value ?? ''} onChange={e => { const v = e.target.value; const next = Number(v); field.onChange(v === '' ? 5 : Math.min(60, Math.max(1, Number.isNaN(next) ? 5 : next))) }} /></FormControl>
+                      </div>
+                      <FormDescription className="mt-3">How long StreamNZB waits for the initial playback probe/open before failing over to the next release. Higher values reduce false startup timeouts but delay failover.</FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )} />
                 </div>
               </CardContent>
             </Card>

--- a/frontend/src/components/DashboardPage.jsx
+++ b/frontend/src/components/DashboardPage.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
@@ -12,7 +12,6 @@ import {
 import { ComposedChart, Area, XAxis, YAxis } from "recharts"
 import { Activity, Globe, X, MonitorPlay, Loader2 } from "lucide-react"
 import { cn } from "@/lib/utils"
-import { apiFetch } from '../api'
 
 const chartConfig = {
   speed: {
@@ -31,10 +30,7 @@ function formatDownloadedMb(mb) {
   return { value: n.toFixed(1), unit: 'MB' }
 }
 
-export function DashboardPage({ stats, chartData, sendCommand, config }) {
-  const [availNZBStatus, setAvailNZBStatus] = useState(null)
-  const [availNZBStatusLoading, setAvailNZBStatusLoading] = useState(false)
-  const [availNZBStatusError, setAvailNZBStatusError] = useState('')
+export function DashboardPage({ stats, chartData, sendCommand, config, availNZBStatus, availNZBStatusLoading, availNZBStatusError }) {
   const [activeSessionToClose, setActiveSessionToClose] = useState(null)
   const availNZBEnabled = (config?.availnzb_mode || '') !== 'disabled'
   const indexerUrls = useMemo(() => {
@@ -105,36 +101,6 @@ export function DashboardPage({ stats, chartData, sendCommand, config }) {
 
     return rows
   }, [config, stats])
-
-  useEffect(() => {
-    if (!availNZBEnabled) {
-      setAvailNZBStatus(null)
-      setAvailNZBStatusError('')
-      setAvailNZBStatusLoading(false)
-      return
-    }
-
-    let cancelled = false
-
-    const fetchAvailNZBStatus = async () => {
-      setAvailNZBStatusLoading(true)
-      setAvailNZBStatusError('')
-      try {
-        const data = await apiFetch('/api/availnzb/status')
-        if (!cancelled) setAvailNZBStatus(data || null)
-      } catch (error) {
-        if (!cancelled) {
-          setAvailNZBStatus(null)
-          setAvailNZBStatusError(error.message || 'Trust unavailable')
-        }
-      } finally {
-        if (!cancelled) setAvailNZBStatusLoading(false)
-      }
-    }
-
-    fetchAvailNZBStatus()
-    return () => { cancelled = true }
-  }, [availNZBEnabled])
 
   const rawAvailNZBTrustScore = Number(availNZBStatus?.status?.trust_score)
   const maxAvailNZBTrustScore = 60

--- a/frontend/src/components/DashboardPage.jsx
+++ b/frontend/src/components/DashboardPage.jsx
@@ -104,11 +104,15 @@ export function DashboardPage({ stats, chartData, sendCommand, config, availNZBS
 
   const rawAvailNZBTrustScore = Number(availNZBStatus?.status?.trust_score)
   const maxAvailNZBTrustScore = 60
+  const availNZBStatusMessage = availNZBStatusError || availNZBStatus?.status_error || ''
+  const hasAvailNZBTrustError = availNZBEnabled && !availNZBStatusLoading && Boolean(availNZBStatusMessage)
   const availNZBTrustScore = Number.isFinite(rawAvailNZBTrustScore)
     ? (Math.max(0, Math.min(maxAvailNZBTrustScore, rawAvailNZBTrustScore)) / maxAvailNZBTrustScore) * 100
     : null
-  const availNZBTrustSummary = `${Math.round(availNZBTrustScore ?? 0)}%`
-  const availNZBTrustBarClass = availNZBTrustScore === null
+  const availNZBTrustSummary = hasAvailNZBTrustError ? 'Error' : `${Math.round(availNZBTrustScore ?? 0)}%`
+  const availNZBTrustBarClass = hasAvailNZBTrustError
+    ? 'bg-destructive/50'
+    : availNZBTrustScore === null
     ? 'bg-muted-foreground/20'
     : availNZBTrustScore < 34
       ? 'bg-destructive'
@@ -146,14 +150,18 @@ export function DashboardPage({ stats, chartData, sendCommand, config, availNZBS
               <>
                 <CardTitle className="flex items-center gap-2 tabular-nums">
                   {availNZBStatusLoading && <Loader2 className="h-4 w-4 animate-spin text-primary" />}
-                  <span className="text-primary">{availNZBTrustSummary}</span>
+                  <span className={hasAvailNZBTrustError ? 'text-destructive' : 'text-primary'}>{availNZBTrustSummary}</span>
                 </CardTitle>
-                <div className="mt-2 h-2 w-full overflow-hidden rounded-full bg-muted/70" aria-hidden="true">
-                  <div
-                    className={cn("h-full rounded-full transition-all duration-500", availNZBTrustBarClass)}
-                    style={{ width: `${availNZBTrustScore ?? 0}%` }}
-                  />
-                </div>
+                {hasAvailNZBTrustError ? (
+                  <p className="mt-2 line-clamp-2 text-xs text-destructive">{availNZBStatusMessage}</p>
+                ) : (
+                  <div className="mt-2 h-2 w-full overflow-hidden rounded-full bg-muted/70" aria-hidden="true">
+                    <div
+                      className={cn("h-full rounded-full transition-all duration-500", availNZBTrustBarClass)}
+                      style={{ width: `${availNZBTrustScore ?? 0}%` }}
+                    />
+                  </div>
+                )}
               </>
             ) : (
               <CardTitle className="tabular-nums text-muted-foreground">0%</CardTitle>

--- a/frontend/src/components/NetworkSettingsSection.jsx
+++ b/frontend/src/components/NetworkSettingsSection.jsx
@@ -272,7 +272,11 @@ export const NetworkSettingsSection = forwardRef(function NetworkSettingsSection
                     <div className="absolute left-3 right-3 top-0 border-t border-border/60" />
                     <div className={stackedFieldRowClass}>
                       <FormLabel className={cn(labelClass, 'sm:flex-1')}>Proxy Password</FormLabel>
-                      <FormControl><PasswordInput disabled={!proxyEnabled} className={fieldClassName('proxy_auth_pass', `h-9 ${controlWideClass}`)} {...field} /></FormControl>
+                      <FormControl>
+                        <div className={controlWideClass}>
+                          <PasswordInput disabled={!proxyEnabled} className={fieldClassName('proxy_auth_pass', 'h-9 w-full')} {...field} />
+                        </div>
+                      </FormControl>
                     </div>
                     <FormDescription className="mt-3">Optional password clients must provide when using the proxy.</FormDescription>
                     <FormMessage />

--- a/frontend/src/hooks/useSettingsState.js
+++ b/frontend/src/hooks/useSettingsState.js
@@ -17,8 +17,10 @@ const NETWORK_TAB_FIELDS = [
 
 const ADVANCED_TAB_FIELDS = [
   'log_level',
+  'verbose_nntp_logging',
   'keep_log_files',
   'nzb_history_retention_days',
+  'playback_startup_timeout_seconds',
   'memory_limit_mb',
   'availnzb_api_key',
   'availnzb_mode',
@@ -193,6 +195,7 @@ export function useSettingsState({
     useragent: 'User-Agent',
     admin: 'Logs',
     memory: 'Memory & Cache',
+    playback: 'Playback',
     availnzb: 'AvailNZB',
     metadata: 'Metadata APIs',
   }

--- a/frontend/src/hooks/useSettingsState.js
+++ b/frontend/src/hooks/useSettingsState.js
@@ -260,6 +260,8 @@ export function useSettingsState({
       trimmedFullData.keep_log_files = Math.min(50, Math.max(1, Number.isNaN(keepLog) ? 9 : keepLog))
       const nzbHistoryRetention = Number(trimmedFullData.nzb_history_retention_days)
       trimmedFullData.nzb_history_retention_days = Math.min(3650, Math.max(0, Number.isNaN(nzbHistoryRetention) ? 90 : nzbHistoryRetention))
+      const playbackStartupTimeout = Number(trimmedFullData.playback_startup_timeout_seconds)
+      trimmedFullData.playback_startup_timeout_seconds = Math.min(60, Math.max(1, Number.isNaN(playbackStartupTimeout) ? 5 : playbackStartupTimeout))
 
       const payload = overrides
         ? Object.keys(overrides).reduce((acc, key) => {

--- a/pkg/core/config/config.go
+++ b/pkg/core/config/config.go
@@ -20,6 +20,7 @@ const (
 	defaultAdminPasswordHash               = "8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918"
 	DefaultInternalIndexerTimeoutSeconds   = 5
 	DefaultAggregatorIndexerTimeoutSeconds = 10
+	DefaultPlaybackStartupTimeoutSeconds   = 5
 	CurrentConfigVersion                   = 2
 	StreamModelConfigVersion               = 2
 	defaultMigratedStreamID                = "default"
@@ -119,14 +120,26 @@ func (ic IndexerConfig) EffectiveTimeout() time.Duration {
 	return time.Duration(ic.EffectiveTimeoutSeconds()) * time.Second
 }
 
+func (c *Config) EffectivePlaybackStartupTimeoutSeconds() int {
+	if c != nil && c.PlaybackStartupTimeoutSeconds > 0 {
+		return c.PlaybackStartupTimeoutSeconds
+	}
+	return DefaultPlaybackStartupTimeoutSeconds
+}
+
+func (c *Config) EffectivePlaybackStartupTimeout() time.Duration {
+	return time.Duration(c.EffectivePlaybackStartupTimeoutSeconds()) * time.Second
+}
+
 type Config struct {
 	ConfigVersion int `json:"config_version,omitempty"`
 
 	Indexers []IndexerConfig `json:"indexers"`
 
-	AddonPort    int    `json:"addon_port"`
-	AddonBaseURL string `json:"addon_base_url"`
-	LogLevel     string `json:"log_level"`
+	AddonPort          int    `json:"addon_port"`
+	AddonBaseURL       string `json:"addon_base_url"`
+	LogLevel           string `json:"log_level"`
+	VerboseNNTPLogging bool   `json:"verbose_nntp_logging,omitempty"`
 
 	AdminUsername           string `json:"admin_username"`
 	AdminPasswordHash       string `json:"admin_password_hash"`
@@ -166,6 +179,9 @@ type Config struct {
 
 	// NZBHistoryRetentionDays controls how many days NZB attempt history is kept. Default 90.
 	NZBHistoryRetentionDays int `json:"nzb_history_retention_days,omitempty"`
+
+	// PlaybackStartupTimeoutSeconds bounds probe/open work before the first playable response is ready. Default 5.
+	PlaybackStartupTimeoutSeconds int `json:"playback_startup_timeout_seconds,omitempty"`
 
 	// AvailNZBMode controls how the AvailNZB integration behaves.
 	// "" or "full"        – fetch availability status AND report playback results (default).
@@ -380,17 +396,19 @@ func Load() (*Config, error) {
 	}
 
 	cfg := &Config{
-		AddonPort:               7000,
-		AddonBaseURL:            "http://localhost:7000",
-		LogLevel:                "INFO",
-		AdminUsername:           "admin",
-		ProxyPort:               119,
-		ProxyHost:               "0.0.0.0",
-		ProxyEnabled:            true,
-		MemoryLimitMB:           512,
-		KeepLogFiles:            9,
-		NZBHistoryRetentionDays: 90,
-		LoadedPath:              configPath,
+		AddonPort:                     7000,
+		AddonBaseURL:                  "http://localhost:7000",
+		LogLevel:                      "INFO",
+		VerboseNNTPLogging:            false,
+		AdminUsername:                 "admin",
+		ProxyPort:                     119,
+		ProxyHost:                     "0.0.0.0",
+		ProxyEnabled:                  true,
+		MemoryLimitMB:                 512,
+		KeepLogFiles:                  9,
+		NZBHistoryRetentionDays:       90,
+		PlaybackStartupTimeoutSeconds: DefaultPlaybackStartupTimeoutSeconds,
+		LoadedPath:                    configPath,
 	}
 
 	if err := cfg.LoadFile(configPath); err != nil {
@@ -423,6 +441,10 @@ func Load() (*Config, error) {
 	}
 	if cfg.NZBHistoryRetentionDays < 1 {
 		cfg.NZBHistoryRetentionDays = 90
+		needSave = true
+	}
+	if cfg.PlaybackStartupTimeoutSeconds < 1 {
+		cfg.PlaybackStartupTimeoutSeconds = DefaultPlaybackStartupTimeoutSeconds
 		needSave = true
 	}
 

--- a/pkg/core/config/config.go
+++ b/pkg/core/config/config.go
@@ -21,6 +21,7 @@ const (
 	DefaultInternalIndexerTimeoutSeconds   = 5
 	DefaultAggregatorIndexerTimeoutSeconds = 10
 	DefaultPlaybackStartupTimeoutSeconds   = 5
+	MaxPlaybackStartupTimeoutSeconds       = 60
 	CurrentConfigVersion                   = 2
 	StreamModelConfigVersion               = 2
 	defaultMigratedStreamID                = "default"
@@ -120,9 +121,16 @@ func (ic IndexerConfig) EffectiveTimeout() time.Duration {
 	return time.Duration(ic.EffectiveTimeoutSeconds()) * time.Second
 }
 
+func normalizePlaybackStartupTimeoutSeconds(timeout int) int {
+	if timeout < 1 || timeout > MaxPlaybackStartupTimeoutSeconds {
+		return DefaultPlaybackStartupTimeoutSeconds
+	}
+	return timeout
+}
+
 func (c *Config) EffectivePlaybackStartupTimeoutSeconds() int {
-	if c != nil && c.PlaybackStartupTimeoutSeconds > 0 {
-		return c.PlaybackStartupTimeoutSeconds
+	if c != nil {
+		return normalizePlaybackStartupTimeoutSeconds(c.PlaybackStartupTimeoutSeconds)
 	}
 	return DefaultPlaybackStartupTimeoutSeconds
 }
@@ -443,8 +451,8 @@ func Load() (*Config, error) {
 		cfg.NZBHistoryRetentionDays = 90
 		needSave = true
 	}
-	if cfg.PlaybackStartupTimeoutSeconds < 1 {
-		cfg.PlaybackStartupTimeoutSeconds = DefaultPlaybackStartupTimeoutSeconds
+	if normalized := normalizePlaybackStartupTimeoutSeconds(cfg.PlaybackStartupTimeoutSeconds); normalized != cfg.PlaybackStartupTimeoutSeconds {
+		cfg.PlaybackStartupTimeoutSeconds = normalized
 		needSave = true
 	}
 

--- a/pkg/core/config/config_test.go
+++ b/pkg/core/config/config_test.go
@@ -84,6 +84,28 @@ func TestIndexerConfigEffectiveTimeoutHonorsExplicitOverride(t *testing.T) {
 	}
 }
 
+func TestConfigEffectivePlaybackStartupTimeoutDefaults(t *testing.T) {
+	cfg := &Config{}
+
+	if got := cfg.EffectivePlaybackStartupTimeoutSeconds(); got != DefaultPlaybackStartupTimeoutSeconds {
+		t.Fatalf("EffectivePlaybackStartupTimeoutSeconds() = %d, want %d", got, DefaultPlaybackStartupTimeoutSeconds)
+	}
+	if got := cfg.EffectivePlaybackStartupTimeout(); got != time.Duration(DefaultPlaybackStartupTimeoutSeconds)*time.Second {
+		t.Fatalf("EffectivePlaybackStartupTimeout() = %v", got)
+	}
+}
+
+func TestConfigEffectivePlaybackStartupTimeoutHonorsExplicitOverride(t *testing.T) {
+	cfg := &Config{PlaybackStartupTimeoutSeconds: 12}
+
+	if got := cfg.EffectivePlaybackStartupTimeoutSeconds(); got != 12 {
+		t.Fatalf("EffectivePlaybackStartupTimeoutSeconds() = %d, want 12", got)
+	}
+	if got := cfg.EffectivePlaybackStartupTimeout(); got != 12*time.Second {
+		t.Fatalf("EffectivePlaybackStartupTimeout() = %v, want %v", got, 12*time.Second)
+	}
+}
+
 func TestApplyStreamModelUpgradeDefaultsCreatesQueriesAndDefaultStream(t *testing.T) {
 	cfg := &Config{
 		Providers: []Provider{

--- a/pkg/core/config/config_test.go
+++ b/pkg/core/config/config_test.go
@@ -106,6 +106,14 @@ func TestConfigEffectivePlaybackStartupTimeoutHonorsExplicitOverride(t *testing.
 	}
 }
 
+func TestConfigEffectivePlaybackStartupTimeoutRejectsOutOfRangeValues(t *testing.T) {
+	cfg := &Config{PlaybackStartupTimeoutSeconds: 61}
+
+	if got := cfg.EffectivePlaybackStartupTimeoutSeconds(); got != DefaultPlaybackStartupTimeoutSeconds {
+		t.Fatalf("EffectivePlaybackStartupTimeoutSeconds() = %d, want %d", got, DefaultPlaybackStartupTimeoutSeconds)
+	}
+}
+
 func TestApplyStreamModelUpgradeDefaultsCreatesQueriesAndDefaultStream(t *testing.T) {
 	cfg := &Config{
 		Providers: []Provider{

--- a/pkg/core/logger/logger.go
+++ b/pkg/core/logger/logger.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"streamnzb/pkg/core/env"
@@ -28,6 +29,7 @@ var (
 	sensitiveJSONKVRe  = regexp.MustCompile(`(?i)("(?:api[_-]?key|access[_-]?token|auth[_-]?token|refresh[_-]?token|token|password|passwd|pwd|secret|auth_session)"\s*:\s*")([^"]+)`)
 	authorizationKVRe  = regexp.MustCompile(`(?i)\b(authorization[=:]\s*)(bearer\s+|basic\s+)?([^\s,;]+)`)
 	hexPathSegmentRe   = regexp.MustCompile(`(/)(?i:[0-9a-f]{64})(/|$|[?#])`)
+	verboseNNTPLogging atomic.Bool
 )
 
 func sanitizeString(s string) string {
@@ -385,6 +387,21 @@ func PurgeOldLogs(keepCount int) {
 
 func SetLevel(levelStr string) {
 	Init(levelStr)
+}
+
+func SetVerboseNNTPLogging(enabled bool) {
+	verboseNNTPLogging.Store(enabled)
+}
+
+func VerboseNNTPLoggingEnabled() bool {
+	return verboseNNTPLogging.Load()
+}
+
+func VerboseNNTP(msg string, args ...any) {
+	if !VerboseNNTPLoggingEnabled() {
+		return
+	}
+	Debug(msg, args...)
 }
 
 func Trace(msg string, args ...any) {

--- a/pkg/core/logger/logger_test.go
+++ b/pkg/core/logger/logger_test.go
@@ -158,3 +158,20 @@ func TestInitTwiceKeepsCurrentLogFile(t *testing.T) {
 		t.Fatalf("expected current log file to remain active after second init, got %q", text)
 	}
 }
+
+func TestVerboseNNTPLoggingToggle(t *testing.T) {
+	SetVerboseNNTPLogging(false)
+	if VerboseNNTPLoggingEnabled() {
+		t.Fatal("expected verbose NNTP logging to be disabled")
+	}
+
+	SetVerboseNNTPLogging(true)
+	if !VerboseNNTPLoggingEnabled() {
+		t.Fatal("expected verbose NNTP logging to be enabled")
+	}
+
+	SetVerboseNNTPLogging(false)
+	if VerboseNNTPLoggingEnabled() {
+		t.Fatal("expected verbose NNTP logging to be disabled again")
+	}
+}

--- a/pkg/core/logger/logger_test.go
+++ b/pkg/core/logger/logger_test.go
@@ -160,6 +160,11 @@ func TestInitTwiceKeepsCurrentLogFile(t *testing.T) {
 }
 
 func TestVerboseNNTPLoggingToggle(t *testing.T) {
+	previous := VerboseNNTPLoggingEnabled()
+	t.Cleanup(func() {
+		SetVerboseNNTPLogging(previous)
+	})
+
 	SetVerboseNNTPLogging(false)
 	if VerboseNNTPLoggingEnabled() {
 		t.Fatal("expected verbose NNTP logging to be disabled")

--- a/pkg/media/loader/file.go
+++ b/pkg/media/loader/file.go
@@ -176,22 +176,36 @@ func (f *File) SegmentMapDetected() bool {
 }
 
 func (f *File) EnsureSegmentMap() error {
-	f.mu.Lock()
-	if f.detected {
-		f.mu.Unlock()
-		return nil
-	}
-	f.mu.Unlock()
-	return f.detectSegmentSize()
+	return f.EnsureSegmentMapCtx(f.ctx)
 }
 
-func (f *File) detectSegmentSize() error {
+func (f *File) EnsureSegmentMapCtx(ctx context.Context) error {
 	f.mu.Lock()
 	if f.detected {
 		f.mu.Unlock()
 		return nil
 	}
 	f.mu.Unlock()
+	return f.detectSegmentSize(ctx)
+}
+
+func (f *File) detectSegmentSize(ctx context.Context) error {
+	f.mu.Lock()
+	if f.detected {
+		f.mu.Unlock()
+		return nil
+	}
+	f.mu.Unlock()
+
+	if ctx == nil {
+		ctx = f.ctx
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 
 	if len(f.segments) == 0 {
 		f.mu.Lock()
@@ -212,7 +226,7 @@ func (f *File) detectSegmentSize() error {
 	}
 
 	if !usedEstimator {
-		data, err := f.DownloadSegment(f.ctx, 0)
+		data, err := f.DownloadSegment(ctx, 0)
 		if err != nil {
 			return err
 		}
@@ -225,7 +239,10 @@ func (f *File) detectSegmentSize() error {
 	lastSegSize := segSize
 	lastIdx := len(f.segments) - 1
 	if lastIdx > 0 {
-		data, err := f.DownloadSegment(f.ctx, lastIdx)
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		data, err := f.DownloadSegment(ctx, lastIdx)
 		if err != nil {
 			return err
 		}
@@ -614,14 +631,14 @@ func (f *File) OpenStream() (io.ReadSeekCloser, error) {
 }
 
 func (f *File) OpenStreamCtx(ctx context.Context) (io.ReadSeekCloser, error) {
-	if err := f.EnsureSegmentMap(); err != nil {
+	if err := f.EnsureSegmentMapCtx(ctx); err != nil {
 		return nil, err
 	}
 	return NewSegmentReader(ctx, f, 0), nil
 }
 
 func (f *File) OpenReaderAt(ctx context.Context, offset int64) (io.ReadCloser, error) {
-	if err := f.EnsureSegmentMap(); err != nil {
+	if err := f.EnsureSegmentMapCtx(ctx); err != nil {
 		return nil, err
 	}
 	return NewSegmentReader(ctx, f, offset), nil

--- a/pkg/media/loader/file_test.go
+++ b/pkg/media/loader/file_test.go
@@ -225,6 +225,30 @@ func TestConcurrentDownloadFailureCountsOnce(t *testing.T) {
 	}
 }
 
+func TestOpenStreamCtxUsesProvidedContextForSegmentDetection(t *testing.T) {
+	oldLogger := logger.Log
+	logger.Log = slog.New(slog.NewTextHandler(io.Discard, nil))
+	defer func() {
+		logger.Log = oldLogger
+	}()
+
+	fetcher := newDedupBlockingSegmentFetcher([]byte("abc"), nil)
+	f := NewFile(context.Background(), testNZBFileWithSegments(3), nil, nil, fetcher)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	stream, err := f.OpenStreamCtx(ctx)
+	if stream != nil {
+		_ = stream.Close()
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+
+	fetcher.Release()
+}
+
 func TestDownloadSegmentLeaderCancellationDoesNotCancelFollower(t *testing.T) {
 	oldLogger := logger.Log
 	logger.Log = slog.New(slog.NewTextHandler(io.Discard, nil))

--- a/pkg/media/unpack/archive.go
+++ b/pkg/media/unpack/archive.go
@@ -39,6 +39,9 @@ func GetMediaStream(ctx context.Context, files []UnpackableFile, cachedBP interf
 }
 
 func GetMediaStreamForEpisode(ctx context.Context, files []UnpackableFile, cachedBP interface{}, password string, target EpisodeTarget) (ReadSeekCloser, string, int64, interface{}, error) {
+	if err := contextErr(ctx); err != nil {
+		return nil, "", 0, nil, err
+	}
 	logger.Debug("GetMediaStreamForEpisode starting",
 		"target", target,
 		"files", len(files),
@@ -94,7 +97,7 @@ func GetMediaStreamForEpisode(ctx context.Context, files []UnpackableFile, cache
 		logger.Trace("Detected RAR archive", "target", target, "volumes", len(rarFiles))
 		unpackables := make([]UnpackableFile, len(files))
 		copy(unpackables, files)
-		bp, err := ScanArchive(unpackables, password, target)
+		bp, err := ScanArchive(ctx, unpackables, password, target)
 		if err != nil {
 			if errors.Is(err, ErrEpisodeTargetNotFound) {
 				return nil, "", 0, &FailedBlueprint{Err: err, Target: target}, err
@@ -114,7 +117,7 @@ func GetMediaStreamForEpisode(ctx context.Context, files []UnpackableFile, cache
 	if err == nil && len(archiveFiles) > 0 {
 		firstVolName := ExtractFilename(archiveFiles[0].Name())
 		logger.Info("Detected 7z archive", "target", target, "name", firstVolName, "parts", len(archiveFiles))
-		newBp, err := CreateSevenZipBlueprint(archiveFiles, firstVolName, password, target)
+		newBp, err := CreateSevenZipBlueprint(ctx, archiveFiles, firstVolName, password, target)
 		if err != nil {
 			if errors.Is(err, ErrEpisodeTargetNotFound) {
 				return nil, "", 0, &FailedBlueprint{Err: err, Target: target}, err
@@ -160,7 +163,7 @@ func GetMediaStreamForEpisode(ctx context.Context, files []UnpackableFile, cache
 			unpackables := make([]UnpackableFile, len(files))
 			copy(unpackables, files)
 			logger.Info("Attempting heuristic RAR scan on unknown files")
-			bp, err := ScanArchive(unpackables, password, target)
+			bp, err := ScanArchive(ctx, unpackables, password, target)
 			if err == nil {
 				s, name, size, err := StreamFromBlueprint(ctx, bp, password)
 				if err == nil {

--- a/pkg/media/unpack/context.go
+++ b/pkg/media/unpack/context.go
@@ -1,0 +1,34 @@
+package unpack
+
+import (
+	"context"
+	"errors"
+)
+
+type contextAwareSegmentMapEnsurer interface {
+	EnsureSegmentMapCtx(ctx context.Context) error
+}
+
+func ensureSegmentMap(ctx context.Context, f UnpackableFile) error {
+	if err := contextErr(ctx); err != nil {
+		return err
+	}
+	if ensurer, ok := f.(contextAwareSegmentMapEnsurer); ok {
+		return ensurer.EnsureSegmentMapCtx(ctx)
+	}
+	return f.EnsureSegmentMap()
+}
+
+func contextErr(ctx context.Context) error {
+	if ctx == nil {
+		return nil
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func isContextErr(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+}

--- a/pkg/media/unpack/fs.go
+++ b/pkg/media/unpack/fs.go
@@ -1,6 +1,7 @@
 package unpack
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"io/fs"
@@ -9,11 +10,19 @@ import (
 )
 
 type NZBFS struct {
+	ctx   context.Context
 	files map[string]UnpackableFile
 }
 
 func NewNZBFSFromMap(files map[string]UnpackableFile) *NZBFS {
-	return &NZBFS{files: files}
+	return NewNZBFSFromMapCtx(context.Background(), files)
+}
+
+func NewNZBFSFromMapCtx(ctx context.Context, files map[string]UnpackableFile) *NZBFS {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return &NZBFS{ctx: ctx, files: files}
 }
 
 func (n *NZBFS) Open(name string) (fs.File, error) {
@@ -25,12 +34,13 @@ func (n *NZBFS) Open(name string) (fs.File, error) {
 		return nil, fs.ErrNotExist
 	}
 
-	stream, err := f.OpenStream()
+	stream, err := f.OpenStreamCtx(n.ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open stream: %w", err)
 	}
 
 	return &fileWrapper{
+		ctx:    n.ctx,
 		stream: stream,
 		file:   f,
 		name:   ExtractFilename(f.Name()),
@@ -39,6 +49,7 @@ func (n *NZBFS) Open(name string) (fs.File, error) {
 }
 
 type fileWrapper struct {
+	ctx    context.Context
 	stream io.ReadSeekCloser
 	file   UnpackableFile
 	name   string
@@ -52,7 +63,19 @@ func (fw *fileWrapper) Stat() (fs.FileInfo, error) {
 func (fw *fileWrapper) Read(p []byte) (int, error)                { return fw.stream.Read(p) }
 func (fw *fileWrapper) Seek(off int64, whence int) (int64, error) { return fw.stream.Seek(off, whence) }
 func (fw *fileWrapper) Close() error                              { return fw.stream.Close() }
-func (fw *fileWrapper) ReadAt(p []byte, off int64) (int, error)   { return fw.file.ReadAt(p, off) }
+func (fw *fileWrapper) ReadAt(p []byte, off int64) (int, error) {
+	reader, err := fw.file.OpenReaderAt(fw.ctx, off)
+	if err != nil {
+		return 0, err
+	}
+	defer reader.Close()
+
+	n, readErr := io.ReadFull(reader, p)
+	if readErr == io.ErrUnexpectedEOF {
+		return n, io.EOF
+	}
+	return n, readErr
+}
 
 type fileInfo struct {
 	name string

--- a/pkg/media/unpack/rar.go
+++ b/pkg/media/unpack/rar.go
@@ -85,6 +85,7 @@ func streamEncryptedRAR(ctx context.Context, bp *ArchiveBlueprint, password stri
 		}
 		if h.Name == bp.MainFileName || filepath.Base(h.Name) == mainBase {
 			stream := &encryptedRARStream{
+				ctx:          ctx,
 				rc:           rc,
 				limit:        bp.TotalSize,
 				firstVolName: firstName,
@@ -101,6 +102,7 @@ func streamEncryptedRAR(ctx context.Context, bp *ArchiveBlueprint, password stri
 }
 
 type encryptedRARStream struct {
+	ctx          context.Context
 	rc           *rardecode.ReadCloser
 	limit        int64
 	read         int64
@@ -153,7 +155,7 @@ func (e *encryptedRARStream) Seek(offset int64, whence int) (int64, error) {
 	if err := e.rc.Close(); err != nil {
 		logger.Debug("encrypted RAR stream close on seek", "err", err)
 	}
-	fsys := NewNZBFSFromMap(e.fileMap)
+	fsys := NewNZBFSFromMapCtx(e.ctx, e.fileMap)
 	opts := []rardecode.Option{rardecode.FileSystem(fsys), rardecode.Password(e.password)}
 	rc, err := rardecode.OpenReader(e.firstVolName, opts...)
 	if err != nil {

--- a/pkg/media/unpack/rar.go
+++ b/pkg/media/unpack/rar.go
@@ -52,13 +52,16 @@ func StreamFromBlueprint(ctx context.Context, bp *ArchiveBlueprint, password str
 }
 
 func streamEncryptedRAR(ctx context.Context, bp *ArchiveBlueprint, password string) (io.ReadSeekCloser, string, int64, error) {
+	if err := contextErr(ctx); err != nil {
+		return nil, "", 0, err
+	}
 	fileMap := make(map[string]UnpackableFile, len(bp.Parts))
 	for _, p := range bp.Parts {
 		name := ExtractFilename(p.VolFile.Name())
 		fileMap[name] = p.VolFile
 	}
 	firstName := ExtractFilename(bp.Parts[0].VolFile.Name())
-	fsys := NewNZBFSFromMap(fileMap)
+	fsys := NewNZBFSFromMapCtx(ctx, fileMap)
 
 	opts := []rardecode.Option{rardecode.FileSystem(fsys), rardecode.Password(password)}
 	rc, err := rardecode.OpenReader(firstName, opts...)
@@ -68,6 +71,10 @@ func streamEncryptedRAR(ctx context.Context, bp *ArchiveBlueprint, password stri
 
 	mainBase := filepath.Base(bp.MainFileName)
 	for {
+		if err := contextErr(ctx); err != nil {
+			rc.Close()
+			return nil, "", 0, err
+		}
 		h, err := rc.Next()
 		if err != nil {
 			rc.Close()
@@ -193,7 +200,10 @@ func (e *encryptedRARStream) Close() error {
 // failing slowly across hundreds of volumes; we try a few and fail fast.
 const maxFirstVolumesToScan = 5
 
-func ScanArchive(files []UnpackableFile, password string, target EpisodeTarget) (*ArchiveBlueprint, error) {
+func ScanArchive(ctx context.Context, files []UnpackableFile, password string, target EpisodeTarget) (*ArchiveBlueprint, error) {
+	if err := contextErr(ctx); err != nil {
+		return nil, err
+	}
 	rarFiles := filterRarFiles(files)
 	if len(rarFiles) == 0 {
 		return nil, errors.New("no RAR files found")
@@ -211,7 +221,10 @@ func ScanArchive(files []UnpackableFile, password string, target EpisodeTarget) 
 	logger.Debug("Scanning RAR first volumes", "target", target, "count", len(firstVols), "total", len(rarFiles))
 
 	start := time.Now()
-	parts := scanVolumesParallel(firstVols, password)
+	parts, err := scanVolumesParallel(ctx, firstVols, password)
+	if err != nil {
+		return nil, err
+	}
 
 	for _, f := range firstVols {
 		if fc, ok := f.(interface{ IsFailed() bool }); ok && fc.IsFailed() {
@@ -228,7 +241,7 @@ func ScanArchive(files []UnpackableFile, password string, target EpisodeTarget) 
 		}
 	}
 
-	bp, err := buildBlueprint(parts, rarFiles, password, target)
+	bp, err := buildBlueprint(ctx, parts, rarFiles, password, target)
 	if err != nil {
 		return nil, err
 	}
@@ -286,13 +299,30 @@ type filePart struct {
 	isEncrypted  bool
 }
 
-func scanVolumesParallel(files []UnpackableFile, password string) []filePart {
+func scanVolumesParallel(ctx context.Context, files []UnpackableFile, password string) ([]filePart, error) {
 	var mu sync.Mutex
 	var result []filePart
 	sem := make(chan struct{}, 20)
 	var wg sync.WaitGroup
+	var firstErr error
+	var firstErrMu sync.Mutex
+
+	setFirstErr := func(err error) {
+		if err == nil {
+			return
+		}
+		firstErrMu.Lock()
+		if firstErr == nil {
+			firstErr = err
+		}
+		firstErrMu.Unlock()
+	}
 
 	for _, f := range files {
+		if err := contextErr(ctx); err != nil {
+			setFirstErr(err)
+			break
+		}
 		wg.Add(1)
 		sem <- struct{}{}
 		go func(f UnpackableFile) {
@@ -303,19 +333,31 @@ func scanVolumesParallel(files []UnpackableFile, password string) []filePart {
 					logger.Error("Panic scanning RAR", "file", f.Name(), "err", r)
 				}
 			}()
+			if err := contextErr(ctx); err != nil {
+				setFirstErr(err)
+				return
+			}
 
 			cleanName := ExtractFilename(f.Name())
-			fsys := NewNZBFSFromMap(map[string]UnpackableFile{cleanName: f})
+			fsys := NewNZBFSFromMapCtx(ctx, map[string]UnpackableFile{cleanName: f})
 			listOpts := []rardecode.Option{rardecode.FileSystem(fsys), rardecode.ParallelRead(true), rardecode.SkipVolumeCheck}
 			if password != "" {
 				listOpts = append(listOpts, rardecode.Password(password))
 			}
 			infos, err := rardecode.ListArchiveInfo(cleanName, listOpts...)
 			if err != nil {
+				if ctxErr := contextErr(ctx); ctxErr != nil {
+					setFirstErr(ctxErr)
+					return
+				}
 				logger.Debug("Scan failure", "name", cleanName, "err", err)
 			}
 
 			for _, info := range infos {
+				if err := contextErr(ctx); err != nil {
+					setFirstErr(err)
+					return
+				}
 				if info.Name == "" {
 					continue
 				}
@@ -347,14 +389,20 @@ func scanVolumesParallel(files []UnpackableFile, password string) []filePart {
 		}(f)
 	}
 	wg.Wait()
-	return result
+	if firstErr != nil {
+		return nil, firstErr
+	}
+	return result, nil
 }
 
-func buildBlueprint(parts []filePart, allRarFiles []UnpackableFile, password string, target EpisodeTarget) (*ArchiveBlueprint, error) {
+func buildBlueprint(ctx context.Context, parts []filePart, allRarFiles []UnpackableFile, password string, target EpisodeTarget) (*ArchiveBlueprint, error) {
+	if err := contextErr(ctx); err != nil {
+		return nil, err
+	}
 	bestName, err := selectMainFile(parts, target)
 	if err != nil {
 		logger.Debug("RAR blueprint direct media selection failed for requested episode, trying nested archive", "target", target, "err", err)
-		if bp, nestedErr := tryNestedArchive(parts, password, target); nestedErr == nil {
+		if bp, nestedErr := tryNestedArchive(ctx, parts, password, target); nestedErr == nil {
 			return bp, nil
 		}
 		return nil, err
@@ -373,7 +421,7 @@ func buildBlueprint(parts []filePart, allRarFiles []UnpackableFile, password str
 		if archiveTotal > mediaTotal*2 {
 			logger.Info("Archive content outweighs direct media, trying nested archive first",
 				"media", mediaTotal, "archive", archiveTotal, "sample", bestName)
-			if bp, err := tryNestedArchive(parts, password, target); err == nil {
+			if bp, err := tryNestedArchive(ctx, parts, password, target); err == nil {
 				return bp, nil
 			}
 		}
@@ -381,7 +429,7 @@ func buildBlueprint(parts []filePart, allRarFiles []UnpackableFile, password str
 
 	if bestName == "" {
 		logger.Debug("RAR blueprint found no direct media match, trying nested archive", "target", target, "parts", len(parts))
-		return tryNestedArchive(parts, password, target)
+		return tryNestedArchive(ctx, parts, password, target)
 	}
 
 	logger.Info("Selected main media", "target", target, "name", bestName)
@@ -393,7 +441,10 @@ func buildBlueprint(parts []filePart, allRarFiles []UnpackableFile, password str
 	scannedSize := totalPackedSize(mainParts)
 
 	if scannedSize < headerSize && len(allRarFiles) > len(mainParts) {
-		mainParts = aggregateRemainingVolumes(mainParts, allRarFiles, bestName, headerSize, password)
+		mainParts, err = aggregateRemainingVolumes(ctx, mainParts, allRarFiles, bestName, headerSize, password)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	compressed := false
@@ -501,7 +552,10 @@ func totalPackedSize(parts []filePart) int64 {
 	return total
 }
 
-func aggregateRemainingVolumes(mainParts []filePart, allRarFiles []UnpackableFile, name string, headerSize int64, password string) []filePart {
+func aggregateRemainingVolumes(ctx context.Context, mainParts []filePart, allRarFiles []UnpackableFile, name string, headerSize int64, password string) ([]filePart, error) {
+	if err := contextErr(ctx); err != nil {
+		return nil, err
+	}
 	sort.Slice(allRarFiles, func(i, j int) bool {
 		return GetRARVolumeNumber(allRarFiles[i].Name()) < GetRARVolumeNumber(allRarFiles[j].Name())
 	})
@@ -515,24 +569,30 @@ func aggregateRemainingVolumes(mainParts []filePart, allRarFiles []UnpackableFil
 		}
 	}
 	if startIdx == -1 {
-		return mainParts
+		return mainParts, nil
 	}
 
-	probe := probeContinuation(allRarFiles, startIdx, name, password)
+	probe, err := probeContinuation(ctx, allRarFiles, startIdx, name, password)
+	if err != nil {
+		return nil, err
+	}
 	if probe.dataOffset > 0 {
 		logger.Trace("Probed continuation volume", "dataOffset", probe.dataOffset, "packedSize", probe.packedSize)
 	}
 
-	return aggregateRemainingVolumesFromStart(mainParts, allRarFiles, startIdx, name, headerSize, probe)
+	return aggregateRemainingVolumesFromStart(ctx, mainParts, allRarFiles, startIdx, name, headerSize, probe)
 }
 
-func aggregateRemainingVolumesFromStart(mainParts []filePart, allRarFiles []UnpackableFile, startIdx int, name string, headerSize int64, probe continuationProbe) []filePart {
+func aggregateRemainingVolumesFromStart(ctx context.Context, mainParts []filePart, allRarFiles []UnpackableFile, startIdx int, name string, headerSize int64, probe continuationProbe) ([]filePart, error) {
+	if err := contextErr(ctx); err != nil {
+		return nil, err
+	}
 	first := mainParts[0]
 	result := []filePart{first}
 
 	numContVolumes := len(allRarFiles) - startIdx - 1
 	if numContVolumes <= 0 {
-		return result
+		return result, nil
 	}
 
 	contPackedSize := probe.packedSize
@@ -547,10 +607,15 @@ func aggregateRemainingVolumesFromStart(mainParts []filePart, allRarFiles []Unpa
 
 	added := 0
 	for i := startIdx + 1; i < len(allRarFiles); i++ {
+		if err := contextErr(ctx); err != nil {
+			return nil, err
+		}
 		f := allRarFiles[i]
 		fileSize := int64(0)
 		if contPackedSize <= 0 {
-			_ = f.EnsureSegmentMap()
+			if err := ensureSegmentMap(ctx, f); err != nil {
+				return nil, err
+			}
 			fileSize = f.Size()
 			if fileSize <= 0 {
 				continue
@@ -588,7 +653,7 @@ func aggregateRemainingVolumesFromStart(mainParts []filePart, allRarFiles []Unpa
 		added++
 	}
 	logger.Trace("Manual volume aggregation", "added", added, "total", len(result))
-	return result
+	return result, nil
 }
 
 type continuationProbe struct {
@@ -596,9 +661,12 @@ type continuationProbe struct {
 	packedSize int64
 }
 
-func probeContinuation(allRarFiles []UnpackableFile, startIdx int, targetName string, password string) continuationProbe {
+func probeContinuation(ctx context.Context, allRarFiles []UnpackableFile, startIdx int, targetName string, password string) (continuationProbe, error) {
+	if err := contextErr(ctx); err != nil {
+		return continuationProbe{}, err
+	}
 	if startIdx+1 >= len(allRarFiles) {
-		return continuationProbe{}
+		return continuationProbe{}, nil
 	}
 
 	firstFile := allRarFiles[startIdx]
@@ -606,7 +674,7 @@ func probeContinuation(allRarFiles []UnpackableFile, startIdx int, targetName st
 	firstName := ExtractFilename(firstFile.Name())
 	secondName := ExtractFilename(secondFile.Name())
 
-	fsys := NewNZBFSFromMap(map[string]UnpackableFile{
+	fsys := NewNZBFSFromMapCtx(ctx, map[string]UnpackableFile{
 		firstName:  firstFile,
 		secondName: secondFile,
 	})
@@ -616,12 +684,18 @@ func probeContinuation(allRarFiles []UnpackableFile, startIdx int, targetName st
 	}
 	infos, err := rardecode.ListArchiveInfo(firstName, listOpts...)
 	if err != nil {
+		if ctxErr := contextErr(ctx); ctxErr != nil {
+			return continuationProbe{}, ctxErr
+		}
 		logger.Debug("Continuation probe failed, falling back to zero offset", "err", err)
-		return continuationProbe{}
+		return continuationProbe{}, nil
 	}
 
 	lowerTarget := strings.ToLower(targetName)
 	for _, info := range infos {
+		if err := contextErr(ctx); err != nil {
+			return continuationProbe{}, err
+		}
 		if strings.ToLower(info.Name) != lowerTarget {
 			continue
 		}
@@ -629,13 +703,16 @@ func probeContinuation(allRarFiles []UnpackableFile, startIdx int, targetName st
 			return continuationProbe{
 				dataOffset: info.Parts[1].DataOffset,
 				packedSize: info.Parts[1].PackedSize,
-			}
+			}, nil
 		}
 	}
-	return continuationProbe{}
+	return continuationProbe{}, nil
 }
 
-func tryNestedArchive(parts []filePart, password string, target EpisodeTarget) (*ArchiveBlueprint, error) {
+func tryNestedArchive(ctx context.Context, parts []filePart, password string, target EpisodeTarget) (*ArchiveBlueprint, error) {
+	if err := contextErr(ctx); err != nil {
+		return nil, err
+	}
 	if len(parts) == 0 {
 		return nil, errors.New("empty archive")
 	}
@@ -735,7 +812,7 @@ func tryNestedArchive(parts []filePart, password string, target EpisodeTarget) (
 		logger.Debug("Nested VirtualFile", "name", nf.Name(), "size", nf.Size(), "extracted", ExtractFilename(nf.Name()))
 	}
 	logger.Info("Recursively scanning nested archive", "set", bestSet, "volumes", len(nestedFiles))
-	return ScanArchive(nestedFiles, password, target)
+	return ScanArchive(ctx, nestedFiles, password, target)
 }
 
 func filterRarFiles(files []UnpackableFile) []UnpackableFile {

--- a/pkg/media/unpack/rar_test.go
+++ b/pkg/media/unpack/rar_test.go
@@ -36,7 +36,8 @@ func TestAggregateRemainingVolumesFromStartSkipsSegmentDetectionWhenProbeProvide
 	secondFile := &trackingUnpackableFile{memoryUnpackableFile: &memoryUnpackableFile{name: "release.part002.rar", data: []byte("second")}}
 	thirdFile := &trackingUnpackableFile{memoryUnpackableFile: &memoryUnpackableFile{name: "release.part003.rar", data: []byte("third")}}
 
-	parts := aggregateRemainingVolumesFromStart(
+	parts, err := aggregateRemainingVolumesFromStart(
+		context.Background(),
 		[]filePart{{name: "movie.mkv", unpackedSize: 1000, dataOffset: 100, packedSize: 200, volFile: firstFile, volName: firstFile.Name(), isMedia: true}},
 		[]UnpackableFile{firstFile, secondFile, thirdFile},
 		0,
@@ -44,6 +45,9 @@ func TestAggregateRemainingVolumesFromStartSkipsSegmentDetectionWhenProbeProvide
 		1000,
 		continuationProbe{dataOffset: 24, packedSize: 300},
 	)
+	if err != nil {
+		t.Fatalf("aggregateRemainingVolumesFromStart returned error: %v", err)
+	}
 
 	if len(parts) != 3 {
 		t.Fatalf("expected 3 parts, got %d", len(parts))
@@ -65,7 +69,8 @@ func TestAggregateRemainingVolumesFromStartFallsBackToSegmentDetectionWithoutPro
 	firstFile := &trackingUnpackableFile{memoryUnpackableFile: &memoryUnpackableFile{name: "release.part001.rar", data: []byte("first")}}
 	secondFile := &trackingUnpackableFile{memoryUnpackableFile: &memoryUnpackableFile{name: "release.part002.rar", data: make([]byte, 350)}}
 
-	parts := aggregateRemainingVolumesFromStart(
+	parts, err := aggregateRemainingVolumesFromStart(
+		context.Background(),
 		[]filePart{{name: "movie.mkv", unpackedSize: 500, dataOffset: 100, packedSize: 200, volFile: firstFile, volName: firstFile.Name(), isMedia: true}},
 		[]UnpackableFile{firstFile, secondFile},
 		0,
@@ -73,6 +78,9 @@ func TestAggregateRemainingVolumesFromStartFallsBackToSegmentDetectionWithoutPro
 		500,
 		continuationProbe{dataOffset: 50},
 	)
+	if err != nil {
+		t.Fatalf("aggregateRemainingVolumesFromStart returned error: %v", err)
+	}
 
 	if len(parts) != 2 {
 		t.Fatalf("expected 2 parts, got %d", len(parts))
@@ -111,11 +119,25 @@ func TestGetMediaStreamForEpisodeSkipsCachedArchiveBlueprintForDifferentTarget(t
 func TestTryNestedArchiveFailsWhenRequestedEpisodeMissing(t *testing.T) {
 	discardTestLogger(t)
 
-	_, err := tryNestedArchive([]filePart{
+	_, err := tryNestedArchive(context.Background(), []filePart{
 		{name: "Show.S01E04.rar", packedSize: 100},
 		{name: "Show.S01E04.r00", packedSize: 100},
 	}, "", EpisodeTarget{Season: 1, Episode: 1})
 	if !errors.Is(err, ErrEpisodeTargetNotFound) {
 		t.Fatalf("expected ErrEpisodeTargetNotFound, got %v", err)
+	}
+}
+
+func TestScanArchiveReturnsContextErrorWhenCanceled(t *testing.T) {
+	discardTestLogger(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := ScanArchive(ctx, []UnpackableFile{
+		&memoryUnpackableFile{name: "release.part01.rar", data: []byte("ignored")},
+	}, "", EpisodeTarget{})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
 	}
 }

--- a/pkg/media/unpack/sevenzip.go
+++ b/pkg/media/unpack/sevenzip.go
@@ -23,13 +23,19 @@ type SevenZipBlueprint struct {
 	Target       EpisodeTarget
 }
 
-func CreateSevenZipBlueprint(files []UnpackableFile, firstVolName string, password string, target EpisodeTarget) (*SevenZipBlueprint, error) {
+func CreateSevenZipBlueprint(ctx context.Context, files []UnpackableFile, firstVolName string, password string, target EpisodeTarget) (*SevenZipBlueprint, error) {
+	if err := contextErr(ctx); err != nil {
+		return nil, err
+	}
 	archiveFiles := make([]UnpackableFile, len(files))
 	copy(archiveFiles, files)
 	sort.Slice(archiveFiles, func(i, j int) bool {
 		return Get7zVolumeNumber(archiveFiles[i].Name()) < Get7zVolumeNumber(archiveFiles[j].Name())
 	})
-	parts := filesToParts(archiveFiles)
+	parts, err := filesToParts(ctx, archiveFiles)
+	if err != nil {
+		return nil, err
+	}
 	mr := NewConcatenatedReaderAt(parts)
 
 	// Verify 7z magic signature before passing to library
@@ -43,7 +49,6 @@ func CreateSevenZipBlueprint(files []UnpackableFile, firstVolName string, passwo
 	}
 
 	var r *sevenzip.Reader
-	var err error
 	if password != "" {
 		r, err = sevenzip.NewReaderWithPassword(mr, mr.Size(), password)
 	} else {
@@ -110,7 +115,10 @@ func Open7zStreamFromBlueprint(ctx context.Context, bp *SevenZipBlueprint, passw
 		return nil, "", 0, ErrEncrypted7zStreaming
 	}
 
-	parts := filesToParts(bp.Files)
+	parts, err := filesToParts(ctx, bp.Files)
+	if err != nil {
+		return nil, "", 0, err
+	}
 	streamParts, err := mapOffsetToParts(parts, bp.FileOffset, bp.TotalSize)
 	if err != nil {
 		return nil, "", 0, err
@@ -134,16 +142,22 @@ func filter7zFiles(files []UnpackableFile) []UnpackableFile {
 	return result
 }
 
-func filesToParts(files []UnpackableFile) []Part {
+func filesToParts(ctx context.Context, files []UnpackableFile) ([]Part, error) {
 	parts := make([]Part, len(files))
 	if len(files) == 0 {
-		return parts
+		return parts, nil
 	}
 
-	firstSize := resolved7zVolumeSize(files[0])
+	firstSize, err := resolved7zVolumeSize(ctx, files[0])
+	if err != nil {
+		return nil, err
+	}
 	lastSize := firstSize
 	if len(files) > 1 {
-		lastSize = resolved7zVolumeSize(files[len(files)-1])
+		lastSize, err = resolved7zVolumeSize(ctx, files[len(files)-1])
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	for i, f := range files {
@@ -153,12 +167,14 @@ func filesToParts(files []UnpackableFile) []Part {
 		}
 		parts[i] = Part{Reader: f, Offset: 0, Size: size}
 	}
-	return parts
+	return parts, nil
 }
 
-func resolved7zVolumeSize(f UnpackableFile) int64 {
-	_ = f.EnsureSegmentMap()
-	return f.Size()
+func resolved7zVolumeSize(ctx context.Context, f UnpackableFile) (int64, error) {
+	if err := ensureSegmentMap(ctx, f); err != nil {
+		return 0, err
+	}
+	return f.Size(), nil
 }
 
 func mapOffsetToParts(volumes []Part, startOffset, size int64) ([]virtualPart, error) {

--- a/pkg/media/unpack/sevenzip_test.go
+++ b/pkg/media/unpack/sevenzip_test.go
@@ -81,7 +81,10 @@ func TestFilesToPartsSplitSevenZipUsesFirstVolumeSizeForMiddleParts(t *testing.T
 		resolvedSize:         80,
 	}
 
-	parts := filesToParts([]UnpackableFile{first, middle, last})
+	parts, err := filesToParts(context.Background(), []UnpackableFile{first, middle, last})
+	if err != nil {
+		t.Fatalf("filesToParts returned error: %v", err)
+	}
 
 	if len(parts) != 3 {
 		t.Fatalf("expected 3 parts, got %d", len(parts))

--- a/pkg/server/api/server.go
+++ b/pkg/server/api/server.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -48,6 +49,9 @@ type Server struct {
 	clientsMu     sync.Mutex
 	logCh         chan string
 	attemptLister *persistence.StateManager
+	availNZBStore availnzb.KeyStore
+
+	availNZBRegistrationInFlight bool
 }
 
 type Client struct {
@@ -143,6 +147,7 @@ func (s *Server) SetAttemptLister(m *persistence.StateManager) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.attemptLister = m
+	s.availNZBStore = m
 }
 
 func (s *Server) SetProxyServer(p *proxy.Server) {
@@ -155,6 +160,97 @@ func (s *Server) SetAvailNZBAPIKey(apiKey string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.availNZBAPIKey = strings.TrimSpace(apiKey)
+}
+
+func (s *Server) syncLiveAvailNZBAPIKey(apiKey string) {
+	apiKey = strings.TrimSpace(apiKey)
+	if s.app != nil {
+		s.app.SetAvailNZBAPIKey(apiKey)
+	}
+	s.SetAvailNZBAPIKey(apiKey)
+}
+
+func (s *Server) ensureAvailNZBReadyForReload(newCfg *config.Config) {
+	if newCfg == nil || newCfg.AvailNZBMode == "disabled" {
+		return
+	}
+
+	explicitKey := strings.TrimSpace(newCfg.AvailNZBAPIKey)
+	if explicitKey != "" {
+		s.syncLiveAvailNZBAPIKey(explicitKey)
+		return
+	}
+
+	s.mu.RLock()
+	currentKey := strings.TrimSpace(s.availNZBAPIKey)
+	availNZBURL := strings.TrimSpace(s.availNZBURL)
+	store := s.availNZBStore
+	s.mu.RUnlock()
+
+	if currentKey != "" {
+		s.syncLiveAvailNZBAPIKey(currentKey)
+		return
+	}
+
+	resolvedKey, err := availnzb.ResolveStartupAPIKey(store, availNZBURL, "")
+	if err != nil {
+		logger.Warn("AvailNZB key bootstrap during reload failed", "err", err)
+		return
+	}
+	if resolvedKey != "" {
+		s.syncLiveAvailNZBAPIKey(resolvedKey)
+		return
+	}
+
+	s.startDeferredAvailNZBRegistration(newCfg.AvailNZBMode)
+}
+
+func (s *Server) startDeferredAvailNZBRegistration(mode string) {
+	s.mu.Lock()
+	if s.availNZBRegistrationInFlight {
+		s.mu.Unlock()
+		return
+	}
+	availNZBURL := strings.TrimSpace(s.availNZBURL)
+	store := s.availNZBStore
+	if availNZBURL == "" || store == nil {
+		s.mu.Unlock()
+		return
+	}
+	s.availNZBRegistrationInFlight = true
+	s.mu.Unlock()
+
+	logger.Info("AvailNZB API key registration deferred", "mode", mode)
+
+	go func() {
+		defer func() {
+			s.mu.Lock()
+			s.availNZBRegistrationInFlight = false
+			s.mu.Unlock()
+		}()
+
+		registeredKey, err := availnzb.RegisterAndPersistAPIKey(store, availNZBURL, availnzb.DefaultAppName)
+		if err != nil {
+			if errors.Is(err, availnzb.ErrRegisterKeyIPAlreadyHasKey) {
+				return
+			}
+			logger.Warn("AvailNZB background key registration failed", "err", err)
+			return
+		}
+
+		s.syncLiveAvailNZBAPIKey(registeredKey)
+
+		if s.app != nil {
+			current := s.app.Components()
+			if current != nil && current.AvailClient != nil {
+				if err := current.AvailClient.RefreshBackbones(); err != nil {
+					logger.Debug("AvailNZB backbones refresh", "source", "background_registration", "err", err)
+				}
+			}
+		}
+
+		logger.Info("AvailNZB background key registration completed")
+	}()
 }
 
 func (s *Server) ReloadFromComponents(comp *app.Components, fullReload bool) {
@@ -230,6 +326,7 @@ func (s *Server) ReloadFromComponents(comp *app.Components, fullReload bool) {
 	}
 
 	logger.SetLevel(comp.Config.LogLevel)
+	logger.SetVerboseNNTPLogging(comp.Config.VerboseNNTPLogging)
 	if s.strmServer != nil {
 		s.strmServer.Reload(&stremio.ServerOptions{
 			Config:               comp.Config,

--- a/pkg/server/api/server_availnzb_reload_test.go
+++ b/pkg/server/api/server_availnzb_reload_test.go
@@ -1,0 +1,124 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"streamnzb/pkg/core/config"
+)
+
+type memoryAvailNZBStore struct {
+	mu   sync.Mutex
+	data map[string]json.RawMessage
+}
+
+func newMemoryAvailNZBStore() *memoryAvailNZBStore {
+	return &memoryAvailNZBStore{data: make(map[string]json.RawMessage)}
+}
+
+func (s *memoryAvailNZBStore) Get(key string, target interface{}) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	raw, ok := s.data[key]
+	if !ok {
+		return false, nil
+	}
+	if err := json.Unmarshal(raw, target); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (s *memoryAvailNZBStore) Set(key string, value interface{}) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	s.data[key] = raw
+	return nil
+}
+
+func TestEnsureAvailNZBReadyForReloadUsesStoredKey(t *testing.T) {
+	store := newMemoryAvailNZBStore()
+	if err := store.Set("availnzb_api_key", map[string]string{"token": "stored-key"}); err != nil {
+		t.Fatalf("seed store: %v", err)
+	}
+
+	srv := &Server{
+		availNZBURL:   "https://snzb.example",
+		availNZBStore: store,
+	}
+
+	srv.ensureAvailNZBReadyForReload(&config.Config{AvailNZBMode: "status_only"})
+
+	srv.mu.RLock()
+	got := srv.availNZBAPIKey
+	srv.mu.RUnlock()
+
+	if got != "stored-key" {
+		t.Fatalf("availNZBAPIKey = %q, want %q", got, "stored-key")
+	}
+}
+
+func TestEnsureAvailNZBReadyForReloadRegistersMissingKey(t *testing.T) {
+	store := newMemoryAvailNZBStore()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/v1/keys" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"id":              "1",
+			"name":            "StreamNZB",
+			"token":           "registered-key",
+			"recovery_secret": "recover-me",
+		})
+	}))
+	defer ts.Close()
+
+	srv := &Server{
+		availNZBURL:   ts.URL,
+		availNZBStore: store,
+	}
+
+	srv.ensureAvailNZBReadyForReload(&config.Config{AvailNZBMode: "status_only"})
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		srv.mu.RLock()
+		got := srv.availNZBAPIKey
+		inFlight := srv.availNZBRegistrationInFlight
+		srv.mu.RUnlock()
+		if got == "registered-key" && !inFlight {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for background registration, key=%q inFlight=%v", got, inFlight)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	var stored struct {
+		Token string `json:"token"`
+	}
+	found, err := store.Get("availnzb_api_key", &stored)
+	if err != nil {
+		t.Fatalf("read stored key: %v", err)
+	}
+	if !found {
+		t.Fatal("expected stored API key after registration")
+	}
+	if stored.Token != "registered-key" {
+		t.Fatalf("stored token = %q, want %q", stored.Token, "registered-key")
+	}
+}

--- a/pkg/server/api/websocket.go
+++ b/pkg/server/api/websocket.go
@@ -266,6 +266,8 @@ func (s *Server) handleSaveConfigWS(conn *websocket.Conn, client *Client, payloa
 
 func (s *Server) reloadConfigAsync(newCfg *config.Config) {
 	go func() {
+		s.ensureAvailNZBReadyForReload(newCfg)
+
 		if s.app != nil {
 			comp, fullReload, err := s.app.Reload(newCfg)
 			if err != nil {
@@ -650,28 +652,30 @@ func (s *Server) validateConfig(cfg *config.Config) map[string]string {
 }
 
 type configValidationPlan struct {
-	validateKeepLogFiles        bool
-	validateNZBHistoryRetention bool
-	validateMovieSearchQueries  bool
-	validateSeriesSearchQueries bool
-	validateDeviceAssignments   bool
-	validateProviders           bool
-	validateIndexers            bool
-	providerDeletionOnly        bool
-	indexerDeletionOnly         bool
-	changedProviderIndexes      map[int]bool
-	changedIndexerIndexes       map[int]bool
+	validateKeepLogFiles           bool
+	validateNZBHistoryRetention    bool
+	validatePlaybackStartupTimeout bool
+	validateMovieSearchQueries     bool
+	validateSeriesSearchQueries    bool
+	validateDeviceAssignments      bool
+	validateProviders              bool
+	validateIndexers               bool
+	providerDeletionOnly           bool
+	indexerDeletionOnly            bool
+	changedProviderIndexes         map[int]bool
+	changedIndexerIndexes          map[int]bool
 }
 
 func fullConfigValidationPlan() configValidationPlan {
 	return configValidationPlan{
-		validateKeepLogFiles:        true,
-		validateNZBHistoryRetention: true,
-		validateMovieSearchQueries:  true,
-		validateSeriesSearchQueries: true,
-		validateDeviceAssignments:   true,
-		validateProviders:           true,
-		validateIndexers:            true,
+		validateKeepLogFiles:           true,
+		validateNZBHistoryRetention:    true,
+		validatePlaybackStartupTimeout: true,
+		validateMovieSearchQueries:     true,
+		validateSeriesSearchQueries:    true,
+		validateDeviceAssignments:      true,
+		validateProviders:              true,
+		validateIndexers:               true,
 	}
 }
 
@@ -693,6 +697,9 @@ func validationPlanFromPatch(body []byte, currentCfg, nextCfg *config.Config) co
 	}
 	if _, ok := raw["nzb_history_retention_days"]; ok {
 		plan.validateNZBHistoryRetention = true
+	}
+	if _, ok := raw["playback_startup_timeout_seconds"]; ok {
+		plan.validatePlaybackStartupTimeout = true
 	}
 	if _, ok := raw["movie_search_queries"]; ok {
 		plan.validateMovieSearchQueries = true
@@ -739,6 +746,9 @@ func (s *Server) validateConfigWithPlan(cfg *config.Config, plan configValidatio
 	}
 	if plan.validateNZBHistoryRetention && (cfg.NZBHistoryRetentionDays < 0 || cfg.NZBHistoryRetentionDays > 3650) {
 		errors["nzb_history_retention_days"] = "Must be between 0 and 3650 days"
+	}
+	if plan.validatePlaybackStartupTimeout && (cfg.PlaybackStartupTimeoutSeconds < 1 || cfg.PlaybackStartupTimeoutSeconds > 60) {
+		errors["playback_startup_timeout_seconds"] = "Must be between 1 and 60 seconds"
 	}
 	validateSearchQueries := func(prefix string, queries []config.SearchQueryConfig) {
 		seen := make(map[string]bool)

--- a/pkg/server/api/websocket.go
+++ b/pkg/server/api/websocket.go
@@ -747,7 +747,7 @@ func (s *Server) validateConfigWithPlan(cfg *config.Config, plan configValidatio
 	if plan.validateNZBHistoryRetention && (cfg.NZBHistoryRetentionDays < 0 || cfg.NZBHistoryRetentionDays > 3650) {
 		errors["nzb_history_retention_days"] = "Must be between 0 and 3650 days"
 	}
-	if plan.validatePlaybackStartupTimeout && (cfg.PlaybackStartupTimeoutSeconds < 1 || cfg.PlaybackStartupTimeoutSeconds > 60) {
+	if plan.validatePlaybackStartupTimeout && (cfg.PlaybackStartupTimeoutSeconds < 1 || cfg.PlaybackStartupTimeoutSeconds > config.MaxPlaybackStartupTimeoutSeconds) {
 		errors["playback_startup_timeout_seconds"] = "Must be between 1 and 60 seconds"
 	}
 	validateSearchQueries := func(prefix string, queries []config.SearchQueryConfig) {

--- a/pkg/server/api/websocket_test.go
+++ b/pkg/server/api/websocket_test.go
@@ -143,3 +143,17 @@ func TestValidateConfigWithPlanAllowsIndexerDeleteDespiteOtherInvalidIndexer(t *
 		t.Fatalf("expected indexer delete to skip unrelated indexer validation, got %q", got)
 	}
 }
+
+func TestValidateConfigRejectsOutOfRangePlaybackStartupTimeout(t *testing.T) {
+	s := &Server{}
+
+	errs := s.validateConfig(&config.Config{
+		KeepLogFiles:                  9,
+		NZBHistoryRetentionDays:       90,
+		PlaybackStartupTimeoutSeconds: 0,
+	})
+
+	if got := errs["playback_startup_timeout_seconds"]; got == "" {
+		t.Fatalf("expected playback startup timeout validation error, got %#v", errs)
+	}
+}

--- a/pkg/server/stremio/handlers_attempts_test.go
+++ b/pkg/server/stremio/handlers_attempts_test.go
@@ -1,9 +1,12 @@
 package stremio
 
 import (
+	"errors"
 	"testing"
+	"time"
 
 	"streamnzb/pkg/media/unpack"
+	"streamnzb/pkg/services/availnzb"
 	"streamnzb/pkg/session"
 )
 
@@ -49,6 +52,18 @@ func TestRecordAttemptParamsFailureUsesUsedProviders(t *testing.T) {
 	}
 }
 
+func TestRecordAttemptParamsFailureUsesAttemptedProvidersWhenNoUsedProvidersExist(t *testing.T) {
+	server := &Server{}
+	sess := &session.Session{}
+	sess.RecordAttemptedProviderHost("news-a.example.net")
+	sess.RecordAttemptedProviderHost("news-b.example.net")
+
+	params := server.recordAttemptParamsForFailure(sess, errors.New("segment unavailable: fetch segment msgid: 430 No Such Article"))
+	if got := params.ProviderName; got != "news-a.example.net, news-b.example.net" {
+		t.Fatalf("ProviderName = %q, want %q", got, "news-a.example.net, news-b.example.net")
+	}
+}
+
 func TestCacheReturnedPlaybackBlueprintReplacesStaleBlueprint(t *testing.T) {
 	sess := &session.Session{}
 	stale := &unpack.DirectBlueprint{FileName: "Show.S01E04.mkv", FileIndex: 1, Target: unpack.EpisodeTarget{Season: 1, Episode: 4}}
@@ -67,5 +82,70 @@ func TestNormalizeAttemptReasonEOF(t *testing.T) {
 	want := "No playable media stream could be opened from this release (EOF)."
 	if got != want {
 		t.Fatalf("normalizeAttemptReason(EOF) = %q, want %q", got, want)
+	}
+}
+
+func TestAvailOutcomeForFailureSegmentUnavailable(t *testing.T) {
+	got := availOutcomeForFailure(errors.New("segment unavailable: fetch segment msgid: 430 No Such Article"))
+	if got.Status != "skipped" {
+		t.Fatalf("Status = %q, want skipped", got.Status)
+	}
+	want := "Not reported to AvailNZB because this segment fetch failure does not reliably prove the release is bad."
+	if got.Reason != want {
+		t.Fatalf("Reason = %q, want %q", got.Reason, want)
+	}
+}
+
+func TestCommitGoodAttemptIfQualifiedBelowThreshold(t *testing.T) {
+	server := &Server{}
+	sess := &session.Session{ID: "stream:test:movie:tmdb:1:0"}
+	sess.AddBytesRead(32 << 20)
+
+	if committed := server.commitGoodAttemptIfQualified(sess, sess.ID, sess.ID, time.Now().Add(-5*time.Second)); committed {
+		t.Fatal("expected below-threshold attempt not to commit success")
+	}
+	if _, ok := server.recordedSuccessSessionIDs.Load(sess.ID); ok {
+		t.Fatal("did not expect recorded success marker below threshold")
+	}
+}
+
+func TestCommitGoodAttemptIfQualifiedCommitsAtThreshold(t *testing.T) {
+	server := &Server{}
+	sess := &session.Session{ID: "stream:test:movie:tmdb:2:0"}
+	sess.AddBytesRead(65 << 20)
+
+	if committed := server.commitGoodAttemptIfQualified(sess, sess.ID, sess.ID, time.Now()); !committed {
+		t.Fatal("expected threshold-reaching attempt to commit success immediately")
+	}
+	if _, ok := server.recordedSuccessSessionIDs.Load(sess.ID); !ok {
+		t.Fatal("expected recorded success marker after threshold commit")
+	}
+}
+
+func TestCommitGoodAttemptIfQualifiedCommitsAtDurationThreshold(t *testing.T) {
+	server := &Server{}
+	sess := &session.Session{ID: "stream:test:movie:tmdb:3:0"}
+	sess.AddBytesRead(1 << 20)
+
+	if committed := server.commitGoodAttemptIfQualified(sess, sess.ID, sess.ID, time.Now().Add(-21*time.Second)); !committed {
+		t.Fatal("expected duration threshold to commit success")
+	}
+	if _, ok := server.recordedSuccessSessionIDs.Load(sess.ID); !ok {
+		t.Fatal("expected recorded success marker after duration threshold commit")
+	}
+}
+
+func TestCommitGoodAttemptIfQualifiedUsesAvailThresholds(t *testing.T) {
+	server := &Server{}
+	sess := &session.Session{ID: "stream:test:movie:tmdb:4:0"}
+	sess.AddBytesRead(10 << 20)
+	server.availReporter = &availnzb.Reporter{
+		MinBytesToReportGood:    8 << 20,
+		MinDurationToReportGood: 45 * time.Second,
+		Disabled:                true,
+	}
+
+	if committed := server.commitGoodAttemptIfQualified(sess, sess.ID, sess.ID, time.Now()); !committed {
+		t.Fatal("expected custom threshold to commit success")
 	}
 }

--- a/pkg/server/stremio/handlers_attempts_test.go
+++ b/pkg/server/stremio/handlers_attempts_test.go
@@ -58,7 +58,7 @@ func TestRecordAttemptParamsFailureUsesAttemptedProvidersWhenNoUsedProvidersExis
 	sess.RecordAttemptedProviderHost("news-a.example.net")
 	sess.RecordAttemptedProviderHost("news-b.example.net")
 
-	params := server.recordAttemptParamsForFailure(sess, errors.New("segment unavailable: fetch segment msgid: 430 No Such Article"))
+	params := server.recordAttemptParamsForFailure(sess)
 	if got := params.ProviderName; got != "news-a.example.net, news-b.example.net" {
 		t.Fatalf("ProviderName = %q, want %q", got, "news-a.example.net, news-b.example.net")
 	}

--- a/pkg/server/stremio/handlers_failover_test.go
+++ b/pkg/server/stremio/handlers_failover_test.go
@@ -13,6 +13,7 @@ import (
 	"streamnzb/pkg/core/logger"
 	"streamnzb/pkg/release"
 	"streamnzb/pkg/search/triage"
+	"streamnzb/pkg/services/availnzb"
 	"streamnzb/pkg/session"
 )
 
@@ -47,6 +48,12 @@ func TestSwitchToNextFallbackSkipsUnresolvableCandidate(t *testing.T) {
 		},
 		until: time.Now().Add(time.Minute),
 	})
+	server.rawSearchCache.Store(key.StreamID+":"+key.ContentType+":"+key.ID, &rawSearchCacheEntry{
+		raw: &rawSearchResult{
+			Params: &SearchParams{ContentType: key.ContentType, ID: key.ID},
+		},
+		until: time.Now().Add(time.Minute),
+	})
 
 	nextSess, nextID, err := server.switchToNextFallback(context.Background(), &session.Session{ID: currentID}, nil)
 	if err != nil {
@@ -66,6 +73,117 @@ func TestSwitchToNextFallbackSkipsUnresolvableCandidate(t *testing.T) {
 	}
 	if manager.GetSlotFailedDuringPlayback(wantID) {
 		t.Fatalf("did not expect resolved slot %q to be marked failed", wantID)
+	}
+	if _, ok := server.playlistCache.Load(key.CacheKey()); !ok {
+		t.Fatalf("expected playlist cache to survive failover skipping")
+	}
+	if _, ok := server.rawSearchCache.Load(key.StreamID + ":" + key.ContentType + ":" + key.ID); !ok {
+		t.Fatalf("expected raw search cache to survive failover skipping")
+	}
+}
+
+func TestApplyReportedBadReleaseToCachesMarksCachedReleaseUnavailable(t *testing.T) {
+	initFailoverTestLogger()
+	t.Parallel()
+
+	manager := session.NewManager(nil, nil, time.Minute)
+	t.Cleanup(manager.Shutdown)
+	server := &Server{sessionManager: manager}
+	key := StreamSlotKey{StreamID: "stream_test", ContentType: "series", ID: "tt123:1:4"}
+	failedDetailsURL := "https://example.invalid/details/failed"
+	otherDetailsURL := "https://example.invalid/details/other"
+
+	server.playlistCache.Store(key.CacheKey(), &playlistCacheEntry{
+		result: &playlistResult{
+			Candidates: []triage.Candidate{
+				{Release: &release.Release{Title: "failed", DetailsURL: failedDetailsURL}},
+				{Release: &release.Release{Title: "other", DetailsURL: otherDetailsURL}},
+			},
+			CachedAvailable: map[string]bool{
+				failedDetailsURL: true,
+				otherDetailsURL:  true,
+			},
+			UnavailableDetailsURLs: map[string]bool{},
+		},
+		until: time.Now().Add(time.Minute),
+	})
+	server.rawSearchCache.Store(key.StreamID+":"+key.ContentType+":"+key.ID, &rawSearchCacheEntry{
+		raw: &rawSearchResult{
+			Params: &SearchParams{ContentType: key.ContentType, ID: key.ID},
+			IndexerReleases: []*release.Release{
+				{Title: "failed", DetailsURL: failedDetailsURL, Available: &availTrue},
+				{Title: "other", DetailsURL: otherDetailsURL, Available: &availTrue},
+			},
+			Avail: &AvailContext{
+				ByDetailsURL: map[string]*availnzb.ReleaseWithStatus{
+					failedDetailsURL: {
+						Release:   &release.Release{Title: "failed", DetailsURL: failedDetailsURL, Available: &availTrue},
+						Available: true,
+					},
+				},
+				AvailableByDetailsURL: map[string]bool{
+					failedDetailsURL: true,
+					otherDetailsURL:  true,
+				},
+				UnavailableByDetailsURL: map[string]bool{},
+				Result: &availnzb.ReleasesResult{
+					Releases: []*availnzb.ReleaseWithStatus{
+						{
+							Release:   &release.Release{Title: "failed", DetailsURL: failedDetailsURL, Available: &availTrue},
+							Available: true,
+						},
+					},
+				},
+			},
+		},
+		until: time.Now().Add(time.Minute),
+	})
+
+	server.applyReportedBadReleaseToCaches(&session.Session{
+		ID:      key.SlotPath(0),
+		Release: &release.Release{DetailsURL: failedDetailsURL},
+	}, availnzb.SentOutcome(false))
+
+	cachedPlaylistValue, ok := server.playlistCache.Load(key.CacheKey())
+	if !ok {
+		t.Fatalf("expected playlist cache entry to remain available")
+	}
+	cachedPlaylist := cachedPlaylistValue.(*playlistCacheEntry).result
+	if len(cachedPlaylist.Candidates) != 1 || cachedPlaylist.Candidates[0].Release == nil || cachedPlaylist.Candidates[0].Release.DetailsURL != otherDetailsURL {
+		t.Fatalf("expected failed release to be removed from cached playlist, got %#v", cachedPlaylist.Candidates)
+	}
+	if len(cachedPlaylist.SlotPaths) != 1 || cachedPlaylist.SlotPaths[0] != key.SlotPath(1) {
+		t.Fatalf("expected cached playlist slot paths to preserve original fallback order, got %#v", cachedPlaylist.SlotPaths)
+	}
+	if nextID := server.deriveNextSlotIDFromPlaylist(key.SlotPath(0), key, 0, cachedPlaylist, nil); nextID != key.SlotPath(1) {
+		t.Fatalf("expected failover to advance to the next original slot after cache update, got %q", nextID)
+	}
+	if cachedPlaylist.FirstIsAvailGood != true {
+		t.Fatalf("expected first remaining candidate to stay avail-good")
+	}
+	if !cachedPlaylist.UnavailableDetailsURLs[failedDetailsURL] {
+		t.Fatalf("expected failed release to be marked unavailable in cached playlist")
+	}
+	if cachedPlaylist.CachedAvailable[failedDetailsURL] {
+		t.Fatalf("expected failed release to be removed from cached available set")
+	}
+
+	cachedRawValue, ok := server.rawSearchCache.Load(key.StreamID + ":" + key.ContentType + ":" + key.ID)
+	if !ok {
+		t.Fatalf("expected raw search cache entry to remain available")
+	}
+	cachedRaw := cachedRawValue.(*rawSearchCacheEntry).raw
+	if !cachedRaw.Avail.UnavailableByDetailsURL[failedDetailsURL] {
+		t.Fatalf("expected raw avail context to mark failed release unavailable")
+	}
+	if cachedRaw.Avail.AvailableByDetailsURL[failedDetailsURL] {
+		t.Fatalf("expected raw avail context to remove failed release from available set")
+	}
+	if rel := cachedRaw.Avail.ByDetailsURL[failedDetailsURL]; rel == nil || rel.Available {
+		t.Fatalf("expected raw avail cache entry to be marked unavailable, got %#v", rel)
+	}
+	if cachedRaw.IndexerReleases[0].Available == nil || *cachedRaw.IndexerReleases[0].Available {
+		t.Fatalf("expected cached raw indexer release to be marked unavailable")
 	}
 }
 
@@ -100,7 +218,7 @@ func TestClassifyPlaybackStartupErrWrapsOwnTimeout(t *testing.T) {
 	defer cancel()
 	<-ctx.Done()
 
-	err := classifyPlaybackStartupErr("probe", ctx, context.DeadlineExceeded)
+	err := classifyPlaybackStartupErr("probe", 5*time.Second, ctx, context.DeadlineExceeded)
 	if !errors.Is(err, ErrPlaybackStartupTimeout) {
 		t.Fatalf("expected startup timeout error, got %v", err)
 	}
@@ -116,7 +234,7 @@ func TestClassifyPlaybackStartupErrPreservesParentCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	err := classifyPlaybackStartupErr("open", ctx, context.Canceled)
+	err := classifyPlaybackStartupErr("open", 5*time.Second, ctx, context.Canceled)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("expected context cancellation, got %v", err)
 	}

--- a/pkg/server/stremio/handlers_playback.go
+++ b/pkg/server/stremio/handlers_playback.go
@@ -1876,7 +1876,7 @@ func providerHostsForOutcome(sess *session.Session, success bool) []string {
 	return sess.AttemptedProviderHosts()
 }
 
-func (s *Server) recordAttemptParamsForFailure(sess *session.Session, _ error) persistence.RecordAttemptParams {
+func (s *Server) recordAttemptParamsForFailure(sess *session.Session) persistence.RecordAttemptParams {
 	params := s.recordAttemptParamsForOutcome(sess, false)
 	return params
 }
@@ -1913,7 +1913,7 @@ func (s *Server) recordFailureAttempt(sess *session.Session, streamErr error, av
 	if s.attemptRecorder == nil || sess == nil {
 		return
 	}
-	p := s.recordAttemptParamsForFailure(sess, streamErr)
+	p := s.recordAttemptParamsForFailure(sess)
 	p.Success = false
 	p.FailureReason = normalizeAttemptReason(streamErr.Error())
 	p.AvailStatus = availOutcome.Status
@@ -1953,10 +1953,14 @@ func (s *Server) logBelowGoodThresholdOnce(sess *session.Session, sessionID, req
 			}()
 		}
 	}
+	bytesRead := int64(0)
+	if sess != nil {
+		bytesRead = sess.BytesRead()
+	}
 	logger.Debug("Skipping success bookkeeping below good threshold",
 		"session", sessionID,
 		"requested_session", requestedSessionID,
-		"bytes_read", sess.BytesRead(),
+		"bytes_read", bytesRead,
 		"serve_duration", serveDuration,
 		"min_bytes", minBytes,
 		"min_duration", minDuration,

--- a/pkg/server/stremio/handlers_playback.go
+++ b/pkg/server/stremio/handlers_playback.go
@@ -135,6 +135,7 @@ type StreamMonitor struct {
 	clientIP      string
 	manager       *session.Manager
 	onReadError   func(slotPath string, err error)
+	onProgress    func()
 	lastUpdate    time.Time
 	mu            sync.Mutex
 	readErrorOnce sync.Once
@@ -151,6 +152,9 @@ func (s *StreamMonitor) Read(p []byte) (n int, err error) {
 		s.bytesRead.Add(int64(n))
 		if s.manager != nil {
 			s.manager.AddBytesRead(s.sessionID, int64(n))
+		}
+		if s.onProgress != nil {
+			s.onProgress()
 		}
 	}
 	if errors.Is(err, io.EOF) {
@@ -387,13 +391,17 @@ var streamSinkKey = streamSinkKeyType{}
 
 const streamSlotPrefix = "stream:"
 
-const (
-	// playbackStartupTimeout bounds probe/open work before the first playable response is ready.
-	// Slow archive-heavy startup should fail over rather than keep the player spinning indefinitely.
-	playbackStartupTimeout = 5 * time.Second
-)
-
 var ErrPlaybackStartupTimeout = errors.New("playback startup timeout")
+
+func (s *Server) playbackStartupTimeout() time.Duration {
+	s.mu.RLock()
+	cfg := s.config
+	s.mu.RUnlock()
+	if cfg == nil {
+		return time.Duration(config.DefaultPlaybackStartupTimeoutSeconds) * time.Second
+	}
+	return cfg.EffectivePlaybackStartupTimeout()
+}
 
 type StreamSlotKey struct {
 	StreamID    string
@@ -936,21 +944,21 @@ func isDataCorruptErr(err error) bool {
 	return false
 }
 
-func classifyPlaybackStartupErr(phase string, startupCtx context.Context, err error) error {
+func classifyPlaybackStartupErr(phase string, startupTimeout time.Duration, startupCtx context.Context, err error) error {
 	if err == nil {
 		return nil
 	}
 	if errors.Is(startupCtx.Err(), context.DeadlineExceeded) {
-		return playbackStartupTimeoutErr(phase, err)
+		return playbackStartupTimeoutErr(startupTimeout, phase, err)
 	}
 	return err
 }
 
-func playbackStartupTimeoutErr(phase string, cause error) error {
+func playbackStartupTimeoutErr(startupTimeout time.Duration, phase string, cause error) error {
 	if cause != nil {
-		return fmt.Errorf("%w during %s after %s: %v", ErrPlaybackStartupTimeout, phase, playbackStartupTimeout, cause)
+		return fmt.Errorf("%w during %s after %s: %v", ErrPlaybackStartupTimeout, phase, startupTimeout, cause)
 	}
-	return fmt.Errorf("%w during %s after %s", ErrPlaybackStartupTimeout, phase, playbackStartupTimeout)
+	return fmt.Errorf("%w during %s after %s", ErrPlaybackStartupTimeout, phase, startupTimeout)
 }
 
 func isPlayPrepareCancellation(err error) bool {
@@ -980,7 +988,7 @@ type playbackSourceOpenResult struct {
 func (s *Server) handlePlay(w http.ResponseWriter, r *http.Request, streamConfig *auth.Stream) {
 	sessionID := strings.TrimPrefix(r.URL.Path, "/play/")
 	requestedSessionID := sessionID
-	logger.Info("Play request", "session", sessionID)
+	logger.Debug("Play request", "session", sessionID)
 
 	var (
 		sess   *session.Session
@@ -1086,16 +1094,16 @@ func (s *Server) handlePlay(w http.ResponseWriter, r *http.Request, streamConfig
 			// after the quota resets or is raised manually.
 			if !temporaryLimitErr {
 				s.sessionManager.SetSlotFailedDuringPlayback(sessionID)
-				s.ClearSearchCaches()
 			}
 			availOutcome := availOutcomeForFailure(prepareErr)
 			if shouldReportBadRelease(prepareErr) && s.availReporter != nil {
 				availOutcome = s.availReporter.ReportBad(sess, prepareErr.Error())
 			}
+			s.applyReportedBadReleaseToCaches(sess, availOutcome)
 			// Gate failure recording: concurrent goroutines for the same session (Stremio's automatic
 			// re-requests) must not each insert a Failure row. Only the first one wins.
 			if _, alreadyFailed := s.recordedFailureSessionIDs.LoadOrStore(sessionID, struct{}{}); !alreadyFailed {
-				s.recordAttempt(sess, false, prepareErr.Error(), availOutcome)
+				s.recordFailureAttempt(sess, prepareErr, availOutcome)
 				go func(id string, done <-chan struct{}) {
 					<-done
 					s.recordedFailureSessionIDs.Delete(id)
@@ -1104,7 +1112,7 @@ func (s *Server) handlePlay(w http.ResponseWriter, r *http.Request, streamConfig
 			s.sessionManager.DeleteSession(sessionID)
 			if !temporaryLimitErr && streamFailoverEnabled(streamConfig) {
 				if nextSess, nextID, switchErr := s.switchToNextFallback(r.Context(), sess, streamConfig); nextID != "" && switchErr == nil {
-					logger.Info("Trying next fallback slot (internal)", "from", sessionID, "to", nextID, "err", prepareErr)
+					logger.Info("Playback failover advanced", "from", sessionID, "to", nextID, "err", prepareErr)
 					sess, sessionID = nextSess, nextID
 					continue
 				}
@@ -1176,7 +1184,7 @@ func (s *Server) handlePlay(w http.ResponseWriter, r *http.Request, streamConfig
 	serveFailureRecorded := false
 	onReadError := func(playbackSessionID string, readErr error) {
 		// Trigger slot failover for any permanent mid-stream error:
-		//   - 430 No Such Article (segment missing on all providers)
+		//   - 430 No Such Article (segment missing across all selected providers)
 		//   - yEnc decode failure (data corruption)
 		//   - ErrTooManyZeroFills (too many segments failed across all providers)
 		// All three mean the slot is unrecoverable. SetSlotFailedDuringPlayback marks it so the
@@ -1186,15 +1194,18 @@ func (s *Server) handlePlay(w http.ResponseWriter, r *http.Request, streamConfig
 			return
 		}
 		s.sessionManager.SetSlotFailedDuringPlayback(playbackSessionID)
-		s.ClearSearchCaches()
 		if errSess, _ := s.sessionManager.GetSession(playbackSessionID); errSess != nil {
+			if _, alreadySucceeded := s.recordedSuccessSessionIDs.Load(playbackSessionID); alreadySucceeded {
+				return
+			}
 			errSess.ResetPlaybackStream()
 			availOutcome := availOutcomeForFailure(readErr)
-			if s.availReporter != nil {
+			if shouldReportBadRelease(readErr) && s.availReporter != nil {
 				availOutcome = s.availReporter.ReportBad(errSess, readErr.Error())
 			}
+			s.applyReportedBadReleaseToCaches(errSess, availOutcome)
 			if _, alreadyFailed := s.recordedFailureSessionIDs.LoadOrStore(playbackSessionID, struct{}{}); !alreadyFailed {
-				s.recordAttempt(errSess, false, readErr.Error(), availOutcome)
+				s.recordFailureAttempt(errSess, readErr, availOutcome)
 				go func(id string, done <-chan struct{}) {
 					<-done
 					s.recordedFailureSessionIDs.Delete(id)
@@ -1216,12 +1227,15 @@ func (s *Server) handlePlay(w http.ResponseWriter, r *http.Request, streamConfig
 
 	bufW := newMediaResponseWriter(w, name)
 	serveStartedAt := time.Now()
+	monitoredStream.onProgress = func() {
+		s.commitGoodAttemptIfQualified(sess, sessionID, requestedSessionID, serveStartedAt)
+	}
 	effectiveRange := r.Header.Get("Range")
 	probeLikeServe := false
 	probeLikeServeReason := ""
 
 	logger.Debug("play handler serving stream", "session", sessionID, "name", name, "size", size)
-	logger.Info("Serving media",
+	logger.Debug("Serving media",
 		"session", sessionID,
 		"requested_session", requestedSessionID,
 		"name", name,
@@ -1249,7 +1263,7 @@ func (s *Server) handlePlay(w http.ResponseWriter, r *http.Request, streamConfig
 		}
 		probeLikeServe, probeLikeServeReason = classifyProbeLikeServe(r, size, effectiveRange, responseStats, streamStats, closeReasonText)
 
-		logger.Info("Finished serving media",
+		logger.Debug("Finished serving media",
 			"session", sessionID,
 			"requested_session", requestedSessionID,
 			"method", r.Method,
@@ -1316,6 +1330,9 @@ func (s *Server) handlePlay(w http.ResponseWriter, r *http.Request, streamConfig
 			minBytes = s.availReporter.MinBytesToReportGood
 			minDuration = s.availReporter.MinDurationToReportGood
 		}
+		if s.commitGoodAttemptIfQualified(sess, sessionID, requestedSessionID, serveStartedAt) {
+			return
+		}
 		if !availnzb.QualifiesGood(sess, serveDuration, minBytes, minDuration) {
 			reason := fmt.Sprintf(
 				"Playback ended too early to classify this release as good. Threshold not reached (%d/%d bytes, %ds/%ds).",
@@ -1324,30 +1341,12 @@ func (s *Server) handlePlay(w http.ResponseWriter, r *http.Request, streamConfig
 				int(serveDuration/time.Second),
 				int(minDuration/time.Second),
 			)
-			logger.Debug("Skipping success bookkeeping below good threshold",
-				"session", sessionID,
-				"requested_session", requestedSessionID,
-				"bytes_read", sess.BytesRead(),
-				"serve_duration", serveDuration,
-				"min_bytes", minBytes,
-				"min_duration", minDuration,
-				"reason", reason,
-			)
+			s.logBelowGoodThresholdOnce(sess, sessionID, requestedSessionID, serveDuration, minBytes, minDuration, reason)
 			s.recordPendingAttempt(sess, reason, availnzb.SkippedOutcome("Playback ended before the good threshold was reached."))
 			return
 		}
-		availOutcome := availnzb.ReportOutcome{}
-		if s.availReporter != nil {
-			availOutcome = s.availReporter.ReportGood(sess, serveDuration)
-		}
-		if _, already := s.recordedSuccessSessionIDs.LoadOrStore(sessionID, struct{}{}); !already {
-			s.recordAttempt(sess, true, "", availOutcome)
-			// When session is gone, allow recording success again for a future play of the same release.
-			go func() {
-				<-sess.Done()
-				s.recordedSuccessSessionIDs.Delete(sessionID)
-			}()
-		}
+		// Safety fallback: this path should normally already have returned via commitGoodAttemptIfQualified.
+		s.commitGoodAttemptIfQualified(sess, sessionID, requestedSessionID, serveStartedAt)
 	}()
 
 	http.ServeContent(bufW, r, name, time.Time{}, monitoredStream)
@@ -1404,9 +1403,10 @@ func (s *Server) preparePlaybackStream(ctx context.Context, sess *session.Sessio
 
 	needProbe := !haveSnapshot || !snapshot.HasStartupInfo || (needDurationProbe && !snapshot.StartupInfo.DurationKnown)
 	if needProbe {
-		probeCtx, cancel := context.WithTimeout(ctx, playbackStartupTimeout)
+		startupTimeout := s.playbackStartupTimeout()
+		probeCtx, cancel := context.WithTimeout(ctx, startupTimeout)
 		spec, startupInfo, err := s.probePlaybackSource(probeCtx, sess, needDurationProbe)
-		err = classifyPlaybackStartupErr("probe", probeCtx, err)
+		err = classifyPlaybackStartupErr("probe", startupTimeout, probeCtx, err)
 		cancel()
 		if err != nil {
 			return preparedPlaybackStream{}, err
@@ -1420,7 +1420,7 @@ func (s *Server) preparePlaybackStream(ctx context.Context, sess *session.Sessio
 		return preparedPlaybackStream{}, fmt.Errorf("playback stream spec missing for session %s", sess.ID)
 	}
 
-	stream, err := s.openExpectedPlaybackSourceWithStartupTimeout(ctx, sess, preparedStream.Spec)
+	stream, err := s.openExpectedPlaybackSourceWithStartupTimeout(ctx, sess, preparedStream.Spec, s.playbackStartupTimeout())
 	if err != nil {
 		sess.ResetPlaybackStream()
 		return preparedPlaybackStream{}, err
@@ -1432,7 +1432,7 @@ func (s *Server) preparePlaybackStream(ctx context.Context, sess *session.Sessio
 	return preparedStream, nil
 }
 
-func (s *Server) openExpectedPlaybackSourceWithStartupTimeout(ctx context.Context, sess *session.Session, spec session.PlaybackStreamSpec) (io.ReadSeekCloser, error) {
+func (s *Server) openExpectedPlaybackSourceWithStartupTimeout(ctx context.Context, sess *session.Session, spec session.PlaybackStreamSpec, startupTimeout time.Duration) (io.ReadSeekCloser, error) {
 	openCtx, cancel := context.WithCancel(ctx)
 	resultCh := make(chan playbackSourceOpenResult, 1)
 	done := make(chan struct{})
@@ -1447,7 +1447,7 @@ func (s *Server) openExpectedPlaybackSourceWithStartupTimeout(ctx context.Contex
 		}
 	}()
 
-	timer := time.NewTimer(playbackStartupTimeout)
+	timer := time.NewTimer(startupTimeout)
 	defer timer.Stop()
 
 	cleanup := func() {
@@ -1472,7 +1472,7 @@ func (s *Server) openExpectedPlaybackSourceWithStartupTimeout(ctx context.Contex
 		return res.stream, nil
 	case <-timer.C:
 		cleanup()
-		return nil, playbackStartupTimeoutErr("open", nil)
+		return nil, playbackStartupTimeoutErr(startupTimeout, "open", nil)
 	case <-ctx.Done():
 		cleanup()
 		return nil, ctx.Err()
@@ -1654,10 +1654,25 @@ func (s *Server) deriveNextSlotIDFromPlaylist(currentID string, key StreamSlotKe
 	useSlotPaths := len(list.SlotPaths) == n
 	startIndex := currentIndex + 1
 	if useSlotPaths {
-		startIndex = n
+		foundCurrent := false
 		for i, slotPath := range list.SlotPaths {
 			if slotPath == currentID {
 				startIndex = i + 1
+				foundCurrent = true
+				break
+			}
+		}
+		if !foundCurrent {
+			startIndex = 0
+			for i, slotPath := range list.SlotPaths {
+				_, _, _, slotIndex, ok := parseStreamSlotID(slotPath)
+				if !ok {
+					continue
+				}
+				if slotIndex <= currentIndex {
+					startIndex = i + 1
+					continue
+				}
 				break
 			}
 		}
@@ -1718,7 +1733,6 @@ func (s *Server) switchToNextFallback(ctx context.Context, sess *session.Session
 		}
 		logger.Info("Skipping unresolved fallback slot", "from", currentID, "to", nextID, "err", err)
 		s.sessionManager.SetSlotFailedDuringPlayback(nextID)
-		s.ClearSearchCaches()
 		currentID = nextID
 		_, _, _, currentIndex, ok = parseStreamSlotID(currentID)
 		if !ok {
@@ -1741,6 +1755,25 @@ func (s *Server) getOrResolveSession(ctx context.Context, sessionID string, stre
 		return sess, nil
 	}
 	return nil, err
+}
+
+func (s *Server) applyReportedBadReleaseToCaches(sess *session.Session, outcome availnzb.ReportOutcome) {
+	if s == nil || sess == nil || outcome.Status != "sent" {
+		return
+	}
+	detailsURL := strings.TrimSpace(sess.ReleaseURL())
+	if detailsURL == "" {
+		return
+	}
+	streamID, contentType, id, _, ok := parseStreamSlotID(sess.ID)
+	if !ok {
+		return
+	}
+	s.markCachedReleaseUnavailable(StreamSlotKey{
+		StreamID:    streamID,
+		ContentType: contentType,
+		ID:          id,
+	}, detailsURL, sess.ID)
 }
 
 func shouldReportBadRelease(streamErr error) bool {
@@ -1779,6 +1812,8 @@ func availOutcomeForFailure(err error) availnzb.ReportOutcome {
 		return availnzb.SkippedOutcome("Not reported to AvailNZB because this startup timeout may be temporary and does not prove the release is bad.")
 	case isIndexerLimitErr(err):
 		return availnzb.SkippedOutcome("Not reported to AvailNZB because the failure was caused by an indexer or provider limit.")
+	case isSegmentUnavailableErr(err):
+		return availnzb.SkippedOutcome("Not reported to AvailNZB because this segment fetch failure does not reliably prove the release is bad.")
 	default:
 		return availnzb.ReportOutcome{}
 	}
@@ -1805,17 +1840,9 @@ func (s *Server) recordAttemptParamsForOutcome(sess *session.Session, success bo
 			contentID = fmt.Sprintf("tvdb:%s:%d:%d", sess.ContentIDs.TvdbID, sess.ContentIDs.Season, sess.ContentIDs.Episode)
 		}
 	}
-	providerName := ""
-	hosts := sess.UsedProviderHosts()
-	if success {
-		hosts = sess.ServedProviderHosts()
-	}
-	if len(hosts) > 0 {
-		providerName = strings.Join(hosts, ", ")
-	}
 	return persistence.RecordAttemptParams{
 		StreamName:   sess.StreamName,
-		ProviderName: providerName,
+		ProviderName: providerNameFromHosts(providerHostsForOutcome(sess, success)),
 		ContentType:  contentType,
 		ContentID:    contentID,
 		ContentTitle: sess.ContentTitle,
@@ -1826,6 +1853,32 @@ func (s *Server) recordAttemptParamsForOutcome(sess *session.Session, success bo
 		ServedFile:   sess.SelectedPlaybackFile(),
 		SlotPath:     sess.ID,
 	}
+}
+
+func providerNameFromHosts(hosts []string) string {
+	if len(hosts) == 0 {
+		return ""
+	}
+	return strings.Join(hosts, ", ")
+}
+
+func providerHostsForOutcome(sess *session.Session, success bool) []string {
+	if sess == nil {
+		return nil
+	}
+	if success {
+		return sess.ServedProviderHosts()
+	}
+	hosts := sess.UsedProviderHosts()
+	if len(hosts) > 0 {
+		return hosts
+	}
+	return sess.AttemptedProviderHosts()
+}
+
+func (s *Server) recordAttemptParamsForFailure(sess *session.Session, _ error) persistence.RecordAttemptParams {
+	params := s.recordAttemptParamsForOutcome(sess, false)
+	return params
 }
 
 // recordPreloadAttempt inserts a preload row when we are about to try playing a slot (result not yet known).
@@ -1856,6 +1909,21 @@ func (s *Server) recordAttempt(sess *session.Session, success bool, failureReaso
 	}
 }
 
+func (s *Server) recordFailureAttempt(sess *session.Session, streamErr error, availOutcome availnzb.ReportOutcome) {
+	if s.attemptRecorder == nil || sess == nil {
+		return
+	}
+	p := s.recordAttemptParamsForFailure(sess, streamErr)
+	p.Success = false
+	p.FailureReason = normalizeAttemptReason(streamErr.Error())
+	p.AvailStatus = availOutcome.Status
+	p.AvailReason = availOutcome.Reason
+	s.attemptRecorder.RecordAttempt(p)
+	if s.onAttemptRecorded != nil {
+		s.onAttemptRecorded()
+	}
+}
+
 func (s *Server) recordPendingAttempt(sess *session.Session, reason string, availOutcome availnzb.ReportOutcome) {
 	if s.attemptRecorder == nil || sess == nil {
 		return
@@ -1868,6 +1936,75 @@ func (s *Server) recordPendingAttempt(sess *session.Session, reason string, avai
 	if s.onAttemptRecorded != nil {
 		s.onAttemptRecorded()
 	}
+}
+
+func (s *Server) logBelowGoodThresholdOnce(sess *session.Session, sessionID, requestedSessionID string, serveDuration time.Duration, minBytes int64, minDuration time.Duration, reason string) {
+	if s == nil {
+		return
+	}
+	if _, already := s.loggedThresholdSkipIDs.LoadOrStore(sessionID, struct{}{}); already {
+		return
+	}
+	if sess != nil {
+		if done := sess.Context().Done(); done != nil {
+			go func() {
+				<-done
+				s.loggedThresholdSkipIDs.Delete(sessionID)
+			}()
+		}
+	}
+	logger.Debug("Skipping success bookkeeping below good threshold",
+		"session", sessionID,
+		"requested_session", requestedSessionID,
+		"bytes_read", sess.BytesRead(),
+		"serve_duration", serveDuration,
+		"min_bytes", minBytes,
+		"min_duration", minDuration,
+		"reason", reason,
+	)
+}
+
+func (s *Server) commitGoodAttemptIfQualified(sess *session.Session, sessionID, requestedSessionID string, serveStartedAt time.Time) bool {
+	if sess == nil {
+		return false
+	}
+	if _, already := s.recordedSuccessSessionIDs.Load(sessionID); already {
+		return true
+	}
+	serveDuration := time.Since(serveStartedAt)
+	minBytes := availnzb.DefaultMinBytesToReportGood
+	minDuration := availnzb.DefaultMinDurationToReportGood
+	if s.availReporter != nil {
+		minBytes = s.availReporter.MinBytesToReportGood
+		minDuration = s.availReporter.MinDurationToReportGood
+	}
+	if !availnzb.QualifiesGood(sess, serveDuration, minBytes, minDuration) {
+		return false
+	}
+	availOutcome := availnzb.ReportOutcome{}
+	if s.availReporter != nil {
+		availOutcome = s.availReporter.ReportGood(sess, serveDuration)
+	}
+	if _, already := s.recordedSuccessSessionIDs.LoadOrStore(sessionID, struct{}{}); already {
+		return true
+	}
+	s.recordAttempt(sess, true, "", availOutcome)
+	s.loggedThresholdSkipIDs.Delete(sessionID)
+	if done := sess.Context().Done(); done != nil {
+		go func() {
+			<-done
+			s.recordedSuccessSessionIDs.Delete(sessionID)
+		}()
+	}
+	logger.Info("Playback attempt reached good threshold",
+		"session", sessionID,
+		"requested_session", requestedSessionID,
+		"bytes_read", sess.BytesRead(),
+		"serve_duration", serveDuration,
+		"min_bytes", minBytes,
+		"min_duration", minDuration,
+	)
+	return true
 }
 
 func (s *Server) handleDebugPlay(w http.ResponseWriter, r *http.Request, streamConfig *auth.Stream) {

--- a/pkg/server/stremio/handlers_playlist.go
+++ b/pkg/server/stremio/handlers_playlist.go
@@ -159,10 +159,15 @@ func (s *Server) buildPlaylist(ctx context.Context, key StreamSlotKey, isAIOStre
 	cacheKey := key.CacheKey()
 	if v, ok := s.playlistCache.Load(cacheKey); ok {
 		if ent, _ := v.(*playlistCacheEntry); ent != nil && time.Now().Before(ent.until) {
-			logger.Debug("Play list cache hit", "key", cacheKey)
+			candidateCount := 0
+			if ent.result != nil {
+				candidateCount = len(ent.result.Candidates)
+			}
+			logger.Debug("Playback playlist cache hit", "key", cacheKey, "candidates", candidateCount)
 			return ent.result, nil
 		}
 	}
+	logger.Debug("Playback playlist cache miss", "key", cacheKey)
 	list, err := s.buildPlaylistUncached(ctx, key, isAIOStreams, stream)
 	if err != nil || list == nil {
 		return list, err
@@ -183,10 +188,15 @@ func (s *Server) getOrBuildRawSearchResult(ctx context.Context, contentType, id 
 	rawKey := streamID(stream) + ":" + contentType + ":" + id
 	if v, ok := s.rawSearchCache.Load(rawKey); ok {
 		if ent, _ := v.(*rawSearchCacheEntry); ent != nil && time.Now().Before(ent.until) {
-			logger.Debug("Raw search cache hit", "key", rawKey)
+			releaseCount := 0
+			if ent.raw != nil {
+				releaseCount = len(ent.raw.IndexerReleases)
+			}
+			logger.Debug("Playback candidate cache hit", "key", rawKey, "releases", releaseCount)
 			return cloneRawSearchResult(ent.raw), nil
 		}
 	}
+	logger.Debug("Playback candidate cache miss", "key", rawKey)
 	raw, err := s.buildRawSearchResult(ctx, contentType, id, stream)
 	if err != nil || raw == nil {
 		return nil, err
@@ -463,6 +473,204 @@ func cloneRawSearchResult(raw *rawSearchResult) *rawSearchResult {
 		}
 	}
 	return next
+}
+
+func clonePlaylistResult(list *playlistResult) *playlistResult {
+	if list == nil {
+		return nil
+	}
+	next := &playlistResult{
+		FirstIsAvailGood:       list.FirstIsAvailGood,
+		Params:                 cloneSearchParams(list.Params),
+		CachedAvailable:        make(map[string]bool, len(list.CachedAvailable)),
+		UnavailableDetailsURLs: make(map[string]bool, len(list.UnavailableDetailsURLs)),
+	}
+	if list.Candidates != nil {
+		next.Candidates = make([]triage.Candidate, 0, len(list.Candidates))
+		for _, candidate := range list.Candidates {
+			copyCandidate := candidate
+			copyCandidate.Release = cloneReleaseForPlaylist(candidate.Release)
+			next.Candidates = append(next.Candidates, copyCandidate)
+		}
+	}
+	if list.SlotPaths != nil {
+		next.SlotPaths = append([]string(nil), list.SlotPaths...)
+	}
+	for k, v := range list.CachedAvailable {
+		next.CachedAvailable[k] = v
+	}
+	for k, v := range list.UnavailableDetailsURLs {
+		next.UnavailableDetailsURLs[k] = v
+	}
+	return next
+}
+
+func playlistSlotPaths(list *playlistResult, key StreamSlotKey) []string {
+	if list == nil || len(list.Candidates) == 0 {
+		return nil
+	}
+	if len(list.SlotPaths) == len(list.Candidates) {
+		return append([]string(nil), list.SlotPaths...)
+	}
+	paths := make([]string, len(list.Candidates))
+	for i := range list.Candidates {
+		paths[i] = key.SlotPath(i)
+	}
+	return paths
+}
+
+func markRawSearchResultUnavailable(raw *rawSearchResult, detailsURL string) bool {
+	if raw == nil || strings.TrimSpace(detailsURL) == "" {
+		return false
+	}
+	changed := false
+	if raw.Avail != nil {
+		if raw.Avail.AvailableByDetailsURL != nil && raw.Avail.AvailableByDetailsURL[detailsURL] {
+			delete(raw.Avail.AvailableByDetailsURL, detailsURL)
+			changed = true
+		}
+		if raw.Avail.UnavailableByDetailsURL == nil {
+			raw.Avail.UnavailableByDetailsURL = make(map[string]bool)
+		}
+		if !raw.Avail.UnavailableByDetailsURL[detailsURL] {
+			raw.Avail.UnavailableByDetailsURL[detailsURL] = true
+			changed = true
+		}
+		if rws := raw.Avail.ByDetailsURL[detailsURL]; rws != nil {
+			if rws.Available {
+				rws.Available = false
+				changed = true
+			}
+			if rws.Release != nil {
+				if rws.Release.Available == nil || *rws.Release.Available {
+					rws.Release.Available = &availFalse
+					changed = true
+				}
+			}
+		}
+		if raw.Avail.Result != nil {
+			for _, rws := range raw.Avail.Result.Releases {
+				if rws == nil || rws.Release == nil || rws.Release.DetailsURL != detailsURL {
+					continue
+				}
+				if rws.Available {
+					rws.Available = false
+					changed = true
+				}
+				if rws.Release.Available == nil || *rws.Release.Available {
+					rws.Release.Available = &availFalse
+					changed = true
+				}
+			}
+		}
+	}
+	for _, rel := range raw.IndexerReleases {
+		if rel == nil || rel.DetailsURL != detailsURL {
+			continue
+		}
+		if rel.Available == nil || *rel.Available {
+			rel.Available = &availFalse
+			changed = true
+		}
+	}
+	return changed
+}
+
+func markPlaylistResultUnavailable(list *playlistResult, key StreamSlotKey, detailsURL, slotPath string) bool {
+	if list == nil {
+		return false
+	}
+	changed := false
+	detailsURL = strings.TrimSpace(detailsURL)
+	slotPath = strings.TrimSpace(slotPath)
+	if detailsURL != "" {
+		if list.CachedAvailable != nil && list.CachedAvailable[detailsURL] {
+			delete(list.CachedAvailable, detailsURL)
+			changed = true
+		}
+		if list.UnavailableDetailsURLs == nil {
+			list.UnavailableDetailsURLs = make(map[string]bool)
+		}
+		if !list.UnavailableDetailsURLs[detailsURL] {
+			list.UnavailableDetailsURLs[detailsURL] = true
+			changed = true
+		}
+	}
+
+	paths := playlistSlotPaths(list, key)
+	if len(paths) != len(list.Candidates) {
+		recomputePlaylistAvailability(list)
+		return changed
+	}
+
+	filteredCandidates := make([]triage.Candidate, 0, len(list.Candidates))
+	filteredPaths := make([]string, 0, len(paths))
+	removed := false
+	for i, candidate := range list.Candidates {
+		candidateDetailsURL := ""
+		if candidate.Release != nil {
+			candidateDetailsURL = candidate.Release.DetailsURL
+		}
+		if (detailsURL != "" && candidateDetailsURL == detailsURL) || (slotPath != "" && paths[i] == slotPath) {
+			removed = true
+			continue
+		}
+		filteredCandidates = append(filteredCandidates, candidate)
+		filteredPaths = append(filteredPaths, paths[i])
+	}
+	if removed {
+		list.Candidates = filteredCandidates
+		list.SlotPaths = filteredPaths
+		changed = true
+	}
+	recomputePlaylistAvailability(list)
+	return changed
+}
+
+func recomputePlaylistAvailability(list *playlistResult) {
+	if list == nil {
+		return
+	}
+	list.FirstIsAvailGood = false
+	if len(list.Candidates) == 0 || list.CachedAvailable == nil || list.Candidates[0].Release == nil {
+		return
+	}
+	detailsURL := list.Candidates[0].Release.DetailsURL
+	if detailsURL == "" {
+		return
+	}
+	list.FirstIsAvailGood = list.CachedAvailable[detailsURL]
+}
+
+func (s *Server) markCachedReleaseUnavailable(key StreamSlotKey, detailsURL, slotPath string) {
+	if strings.TrimSpace(detailsURL) == "" {
+		return
+	}
+	updated := false
+	cacheKey := key.CacheKey()
+	if v, ok := s.playlistCache.Load(cacheKey); ok {
+		if ent, _ := v.(*playlistCacheEntry); ent != nil && time.Now().Before(ent.until) && ent.result != nil {
+			nextResult := clonePlaylistResult(ent.result)
+			if markPlaylistResultUnavailable(nextResult, key, detailsURL, slotPath) {
+				s.playlistCache.Store(cacheKey, &playlistCacheEntry{result: nextResult, until: ent.until})
+				updated = true
+			}
+		}
+	}
+
+	rawKey := key.StreamID + ":" + key.ContentType + ":" + key.ID
+	if v, ok := s.rawSearchCache.Load(rawKey); ok {
+		if ent, _ := v.(*rawSearchCacheEntry); ent != nil && time.Now().Before(ent.until) && ent.raw != nil {
+			nextRaw := cloneRawSearchResult(ent.raw)
+			if markRawSearchResultUnavailable(nextRaw, detailsURL) {
+				s.rawSearchCache.Store(rawKey, &rawSearchCacheEntry{raw: nextRaw, until: ent.until})
+				updated = true
+			}
+		}
+	}
+	if updated {
+		logger.Debug("Playback caches updated after bad release report", "key", cacheKey, "details_url", detailsURL, "slot", slotPath)
+	}
 }
 
 func buildUnavailableDetailsURLs(availCtx *AvailContext, filteringActive bool) map[string]bool {

--- a/pkg/server/stremio/handlers_search.go
+++ b/pkg/server/stremio/handlers_search.go
@@ -650,6 +650,12 @@ func (s *Server) buildRawSearchResult(ctx context.Context, contentType, id strin
 		}
 		return "legacy"
 	}()
+	logger.Debug("Building playback candidates",
+		"stream", streamLabel,
+		"type", contentType,
+		"id", id,
+		"requests", len(selectedQueries),
+	)
 	logMetadataLookup(streamLabel, contentType, id)
 	logMetadataLookupFinished(streamLabel, contentType, id, params)
 	if !hasUsableResolvedMetadata(params, contentType) {
@@ -682,6 +688,14 @@ func (s *Server) buildRawSearchResult(ctx context.Context, contentType, id strin
 	indexerReleases = dedupeCombinedSearchResults(streamLabel, stream, indexerReleases, executedRequests)
 	availCtx = alignAvailContextWithSearch(availCtx, indexerReleases)
 	enrichSearchResultsWithAvail(streamLabel, indexerReleases, availCtx)
+	logger.Debug("Playback candidate build finished",
+		"stream", streamLabel,
+		"type", contentType,
+		"id", id,
+		"executed_requests", executedRequests,
+		"releases", len(indexerReleases),
+		"avail_matches", len(availCtx.AvailableByDetailsURL)+len(availCtx.UnavailableByDetailsURL),
+	)
 
 	return &rawSearchResult{
 		Params:          params,

--- a/pkg/server/stremio/server.go
+++ b/pkg/server/stremio/server.go
@@ -45,6 +45,7 @@ type Server struct {
 	recordedSuccessSessionIDs sync.Map // session ID -> struct{}; record actual playback success only once per stream
 	recordedPreloadSessionIDs sync.Map // session ID -> struct{}; record preload only once per session lifetime
 	recordedFailureSessionIDs sync.Map // session ID -> struct{}; record failure only once per session lifetime (prevents concurrent goroutines from inserting duplicate rows)
+	loggedThresholdSkipIDs    sync.Map // session ID -> struct{}; keep threshold-below logs to a single line per session
 	nextReleaseIndex          sync.Map // key: streamToken|key.CacheKey() → *nextReleaseCursor; tracks manual "next" progression
 	webHandler                http.Handler
 	apiHandler                http.Handler

--- a/pkg/services/availnzb/reporter.go
+++ b/pkg/services/availnzb/reporter.go
@@ -131,6 +131,12 @@ func (r *Reporter) report(sess *session.Session, available bool, servedOnly bool
 	if servedOnly {
 		hosts = sess.ServedProviderHosts()
 	}
+	if len(hosts) == 0 && !servedOnly {
+		hosts = sess.AttemptedProviderHosts()
+	}
+	if len(hosts) == 0 && !servedOnly && available && r.providerSrc != nil {
+		hosts = r.providerSrc.GetProviderHosts()
+	}
 	if len(hosts) == 0 {
 		if servedOnly {
 			logger.Debug("Skipping AvailNZB report without served provider hosts", "session", sess.ID)

--- a/pkg/services/availnzb/reporter_test.go
+++ b/pkg/services/availnzb/reporter_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -139,15 +140,27 @@ func TestReportGoodAllowsRetryAfterSkippedAttempt(t *testing.T) {
 }
 
 func TestReportBadFallsBackToAttemptedProviderHosts(t *testing.T) {
-	reportCalls := 0
-	var gotProvider string
+	var (
+		mu          sync.Mutex
+		reportCalls int
+		gotProvider string
+		decodeErr   error
+	)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
 		reportCalls++
+		mu.Unlock()
 		var body ReportRequest
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			t.Fatalf("decode report body: %v", err)
+			mu.Lock()
+			decodeErr = err
+			mu.Unlock()
+			w.WriteHeader(http.StatusBadRequest)
+			return
 		}
+		mu.Lock()
 		gotProvider = body.ProviderURL
+		mu.Unlock()
 		w.WriteHeader(http.StatusAccepted)
 	}))
 	defer server.Close()
@@ -168,6 +181,11 @@ func TestReportBadFallsBackToAttemptedProviderHosts(t *testing.T) {
 	outcome := reporter.ReportBad(sess, "EOF")
 	if outcome.Status != "sent" {
 		t.Fatalf("expected sent outcome, got %+v", outcome)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if decodeErr != nil {
+		t.Fatalf("decode report body: %v", decodeErr)
 	}
 	if reportCalls != 1 {
 		t.Fatalf("expected one report call, got %d", reportCalls)

--- a/pkg/services/availnzb/reporter_test.go
+++ b/pkg/services/availnzb/reporter_test.go
@@ -1,6 +1,7 @@
 package availnzb
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -134,5 +135,44 @@ func TestReportGoodAllowsRetryAfterSkippedAttempt(t *testing.T) {
 	}
 	if reportCalls != 1 {
 		t.Fatalf("expected one successful report call after retry, got %d", reportCalls)
+	}
+}
+
+func TestReportBadFallsBackToAttemptedProviderHosts(t *testing.T) {
+	reportCalls := 0
+	var gotProvider string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reportCalls++
+		var body ReportRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode report body: %v", err)
+		}
+		gotProvider = body.ProviderURL
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-key")
+	reporter := NewReporter(client, nil)
+
+	sess := &session.Session{
+		ID:      "sess-bad-fallback",
+		Release: &release.Release{Title: "Example.Release.2026", DetailsURL: "https://example.invalid/details/123", Size: 1234},
+		ContentIDs: &session.AvailReportMeta{
+			ImdbID: "tt1234567",
+		},
+	}
+	sess.RecordAttemptedProviderHost("news-a.example.net")
+	sess.RecordAttemptedProviderHost("news-b.example.net")
+
+	outcome := reporter.ReportBad(sess, "EOF")
+	if outcome.Status != "sent" {
+		t.Fatalf("expected sent outcome, got %+v", outcome)
+	}
+	if reportCalls != 1 {
+		t.Fatalf("expected one report call, got %d", reportCalls)
+	}
+	if gotProvider != "news-a.example.net,news-b.example.net" {
+		t.Fatalf("provider = %q, want %q", gotProvider, "news-a.example.net,news-b.example.net")
 	}
 }

--- a/pkg/session/manager.go
+++ b/pkg/session/manager.go
@@ -88,6 +88,7 @@ type Session struct {
 
 	segmentFetcher     loader.SegmentFetcher
 	providerHosts      []string
+	attemptedProviders map[string]struct{}
 	usedProviders      map[string]struct{}
 	servedProviders    map[string]struct{}
 	serveTrackingDepth int
@@ -163,6 +164,20 @@ func (s *Session) UsedProviderHosts() []string {
 	return hosts
 }
 
+func (s *Session) AttemptedProviderHosts() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.attemptedProviders) == 0 {
+		return nil
+	}
+	hosts := make([]string, 0, len(s.attemptedProviders))
+	for host := range s.attemptedProviders {
+		hosts = append(hosts, host)
+	}
+	sort.Strings(hosts)
+	return hosts
+}
+
 func (s *Session) ServedProviderHosts() []string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -177,6 +192,25 @@ func (s *Session) ServedProviderHosts() []string {
 	return hosts
 }
 
+func (s *Session) RecordAttemptedProviderHost(host string) {
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.attemptedProviders == nil {
+		s.attemptedProviders = make(map[string]struct{})
+	}
+	s.attemptedProviders[host] = struct{}{}
+}
+
+func (s *Session) RecordAttemptedProviderHosts(hosts []string) {
+	for _, host := range hosts {
+		s.RecordAttemptedProviderHost(host)
+	}
+}
+
 func (s *Session) RecordUsedProviderHost(host string) {
 	host = strings.TrimSpace(host)
 	if host == "" {
@@ -187,6 +221,10 @@ func (s *Session) RecordUsedProviderHost(host string) {
 	if s.usedProviders == nil {
 		s.usedProviders = make(map[string]struct{})
 	}
+	if s.attemptedProviders == nil {
+		s.attemptedProviders = make(map[string]struct{})
+	}
+	s.attemptedProviders[host] = struct{}{}
 	s.usedProviders[host] = struct{}{}
 }
 
@@ -245,6 +283,8 @@ func (f *sessionTrackingFetcher) FetchSegment(ctx context.Context, segment *nzb.
 	data, err := f.base.FetchSegment(ctx, segment, groups)
 	if err == nil {
 		f.record(data)
+	} else {
+		f.session.RecordAttemptedProviderHosts(pool.AttemptedProviderHosts(err))
 	}
 	return data, err
 }
@@ -260,6 +300,8 @@ func (f *sessionTrackingFetcher) FetchSegmentFirst(ctx context.Context, segment 
 	data, err := first.FetchSegmentFirst(ctx, segment, groups)
 	if err == nil {
 		f.record(data)
+	} else {
+		f.session.RecordAttemptedProviderHosts(pool.AttemptedProviderHosts(err))
 	}
 	return data, err
 }
@@ -273,7 +315,15 @@ func (f *sessionTrackingFetcherWithStat) StatSegment(ctx context.Context, messag
 	if f == nil || f.statter == nil {
 		return false, fmt.Errorf("segment statter unavailable")
 	}
-	return f.statter.StatSegment(ctx, messageID, groups)
+	exists, err := f.statter.StatSegment(ctx, messageID, groups)
+	if err != nil {
+		f.session.RecordAttemptedProviderHosts(pool.AttemptedProviderHosts(err))
+		return exists, err
+	}
+	if !exists && f.session != nil {
+		f.session.RecordAttemptedProviderHosts(f.session.ProviderHosts())
+	}
+	return exists, nil
 }
 
 func attachProviderTracking(session *Session, fetcher loader.SegmentFetcher) loader.SegmentFetcher {
@@ -1093,9 +1143,17 @@ func (m *Manager) DeleteSession(sessionID string) {
 }
 
 func (s *Session) Close() {
+	s.closeWithLogging(true, "")
+}
+
+func (s *Session) closeWithLogging(debugLog bool, reason string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	logger.Debug("session Close", "id", s.ID)
+	if debugLog {
+		logger.Debug("session Close", "id", s.ID)
+	} else {
+		logger.Trace("session Close", "id", s.ID, "reason", reason)
+	}
 	if s.cancel != nil {
 		s.cancel()
 		s.cancel = nil
@@ -1151,6 +1209,9 @@ func (m *Manager) cleanup() {
 	now := time.Now()
 	var toClose []*Session
 	var closedIDs []string
+	var idleEvictions int
+	var postPlaybackEvictions int
+	var stuckPlaybackEvictions int
 	for id, session := range m.sessions {
 		session.mu.Lock()
 		// Evict stale Clients entries before computing hasActivePlayback.
@@ -1169,6 +1230,14 @@ func (m *Manager) cleanup() {
 			delete(m.sessions, id)
 			toClose = append(toClose, session)
 			closedIDs = append(closedIDs, id)
+			switch {
+			case evictStuckPlayback:
+				stuckPlaybackEvictions++
+			case evictPostPlayback:
+				postPlaybackEvictions++
+			default:
+				idleEvictions++
+			}
 		}
 		session.mu.Unlock()
 	}
@@ -1176,11 +1245,19 @@ func (m *Manager) cleanup() {
 	m.mu.Unlock()
 
 	for _, s := range toClose {
-		logger.Debug("session cleanup evicting", "id", s.ID)
-		s.Close()
+		s.closeWithLogging(false, "cleanup")
+	}
+	if len(toClose) > 0 {
+		logger.Debug(
+			"session cleanup evicted sessions",
+			"count", len(toClose),
+			"idle", idleEvictions,
+			"post_playback", postPlaybackEvictions,
+			"stuck_playback", stuckPlaybackEvictions,
+			"purge_segment_cache", shouldPurgeCache,
+		)
 	}
 	if shouldPurgeCache {
-		logger.Debug("session cleanup: no sessions with active files, purging segment cache")
 		m.usenetPool.PurgeCache()
 	}
 	if len(toClose) > 0 {

--- a/pkg/session/manager.go
+++ b/pkg/session/manager.go
@@ -206,8 +206,41 @@ func (s *Session) RecordAttemptedProviderHost(host string) {
 }
 
 func (s *Session) RecordAttemptedProviderHosts(hosts []string) {
+	if len(hosts) == 0 {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.attemptedProviders == nil {
+		s.attemptedProviders = make(map[string]struct{})
+	}
 	for _, host := range hosts {
-		s.RecordAttemptedProviderHost(host)
+		host = strings.TrimSpace(host)
+		if host == "" {
+			continue
+		}
+		s.attemptedProviders[host] = struct{}{}
+	}
+}
+
+func (s *Session) RecordConfiguredProviderHostsAttempted() {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.providerHosts) == 0 {
+		return
+	}
+	if s.attemptedProviders == nil {
+		s.attemptedProviders = make(map[string]struct{})
+	}
+	for _, host := range s.providerHosts {
+		host = strings.TrimSpace(host)
+		if host == "" {
+			continue
+		}
+		s.attemptedProviders[host] = struct{}{}
 	}
 }
 
@@ -321,7 +354,7 @@ func (f *sessionTrackingFetcherWithStat) StatSegment(ctx context.Context, messag
 		return exists, err
 	}
 	if !exists && f.session != nil {
-		f.session.RecordAttemptedProviderHosts(f.session.ProviderHosts())
+		f.session.RecordConfiguredProviderHostsAttempted()
 	}
 	return exists, nil
 }

--- a/pkg/usenet/nntp/client.go
+++ b/pkg/usenet/nntp/client.go
@@ -57,7 +57,7 @@ func NewClient(address string, port int, ssl bool) (*Client, error) {
 		return nil, err
 	}
 
-	logger.Debug("nntp NewClient connection opened", "addr", fullAddr)
+	logger.VerboseNNTP("nntp NewClient connection opened", "addr", fullAddr)
 	conn.SetDeadline(time.Now().Add(30 * time.Second))
 	tp := textproto.NewConn(conn)
 	if err = readGreeting(tp); err != nil {
@@ -288,7 +288,7 @@ func (c *Client) Reconnect() error {
 
 func (c *Client) Quit() error {
 	addr := net.JoinHostPort(c.host, strconv.Itoa(c.port))
-	logger.Debug("nntp Client Quit closing connection", "addr", addr)
+	logger.VerboseNNTP("nntp Client Quit closing connection", "addr", addr)
 	return c.conn.Close()
 }
 

--- a/pkg/usenet/nntp/pool.go
+++ b/pkg/usenet/nntp/pool.go
@@ -136,21 +136,21 @@ func (p *ClientPool) TotalMegabytes() float64 {
 }
 
 func (p *ClientPool) Get(ctx context.Context) (*Client, error) {
-	logger.Debug("nntp pool Get", "host", p.host)
+	logger.VerboseNNTP("nntp pool Get", "host", p.host)
 
 	select {
 	case <-ctx.Done():
-		logger.Trace("pool.Get ctx.Done (idle check)", "host", p.host)
+		logger.VerboseNNTP("pool.Get ctx.Done (idle check)", "host", p.host)
 		return nil, ctx.Err()
 	case c := <-p.idleClients:
-		logger.Debug("nntp pool Get from idle", "host", p.host)
+		logger.VerboseNNTP("nntp pool Get from idle", "host", p.host)
 		return c, nil
 	default:
 	}
 
 	select {
 	case <-ctx.Done():
-		logger.Trace("pool.Get ctx.Done (slot check)", "host", p.host)
+		logger.VerboseNNTP("pool.Get ctx.Done (slot check)", "host", p.host)
 		return nil, ctx.Err()
 	case <-p.slots:
 
@@ -165,20 +165,27 @@ func (p *ClientPool) Get(ctx context.Context) (*Client, error) {
 			p.slots <- struct{}{}
 			return nil, err
 		}
-		logger.Debug("nntp pool Get new client", "host", p.host)
+		logger.VerboseNNTP("nntp pool Get new client", "host", p.host)
 		return c, nil
 	default:
 	}
 
-	logger.Debug("nntp pool Get blocking", "host", p.host)
+	waitStarted := time.Now()
 	select {
 	case <-ctx.Done():
-		logger.Trace("pool.Get ctx.Done (blocking)", "host", p.host)
+		if wait := time.Since(waitStarted); wait >= 250*time.Millisecond {
+			logger.Debug("NNTP pool wait exceeded threshold", "host", p.host, "wait", wait, "result", "context_canceled")
+		}
+		logger.VerboseNNTP("pool.Get ctx.Done (blocking)", "host", p.host)
 		return nil, ctx.Err()
 	case c := <-p.idleClients:
-		logger.Debug("nntp pool Get from idle (after block)", "host", p.host)
+		if wait := time.Since(waitStarted); wait >= 250*time.Millisecond {
+			logger.Debug("NNTP pool wait exceeded threshold", "host", p.host, "wait", wait, "result", "idle_client")
+		}
+		logger.VerboseNNTP("nntp pool Get from idle (after block)", "host", p.host)
 		return c, nil
 	case <-p.slots:
+		wait := time.Since(waitStarted)
 
 		c, err := NewClient(p.host, p.port, p.ssl)
 		if err != nil {
@@ -191,7 +198,10 @@ func (p *ClientPool) Get(ctx context.Context) (*Client, error) {
 			p.slots <- struct{}{}
 			return nil, err
 		}
-		logger.Debug("nntp pool Get new client (after block)", "host", p.host)
+		if wait >= 250*time.Millisecond {
+			logger.Debug("NNTP pool wait exceeded threshold", "host", p.host, "wait", wait, "result", "new_client")
+		}
+		logger.VerboseNNTP("nntp pool Get new client (after block)", "host", p.host)
 		return c, nil
 	}
 }
@@ -240,7 +250,7 @@ func (p *ClientPool) Put(c *Client) {
 		return
 	}
 	c.LastUsed = time.Now()
-	logger.Trace("nntp pool Put", "host", p.host)
+	logger.VerboseNNTP("nntp pool Put", "host", p.host)
 
 	// Use stopCh as an extra guard: if Shutdown() fires in the window between
 	// reading closed==false above and reaching this select, the stopCh case
@@ -253,7 +263,7 @@ func (p *ClientPool) Put(c *Client) {
 		c.Quit()
 		p.slots <- struct{}{}
 	default:
-		logger.Trace("nntp pool Put idle full, closing connection", "host", p.host)
+		logger.VerboseNNTP("nntp pool Put idle full, closing connection", "host", p.host)
 		c.Quit()
 		p.slots <- struct{}{}
 	}
@@ -263,7 +273,7 @@ func (p *ClientPool) Discard(c *Client) {
 	if c == nil {
 		return
 	}
-	logger.Debug("nntp pool Discard connection not returned to pool", "host", p.host)
+	logger.VerboseNNTP("nntp pool Discard connection not returned to pool", "host", p.host)
 	c.Quit()
 	p.slots <- struct{}{}
 }

--- a/pkg/usenet/pool/pool.go
+++ b/pkg/usenet/pool/pool.go
@@ -36,7 +36,6 @@ var (
 )
 
 // isArticleNotFound reports whether err indicates 430 No Such Article (article missing on server).
-// On 430 we return immediately instead of trying other providers.
 func isArticleNotFound(err error) bool {
 	if err == nil {
 		return false
@@ -67,6 +66,68 @@ type Pool struct {
 	sf            *singleflight.Group
 	mu            sync.RWMutex
 	activeFetches atomic.Int64
+}
+
+type attemptedProvidersError struct {
+	err   error
+	hosts []string
+}
+
+func (e *attemptedProvidersError) Error() string {
+	if e == nil || e.err == nil {
+		return ""
+	}
+	return e.err.Error()
+}
+
+func (e *attemptedProvidersError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.err
+}
+
+// AttemptedProviderHosts returns the provider hosts that were actually attempted before err was returned.
+func AttemptedProviderHosts(err error) []string {
+	var attemptedErr *attemptedProvidersError
+	if !errors.As(err, &attemptedErr) || attemptedErr == nil || len(attemptedErr.hosts) == 0 {
+		return nil
+	}
+	return append([]string(nil), attemptedErr.hosts...)
+}
+
+func wrapAttemptedProviders(err error, hosts []string) error {
+	if err == nil {
+		return nil
+	}
+	hosts = appendUniqueHosts(nil, hosts...)
+	if len(hosts) == 0 {
+		return err
+	}
+	return &attemptedProvidersError{
+		err:   err,
+		hosts: hosts,
+	}
+}
+
+func appendUniqueHosts(dst []string, hosts ...string) []string {
+	for _, host := range hosts {
+		host = strings.TrimSpace(host)
+		if host == "" {
+			continue
+		}
+		exists := false
+		for _, existing := range dst {
+			if existing == host {
+				exists = true
+				break
+			}
+		}
+		if !exists {
+			dst = append(dst, host)
+		}
+	}
+	return dst
 }
 
 type PoolProviderTraceSnapshot struct {
@@ -179,6 +240,7 @@ func (p *Pool) FetchSegmentFirst(ctx context.Context, segment *nzb.Segment, grou
 	type segResult struct {
 		data SegmentData
 		err  error
+		host string
 	}
 	ch := make(chan segResult, len(providers))
 
@@ -195,6 +257,7 @@ func (p *Pool) FetchSegmentFirst(ctx context.Context, segment *nzb.Segment, grou
 				ch <- segResult{err: err}
 				return
 			}
+			host := p.Host(providerID)
 			p.activeFetches.Add(1)
 			defer p.activeFetches.Add(-1)
 
@@ -216,14 +279,14 @@ func (p *Pool) FetchSegmentFirst(ctx context.Context, segment *nzb.Segment, grou
 			if len(groups) > 0 {
 				if err := conn.Group(groups[0]); err != nil {
 					logger.Debug("fetch segment group failed", "provider", providerID, "err", err)
-					ch <- segResult{err: err}
+					ch <- segResult{err: err, host: host}
 					return
 				}
 			}
 			r, err := conn.Body(messageID)
 			if err != nil {
 				logger.Debug("fetch segment body failed", "provider", providerID, "err", err)
-				ch <- segResult{err: err}
+				ch <- segResult{err: err, host: host}
 				return
 			}
 			cr := &countReader{Reader: r}
@@ -232,20 +295,24 @@ func (p *Pool) FetchSegmentFirst(ctx context.Context, segment *nzb.Segment, grou
 			r.Close()
 			if err != nil {
 				logger.Debug("fetch segment decode failed", "provider", providerID, "err", err)
-				ch <- segResult{err: err}
+				ch <- segResult{err: err, host: host}
 				return
 			}
 			ch <- segResult{data: SegmentData{
 				Body:         frame.Data,
 				Size:         int64(len(frame.Data)),
-				ProviderHost: p.Host(providerID),
+				ProviderHost: host,
 			}}
 		}(exclude)
 	}
 
 	var lastErr error
+	var attempted []string
+	var articleNotFoundErr error
+	sawNonArticleNotFound := false
 	for range providers {
 		res := <-ch
+		attempted = appendUniqueHosts(attempted, res.host)
 		if res.err == nil {
 			if !shouldCacheFetchedSegment(fetchCtx) {
 				cancel()
@@ -260,12 +327,18 @@ func (p *Pool) FetchSegmentFirst(ctx context.Context, segment *nzb.Segment, grou
 		}
 		lastErr = res.err
 		if isArticleNotFound(res.err) {
-			cancel()
-			return SegmentData{}, fmt.Errorf("fetch segment %s: %w", messageID, res.err)
+			if articleNotFoundErr == nil {
+				articleNotFoundErr = res.err
+			}
+			continue
 		}
+		sawNonArticleNotFound = true
+	}
+	if articleNotFoundErr != nil && !sawNonArticleNotFound {
+		return SegmentData{}, wrapAttemptedProviders(fmt.Errorf("fetch segment %s: %w", messageID, articleNotFoundErr), attempted)
 	}
 	if lastErr != nil {
-		return SegmentData{}, fmt.Errorf("fetch segment %s: failed after retries: %w", messageID, lastErr)
+		return SegmentData{}, wrapAttemptedProviders(fmt.Errorf("fetch segment %s: failed after retries: %w", messageID, lastErr), attempted)
 	}
 	return SegmentData{}, fmt.Errorf("fetch segment %s: failed after retries", messageID)
 }
@@ -279,17 +352,33 @@ func (p *Pool) fetchSegmentOnce(ctx context.Context, messageID string, segment *
 	fetchCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
 	defer cancel()
 
+	p.mu.RLock()
+	providerCount := len(p.providers)
+	p.mu.RUnlock()
+
 	var exclude []string
 	var lastErr error
-	for attempt := 0; attempt < 3; attempt++ {
+	var attempted []string
+	var articleNotFoundErr error
+	sawNonArticleNotFound := false
+	maxAttempts := providerCount
+	if maxAttempts < 3 {
+		maxAttempts = 3
+	}
+	for attempt := 0; attempt < maxAttempts; attempt++ {
 		conn, release, discard, providerID, err := p.getConnection(fetchCtx, exclude, 999, false)
 		if err != nil {
 			if errors.Is(err, ErrNoProvidersAvailable) && len(exclude) > 0 {
+				if articleNotFoundErr != nil && !sawNonArticleNotFound && providerCount > 0 && len(exclude) >= providerCount {
+					break
+				}
 				exclude = nil
 				continue
 			}
 			return SegmentData{}, err
 		}
+		host := p.Host(providerID)
+		attempted = appendUniqueHosts(attempted, host)
 
 		data, articleNotFound, err := func() (SegmentData, bool, error) {
 			p.activeFetches.Add(1)
@@ -340,13 +429,17 @@ func (p *Pool) fetchSegmentOnce(ctx context.Context, messageID string, segment *
 			return SegmentData{
 				Body:         frame.Data,
 				Size:         int64(len(frame.Data)),
-				ProviderHost: p.Host(providerID),
+				ProviderHost: host,
 			}, false, nil
 		}()
 		if err != nil {
 			lastErr = err
 			if articleNotFound {
-				return SegmentData{}, fmt.Errorf("fetch segment %s: %w", messageID, err)
+				if articleNotFoundErr == nil {
+					articleNotFoundErr = err
+				}
+			} else {
+				sawNonArticleNotFound = true
 			}
 			exclude = append(exclude, providerID)
 			continue
@@ -362,8 +455,11 @@ func (p *Pool) fetchSegmentOnce(ctx context.Context, messageID string, segment *
 		return data, nil
 	}
 
+	if articleNotFoundErr != nil && !sawNonArticleNotFound {
+		return SegmentData{}, wrapAttemptedProviders(fmt.Errorf("fetch segment %s: %w", messageID, articleNotFoundErr), attempted)
+	}
 	if lastErr != nil {
-		return SegmentData{}, fmt.Errorf("fetch segment %s: failed after retries: %w", messageID, lastErr)
+		return SegmentData{}, wrapAttemptedProviders(fmt.Errorf("fetch segment %s: failed after retries: %w", messageID, lastErr), attempted)
 	}
 	return SegmentData{}, fmt.Errorf("fetch segment %s: failed after retries", messageID)
 }
@@ -392,6 +488,7 @@ func (p *Pool) StatSegment(ctx context.Context, messageID string, groups []strin
 	type statResult struct {
 		exists bool
 		err    error
+		host   string
 	}
 	ch := make(chan statResult, len(providers))
 
@@ -408,6 +505,7 @@ func (p *Pool) StatSegment(ctx context.Context, messageID string, groups []strin
 				ch <- statResult{err: getErr}
 				return
 			}
+			host := p.Host(providerID)
 
 			// Watchdog: if the context is cancelled while we are waiting for
 			// StatArticle (or Group), call discard() so the connection is closed
@@ -437,7 +535,7 @@ func (p *Pool) StatSegment(ctx context.Context, messageID string, groups []strin
 					logger.Debug("stat segment group failed", "provider", providerID, "err", groupErr)
 					doRelease = false
 					discard()
-					ch <- statResult{err: groupErr}
+					ch <- statResult{err: groupErr, host: host}
 					return
 				}
 			}
@@ -446,16 +544,18 @@ func (p *Pool) StatSegment(ctx context.Context, messageID string, groups []strin
 				logger.Debug("stat segment failed", "provider", providerID, "err", statErr)
 				doRelease = false
 				discard()
-				ch <- statResult{err: statErr}
+				ch <- statResult{err: statErr, host: host}
 				return
 			}
-			ch <- statResult{exists: exists}
+			ch <- statResult{exists: exists, host: host}
 		}(exclude)
 	}
 
 	var lastErr error
+	var attempted []string
 	for range providers {
 		res := <-ch
+		attempted = appendUniqueHosts(attempted, res.host)
 		if res.err == nil && res.exists {
 			cancel()
 			logger.Trace("stat segment ok", "message_id", messageID)
@@ -469,7 +569,7 @@ func (p *Pool) StatSegment(ctx context.Context, messageID string, groups []strin
 		}
 	}
 	if lastErr != nil {
-		return false, fmt.Errorf("stat segment %s: %w", messageID, lastErr)
+		return false, wrapAttemptedProviders(fmt.Errorf("stat segment %s: %w", messageID, lastErr), attempted)
 	}
 	logger.Trace("stat segment not found (430)", "message_id", messageID)
 	return false, nil
@@ -542,7 +642,7 @@ func (p *Pool) DiscardConnection(client *nntp.Client, pool *nntp.ClientPool) {
 // Call when no sessions are active so the GC can reclaim the segment memory.
 func (p *Pool) PurgeCache() {
 	p.cache.Purge()
-	logger.Debug("pool PurgeCache: segment cache purged")
+	logger.Trace("pool PurgeCache: segment cache purged")
 }
 
 func (p *Pool) TraceSnapshot() PoolTraceSnapshot {


### PR DESCRIPTION
## Summary
- refine playback failover and AvailNZB reporting so bad/good outcomes, attempted providers, and startup-timeout behavior line up better with real playback
- keep failover on the cached candidate list instead of rebuilding search state, and update cached bad-release state in place when Avail reporting succeeds
- report good attempts as soon as the configured threshold is reached, improve startup/archive timeout handling, and add a dedicated playback startup timeout setting under Advanced
- reduce noisy session cleanup and NNTP logging, add a verbose NNTP logging toggle, and avoid repeated Avail status lookups in Settings
- fix AvailNZB re-enablement without restart and clean up related settings and small-screen UI issues

## Details
- use attempted providers for relevant bad reporting/history cases instead of falling back to every provider configured on the stream
- keep segment-unavailable failures skipped for AvailNZB, but surface explicit skipped reasons in NZB history
- try additional stream-priority providers on mid-stream `430` segment errors before failing over to the next release
- preserve cached playlist/raw-search state across playback failover and update in-memory availability state after successful bad reporting
- make archive/open startup work respect the existing playback startup timeout much more consistently
- move playback startup timeout to its own Advanced playback card
- add an Advanced toggle for verbose NNTP logging instead of overloading the normal log levels

## Testing
- `go test ./pkg/core/config ./pkg/core/logger ./pkg/media/unpack ./pkg/media/loader ./pkg/server/api ./pkg/server/stremio ./pkg/services/availnzb ./pkg/session ./pkg/usenet/nntp ./pkg/usenet/pool`
- `./frontend/node_modules/.bin/vite build`

##Issues
- Fixes #117 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable playback startup timeout setting (1-60 seconds).
  * Added verbose NNTP logging toggle for detailed connection diagnostics.
  * Improved AvailNZB status management with persistent key storage and automatic registration.
  
* **Improvements**
  * Enhanced cache invalidation with more precise release availability tracking.
  * Better handling of provider selection during failure reporting.
  * Improved context propagation for cancellation support during media operations.

* **Bug Fixes**
  * Fixed playback startup timeout application and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->