### PR TITLE
feat(metadata): improve anime title resolution and validation

### DIFF
--- a/pkg/indexer/newznab/client.go
+++ b/pkg/indexer/newznab/client.go
@@ -419,14 +419,14 @@ func normalizeIMDbID(id string) string {
 
 func supportsMovieIDParam(caps *indexer.Caps, param string) bool {
 	if caps == nil || len(caps.Searching.MovieSearchSupportedParams) == 0 {
-		return param == "imdbid"
+		return param == "imdbid" || param == "tmdbid"
 	}
 	return caps.Searching.MovieSearchSupportedParams[param]
 }
 
 func supportsTVIDParam(caps *indexer.Caps, param string) bool {
 	if caps == nil || len(caps.Searching.TVSearchSupportedParams) == 0 {
-		return param == "tvdbid"
+		return param == "tvdbid" || param == "tmdbid" || param == "imdbid"
 	}
 	return caps.Searching.TVSearchSupportedParams[param]
 }

--- a/pkg/indexer/newznab/client_test.go
+++ b/pkg/indexer/newznab/client_test.go
@@ -693,6 +693,82 @@ func TestSearchMovieIDModeUsesTMDBIDWhenCapsSupportIt(t *testing.T) {
 	}
 }
 
+func TestSearchMovieIDModeUsesTMDBIDWithoutCaps(t *testing.T) {
+	var gotQuery url.Values
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		gotQuery = r.URL.Query()
+		w.Header().Set("Content-Type", "application/xml")
+		fmt.Fprint(w, `<?xml version="1.0" encoding="UTF-8"?><rss version="2.0"><channel></channel></rss>`)
+	}))
+	defer server.Close()
+
+	client := NewClient(config.IndexerConfig{
+		Name:   "MockIndexer",
+		URL:    server.URL,
+		APIKey: "test-api-key",
+	}, nil)
+
+	_, err := client.Search(indexer.SearchRequest{
+		Cat:        "2000",
+		TMDBID:     "83533",
+		SearchMode: "id",
+	})
+	if err != nil {
+		t.Fatalf("Search() error = %v", err)
+	}
+
+	if requests != 1 {
+		t.Fatalf("requests = %d, want 1", requests)
+	}
+	if got := gotQuery.Get("t"); got != "movie" {
+		t.Fatalf("t = %q, want %q", got, "movie")
+	}
+	if got := gotQuery.Get("tmdbid"); got != "83533" {
+		t.Fatalf("tmdbid = %q, want %q", got, "83533")
+	}
+}
+
+func TestSearchTVIDModeUsesTMDBIDWithoutCaps(t *testing.T) {
+	var gotQuery url.Values
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		gotQuery = r.URL.Query()
+		w.Header().Set("Content-Type", "application/xml")
+		fmt.Fprint(w, `<?xml version="1.0" encoding="UTF-8"?><rss version="2.0"><channel></channel></rss>`)
+	}))
+	defer server.Close()
+
+	client := NewClient(config.IndexerConfig{
+		Name:   "MockIndexer",
+		URL:    server.URL,
+		APIKey: "test-api-key",
+	}, nil)
+
+	_, err := client.Search(indexer.SearchRequest{
+		Cat:               "5000",
+		TMDBID:            "250307",
+		Season:            "1",
+		SeriesSearchScope: config.SeriesSearchScopeSeason,
+		SearchMode:        "id",
+	})
+	if err != nil {
+		t.Fatalf("Search() error = %v", err)
+	}
+
+	if requests != 1 {
+		t.Fatalf("requests = %d, want 1", requests)
+	}
+	if got := gotQuery.Get("t"); got != "tvsearch" {
+		t.Fatalf("t = %q, want %q", got, "tvsearch")
+	}
+	if got := gotQuery.Get("tmdbid"); got != "250307" {
+		t.Fatalf("tmdbid = %q, want %q", got, "250307")
+	}
+}
+
 func TestSearchTVIDModeOmitsQueryWhenUsingTVSearchParams(t *testing.T) {
 	var gotQuery url.Values
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/search/parser/parser.go
+++ b/pkg/search/parser/parser.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -8,6 +9,8 @@ import (
 
 	"github.com/MunifTanjim/go-ptt"
 )
+
+var dashedSeasonEpisodePattern = regexp.MustCompile(`(?i)\bS(?:eason)?\s*0*([0-9]{1,2})\s*-\s*0*([0-9]{1,3})\b`)
 
 type ParsedRelease struct {
 	Title      string
@@ -117,8 +120,43 @@ func ParseReleaseTitle(title string) *ParsedRelease {
 	if len(parsed.Episodes) > 0 {
 		parsed.Episode = parsed.Episodes[0]
 	}
+	applyDashedSeasonEpisodeFallback(title, parsed)
 
 	return parsed
+}
+
+func applyDashedSeasonEpisodeFallback(rawTitle string, parsed *ParsedRelease) {
+	if parsed == nil {
+		return
+	}
+	matches := dashedSeasonEpisodePattern.FindStringSubmatch(rawTitle)
+	if len(matches) != 3 {
+		return
+	}
+	season, seasonErr := strconv.Atoi(matches[1])
+	episode, episodeErr := strconv.Atoi(matches[2])
+	if seasonErr != nil || episodeErr != nil || season <= 0 || episode <= 0 {
+		return
+	}
+	if !hasInt(parsed.Seasons, season) {
+		parsed.Seasons = append(parsed.Seasons, season)
+	}
+	if !hasInt(parsed.Episodes, episode) {
+		parsed.Episodes = append(parsed.Episodes, episode)
+	}
+	if parsed.Season == 0 {
+		parsed.Season = season
+	}
+	if parsed.Episode == 0 {
+		parsed.Episode = episode
+	}
+	if parsed.Title != "" {
+		cleanedTitle := strings.TrimSpace(dashedSeasonEpisodePattern.ReplaceAllString(parsed.Title, " "))
+		cleanedTitle = strings.Join(strings.Fields(cleanedTitle), " ")
+		if cleanedTitle != "" {
+			parsed.Title = cleanedTitle
+		}
+	}
 }
 
 func uniqueInts(values []int) []int {

--- a/pkg/search/parser/parser.go
+++ b/pkg/search/parser/parser.go
@@ -10,7 +10,7 @@ import (
 	"github.com/MunifTanjim/go-ptt"
 )
 
-var dashedSeasonEpisodePattern = regexp.MustCompile(`(?i)\bS(?:eason)?\s*0*([0-9]{1,2})\s*-\s*0*([0-9]{1,3})\b`)
+var dashedSeasonEpisodePattern = regexp.MustCompile(`(?i)\bS(?:eason)?\s*0*([0-9]{1,2})\s*-\s*0*([0-9]{1,3})(?:$|[\s._()[\]])`)
 
 type ParsedRelease struct {
 	Title      string
@@ -138,16 +138,16 @@ func applyDashedSeasonEpisodeFallback(rawTitle string, parsed *ParsedRelease) {
 	if seasonErr != nil || episodeErr != nil || season <= 0 || episode <= 0 {
 		return
 	}
-	if !hasInt(parsed.Seasons, season) {
-		parsed.Seasons = append(parsed.Seasons, season)
-	}
-	if !hasInt(parsed.Episodes, episode) {
-		parsed.Episodes = append(parsed.Episodes, episode)
-	}
 	if parsed.Season == 0 {
+		if !hasInt(parsed.Seasons, season) {
+			parsed.Seasons = append(parsed.Seasons, season)
+		}
 		parsed.Season = season
 	}
 	if parsed.Episode == 0 {
+		if !hasInt(parsed.Episodes, episode) {
+			parsed.Episodes = append(parsed.Episodes, episode)
+		}
 		parsed.Episode = episode
 	}
 	if parsed.Title != "" {

--- a/pkg/search/parser/parser_test.go
+++ b/pkg/search/parser/parser_test.go
@@ -1,6 +1,9 @@
 package parser
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestParseReleaseTitleRetainsEpisodeCollections(t *testing.T) {
 	parsed := ParseReleaseTitle("The.Walking.Dead.S01E05E06.1080p.WEB-DL")
@@ -40,5 +43,27 @@ func TestParsedReleaseEpisodeMatchRank(t *testing.T) {
 				t.Fatalf("EpisodeMatchRank() = %d, want %d", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestParseReleaseTitleRecognizesDashedSeasonEpisodePattern(t *testing.T) {
+	parsed := ParseReleaseTitle("[SubsPlease] Tensei Shitara Slime Datta Ken S4 - 03 (720p) [370B1C65]")
+	if parsed == nil {
+		t.Fatal("expected parsed release")
+	}
+	if parsed.Season != 4 {
+		t.Fatalf("expected season 4, got %d", parsed.Season)
+	}
+	if parsed.Episode != 3 {
+		t.Fatalf("expected episode 3, got %d", parsed.Episode)
+	}
+	if !parsed.HasSeason(4) {
+		t.Fatal("expected parsed release to include season 4")
+	}
+	if !parsed.HasEpisode(3) {
+		t.Fatalf("expected parsed release to include episode 3, got %v", parsed.Episodes)
+	}
+	if strings.Contains(parsed.Title, "S4 - 03") {
+		t.Fatalf("expected parsed title to drop dashed season/episode suffix, got %q", parsed.Title)
 	}
 }

--- a/pkg/search/parser/parser_test.go
+++ b/pkg/search/parser/parser_test.go
@@ -67,3 +67,9 @@ func TestParseReleaseTitleRecognizesDashedSeasonEpisodePattern(t *testing.T) {
 		t.Fatalf("expected parsed title to drop dashed season/episode suffix, got %q", parsed.Title)
 	}
 }
+
+func TestDashedSeasonEpisodePatternDoesNotFalseMatchInsideLongerToken(t *testing.T) {
+	if matches := dashedSeasonEpisodePattern.FindStringSubmatch("Example.Show.S1 - 24bit.1080p.WEB-DL"); len(matches) != 0 {
+		t.Fatalf("expected no regex match inside longer token, got %v", matches)
+	}
+}

--- a/pkg/search/search_test.go
+++ b/pkg/search/search_test.go
@@ -212,6 +212,24 @@ func TestValidateSearchResultsWithStatsAllowsOptionalAndWordMatches(t *testing.T
 	}
 }
 
+func TestValidateSearchResultsWithStatsAllowsDashedSeasonEpisodePattern(t *testing.T) {
+	releases := []*release.Release{
+		{Title: "[SubsPlease] Tensei Shitara Slime Datta Ken S4 - 03 (720p) [370B1C65]"},
+	}
+
+	filtered, stats := ValidateSearchResultsWithStats(releases, "series", "Tensei shitara Slime Datta Ken", "4", "3", true, false)
+
+	if len(filtered) != 1 {
+		t.Fatalf("expected dashed season/episode title to pass, got %d results", len(filtered))
+	}
+	if stats.DroppedEpisodeRequest != 0 || stats.DroppedTitle != 0 {
+		t.Fatalf("expected no rejection for dashed season/episode pattern, got %+v", stats)
+	}
+	if stats.AcceptedExactEpisode != 1 {
+		t.Fatalf("expected exact episode match, got %+v", stats)
+	}
+}
+
 func TestValidateSearchResultsWithStatsRejectsExtraTrailingTitleWords(t *testing.T) {
 	releases := []*release.Release{
 		{Title: "The.Rookie.Feds.S01E01.1080p.WEB-DL.x264-GROUP"},

--- a/pkg/server/stremio/handlers_search.go
+++ b/pkg/server/stremio/handlers_search.go
@@ -91,7 +91,7 @@ func metadataAlternativeTitle(metadata *resolvedSearchMetadata, contentType stri
 		return ""
 	}
 	if contentType == "movie" {
-		if metadata.MovieDetails == nil || !strings.EqualFold(strings.TrimSpace(metadata.MovieDetails.OriginalLanguage), "ja") {
+		if metadata.MovieDetails == nil || metadata.MovieAlternativeTitles == nil || !strings.EqualFold(strings.TrimSpace(metadata.MovieDetails.OriginalLanguage), "ja") {
 			return ""
 		}
 		if alt := pickRomanizedAlternativeTitle(metadata.MovieAlternativeTitles.Titles); alt != "" && !strings.EqualFold(strings.TrimSpace(alt), original) {
@@ -99,7 +99,7 @@ func metadataAlternativeTitle(metadata *resolvedSearchMetadata, contentType stri
 		}
 		return ""
 	}
-	if metadata.TVDetails == nil || !strings.EqualFold(strings.TrimSpace(metadata.TVDetails.OriginalLanguage), "ja") {
+	if metadata.TVDetails == nil || metadata.TVAlternativeTitles == nil || !strings.EqualFold(strings.TrimSpace(metadata.TVDetails.OriginalLanguage), "ja") {
 		return ""
 	}
 	if alt := pickRomanizedAlternativeTitle(metadata.TVAlternativeTitles.Results); alt != "" && !strings.EqualFold(strings.TrimSpace(alt), original) {

--- a/pkg/server/stremio/handlers_search.go
+++ b/pkg/server/stremio/handlers_search.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"unicode"
 
 	"streamnzb/pkg/auth"
 	"streamnzb/pkg/core/config"
@@ -32,10 +33,12 @@ type SearchParams struct {
 }
 
 type resolvedSearchMetadata struct {
-	MovieDetails      *tmdb.MovieDetails
-	MovieTranslations *tmdb.MovieTranslationsResponse
-	TVDetails         *tmdb.TVDetails
-	TVTranslations    *tmdb.TVTranslationsResponse
+	MovieDetails           *tmdb.MovieDetails
+	MovieTranslations      *tmdb.MovieTranslationsResponse
+	MovieAlternativeTitles *tmdb.MovieAlternativeTitlesResponse
+	TVDetails              *tmdb.TVDetails
+	TVTranslations         *tmdb.TVTranslationsResponse
+	TVAlternativeTitles    *tmdb.TVAlternativeTitlesResponse
 }
 
 func metadataDisplayTitle(metadata *resolvedSearchMetadata, contentType string) string {
@@ -56,6 +59,51 @@ func metadataDisplayTitle(metadata *resolvedSearchMetadata, contentType string) 
 			return title
 		}
 		return strings.TrimSpace(metadata.TVDetails.OriginalName)
+	}
+	return ""
+}
+
+func metadataOriginalTitle(metadata *resolvedSearchMetadata, contentType string) string {
+	if metadata == nil {
+		return ""
+	}
+	if contentType == "movie" {
+		if metadata.MovieDetails != nil {
+			if title := strings.TrimSpace(metadata.MovieDetails.OriginalTitle); title != "" {
+				return title
+			}
+			return strings.TrimSpace(metadata.MovieDetails.Title)
+		}
+		return ""
+	}
+	if metadata.TVDetails != nil {
+		if title := strings.TrimSpace(metadata.TVDetails.OriginalName); title != "" {
+			return title
+		}
+		return strings.TrimSpace(metadata.TVDetails.Name)
+	}
+	return ""
+}
+
+func metadataAlternativeTitle(metadata *resolvedSearchMetadata, contentType string) string {
+	original := strings.TrimSpace(metadataOriginalTitle(metadata, contentType))
+	if metadata == nil || original == "" {
+		return ""
+	}
+	if contentType == "movie" {
+		if metadata.MovieDetails == nil || !strings.EqualFold(strings.TrimSpace(metadata.MovieDetails.OriginalLanguage), "ja") {
+			return ""
+		}
+		if alt := pickRomanizedAlternativeTitle(metadata.MovieAlternativeTitles.Titles); alt != "" && !strings.EqualFold(strings.TrimSpace(alt), original) {
+			return strings.TrimSpace(alt)
+		}
+		return ""
+	}
+	if metadata.TVDetails == nil || !strings.EqualFold(strings.TrimSpace(metadata.TVDetails.OriginalLanguage), "ja") {
+		return ""
+	}
+	if alt := pickRomanizedAlternativeTitle(metadata.TVAlternativeTitles.Results); alt != "" && !strings.EqualFold(strings.TrimSpace(alt), original) {
+		return strings.TrimSpace(alt)
 	}
 	return ""
 }
@@ -125,6 +173,72 @@ func localizedMovieTitleForLanguage(translations *tmdb.MovieTranslationsResponse
 		}
 	}
 	return ""
+}
+
+func hasLatinLetter(s string) bool {
+	for _, r := range s {
+		if unicode.In(r, unicode.Latin) && unicode.IsLetter(r) {
+			return true
+		}
+	}
+	return false
+}
+
+func pickRomanizedAlternativeTitle(alternatives []tmdb.AlternativeTitle) string {
+	for _, alt := range alternatives {
+		title := strings.TrimSpace(alt.Title)
+		if title == "" || !hasLatinLetter(title) {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(alt.Type), "Romaji") {
+			return title
+		}
+	}
+	return ""
+}
+
+func preferredMovieOriginalTitle(metadata *resolvedSearchMetadata) string {
+	if metadata == nil || metadata.MovieDetails == nil {
+		return ""
+	}
+	title := strings.TrimSpace(metadata.MovieDetails.OriginalTitle)
+	if title == "" {
+		title = strings.TrimSpace(metadata.MovieDetails.Title)
+	}
+	if title == "" {
+		return ""
+	}
+	if !strings.EqualFold(strings.TrimSpace(metadata.MovieDetails.OriginalLanguage), "ja") || hasLatinLetter(title) {
+		return title
+	}
+	if metadata.MovieAlternativeTitles != nil {
+		if alt := pickRomanizedAlternativeTitle(metadata.MovieAlternativeTitles.Titles); alt != "" {
+			return alt
+		}
+	}
+	return title
+}
+
+func preferredSeriesOriginalTitle(metadata *resolvedSearchMetadata) string {
+	if metadata == nil || metadata.TVDetails == nil {
+		return ""
+	}
+	title := strings.TrimSpace(metadata.TVDetails.OriginalName)
+	if title == "" {
+		title = strings.TrimSpace(metadata.TVDetails.Name)
+	}
+	if title == "" {
+		return ""
+	}
+	if !strings.EqualFold(strings.TrimSpace(metadata.TVDetails.OriginalLanguage), "ja") || hasLatinLetter(title) {
+		return title
+	}
+	if metadata.TVAlternativeTitles != nil {
+		if alt := pickRomanizedAlternativeTitle(metadata.TVAlternativeTitles.Results); alt != "" {
+			return alt
+		}
+	}
+	return title
 }
 
 func localizedTVTitleForLanguage(translations *tmdb.TVTranslationsResponse, language string) string {
@@ -205,7 +319,7 @@ func buildMovieSearchQueryFromMetadata(metadata *resolvedSearchMetadata, languag
 	}
 	title := strings.TrimSpace(metadata.MovieDetails.Title)
 	if useOriginalTitleLanguage(language) {
-		title = strings.TrimSpace(metadata.MovieDetails.OriginalTitle)
+		title = preferredMovieOriginalTitle(metadata)
 	} else if localized := localizedMovieTitleForLanguage(metadata.MovieTranslations, language); localized != "" {
 		title = localized
 	}
@@ -252,17 +366,7 @@ func buildMovieValidationQueryFromMetadata(metadata *resolvedSearchMetadata, lan
 }
 
 func buildMovieOriginalQueryFromMetadata(metadata *resolvedSearchMetadata) string {
-	if metadata == nil || metadata.MovieDetails == nil {
-		return ""
-	}
-	title := strings.TrimSpace(metadata.MovieDetails.OriginalTitle)
-	if title == "" {
-		title = strings.TrimSpace(metadata.MovieDetails.Title)
-	}
-	if title == "" {
-		return ""
-	}
-	return title
+	return strings.TrimSpace(preferredMovieOriginalTitle(metadata))
 }
 
 func appendSeasonQuery(query, season string) string {
@@ -303,7 +407,7 @@ func buildSeriesSearchTitleFromMetadata(metadata *resolvedSearchMetadata, langua
 	}
 	title := strings.TrimSpace(metadata.TVDetails.Name)
 	if useOriginalTitleLanguage(language) {
-		title = strings.TrimSpace(metadata.TVDetails.OriginalName)
+		title = preferredSeriesOriginalTitle(metadata)
 	} else if localized := localizedTVTitleForLanguage(metadata.TVTranslations, language); localized != "" {
 		title = localized
 	}
@@ -335,17 +439,7 @@ func buildSeriesValidationQueryFromMetadata(metadata *resolvedSearchMetadata, la
 }
 
 func buildSeriesOriginalQueryFromMetadata(metadata *resolvedSearchMetadata) string {
-	if metadata == nil || metadata.TVDetails == nil {
-		return ""
-	}
-	title := strings.TrimSpace(metadata.TVDetails.OriginalName)
-	if title == "" {
-		title = strings.TrimSpace(metadata.TVDetails.Name)
-	}
-	if title == "" {
-		return ""
-	}
-	return title
+	return strings.TrimSpace(preferredSeriesOriginalTitle(metadata))
 }
 
 func searchRequestNormalisationLogValues(metadata *resolvedSearchMetadata, contentType, language string, includeYear bool, season, episode, scope string) (string, string, string, bool) {
@@ -428,15 +522,19 @@ func logMetadataLookup(streamLabel, contentType, id string) {
 }
 
 func logMetadataLookupFinished(streamLabel, contentType, id string, params *SearchParams) {
+	originalTitle := metadataOriginalTitle(params.Metadata, contentType)
 	attrs := []any{
 		"stream", streamLabel,
 		"type", contentType,
 		"id", id,
 		"imdb_id", params.ContentIDs.ImdbID,
 		"tmdb_id", params.Req.TMDBID,
-		"title", metadataDisplayTitle(params.Metadata, contentType),
+		"original_title", originalTitle,
 		"year", metadataDisplayYear(params.Metadata, contentType),
 		"languages", metadataLanguageCount(params.Metadata, contentType),
+	}
+	if alternativeTitle := metadataAlternativeTitle(params.Metadata, contentType); alternativeTitle != "" {
+		attrs = append(attrs, "alternative_title", alternativeTitle)
 	}
 	if contentType == "series" {
 		attrs = append(attrs,
@@ -928,6 +1026,9 @@ func (s *Server) buildSearchParamsBase(contentType, id string, searchQuery *conf
 				} else {
 					logMetadataResolutionState(contentType, id, "tmdb_series_translations", "tmdb_id", req.TMDBID, "status", "failed", "err", err)
 				}
+				if alternatives, err := s.tmdbClient.GetTVAlternativeTitles(tmdbIDNum); err == nil {
+					params.Metadata.TVAlternativeTitles = alternatives
+				}
 				if extIDs, err := s.tmdbClient.GetExternalIDs(tmdbIDNum, "tv"); err == nil {
 					if extIDs.TVDBID != 0 {
 						req.TVDBID = strconv.Itoa(extIDs.TVDBID)
@@ -982,6 +1083,9 @@ func (s *Server) buildSearchParamsBase(contentType, id string, searchQuery *conf
 			}
 			if translations, err := s.tmdbClient.GetMovieTranslations(tmdbIDNum); err == nil {
 				params.Metadata.MovieTranslations = translations
+			}
+			if alternatives, err := s.tmdbClient.GetMovieAlternativeTitles(tmdbIDNum); err == nil {
+				params.Metadata.MovieAlternativeTitles = alternatives
 			}
 			if extIDs, err := s.tmdbClient.GetExternalIDs(tmdbIDNum, "movie"); err == nil && extIDs.IMDbID != "" && contentIDs.ImdbID == "" {
 				contentIDs.ImdbID = extIDs.IMDbID

--- a/pkg/server/stremio/handlers_search_test.go
+++ b/pkg/server/stremio/handlers_search_test.go
@@ -99,6 +99,36 @@ func TestMetadataLogTitlesDoNotAddAlternativeForNonJapaneseOriginals(t *testing.
 	}
 }
 
+func TestMetadataLogTitlesHandleMissingJapaneseAlternativeTitles(t *testing.T) {
+	metadata := &resolvedSearchMetadata{
+		MovieDetails: &tmdb.MovieDetails{
+			Title:            "Spirited Away",
+			OriginalTitle:    "千と千尋の神隠し",
+			OriginalLanguage: "ja",
+		},
+	}
+
+	if got := metadataAlternativeTitle(metadata, "movie"); got != "" {
+		t.Fatalf("metadataAlternativeTitle() = %q, want empty", got)
+	}
+
+	params := &SearchParams{
+		Req: indexer.SearchRequest{TMDBID: "129"},
+		ContentIDs: &session.AvailReportMeta{
+			ImdbID: "tt0245429",
+		},
+		Metadata: metadata,
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("logMetadataLookupFinished() panicked: %v", r)
+		}
+	}()
+
+	logMetadataLookupFinished("Stream01", "movie", "tt0245429", params)
+}
+
 func TestBuildMovieQueriesFromMetadataAddsGermanTransliterationVariant(t *testing.T) {
 	metadata := &resolvedSearchMetadata{
 		MovieDetails: &tmdb.MovieDetails{

--- a/pkg/server/stremio/handlers_search_test.go
+++ b/pkg/server/stremio/handlers_search_test.go
@@ -55,6 +55,50 @@ func TestBuildSeriesQueriesWithOptionsCanOmitYear(t *testing.T) {
 	}
 }
 
+func TestMetadataLogTitlesPreferOriginalAndJapaneseRomajiAlternative(t *testing.T) {
+	metadata := &resolvedSearchMetadata{
+		MovieDetails: &tmdb.MovieDetails{
+			Title:            "Spirited Away",
+			OriginalTitle:    "千と千尋の神隠し",
+			OriginalLanguage: "ja",
+		},
+		MovieAlternativeTitles: &tmdb.MovieAlternativeTitlesResponse{
+			Titles: []tmdb.AlternativeTitle{
+				{ISO3166_1: "JP", Title: "Sen to Chihiro no Kamikakushi", Type: "Romaji"},
+			},
+		},
+	}
+
+	if got := metadataOriginalTitle(metadata, "movie"); got != "千と千尋の神隠し" {
+		t.Fatalf("metadataOriginalTitle() = %q, want %q", got, "千と千尋の神隠し")
+	}
+	if got := metadataAlternativeTitle(metadata, "movie"); got != "Sen to Chihiro no Kamikakushi" {
+		t.Fatalf("metadataAlternativeTitle() = %q, want %q", got, "Sen to Chihiro no Kamikakushi")
+	}
+}
+
+func TestMetadataLogTitlesDoNotAddAlternativeForNonJapaneseOriginals(t *testing.T) {
+	metadata := &resolvedSearchMetadata{
+		MovieDetails: &tmdb.MovieDetails{
+			Title:            "The Lion King",
+			OriginalTitle:    "The Lion King",
+			OriginalLanguage: "en",
+		},
+		MovieAlternativeTitles: &tmdb.MovieAlternativeTitlesResponse{
+			Titles: []tmdb.AlternativeTitle{
+				{ISO3166_1: "US", Title: "Lion King", Type: "Working Title"},
+			},
+		},
+	}
+
+	if got := metadataOriginalTitle(metadata, "movie"); got != "The Lion King" {
+		t.Fatalf("metadataOriginalTitle() = %q, want %q", got, "The Lion King")
+	}
+	if got := metadataAlternativeTitle(metadata, "movie"); got != "" {
+		t.Fatalf("metadataAlternativeTitle() = %q, want empty", got)
+	}
+}
+
 func TestBuildMovieQueriesFromMetadataAddsGermanTransliterationVariant(t *testing.T) {
 	metadata := &resolvedSearchMetadata{
 		MovieDetails: &tmdb.MovieDetails{
@@ -107,6 +151,29 @@ func TestBuildMovieQueriesFromMetadataUsesOriginalTitleWhenRequested(t *testing.
 
 	got := buildMovieQueriesFromMetadata(metadata, "original", false)
 	want := []string{"Der Untergang"}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("buildMovieQueriesFromMetadata() = %#v, want %#v", got, want)
+	}
+}
+
+func TestBuildMovieQueriesFromMetadataUsesRomanizedJapaneseOriginalTitle(t *testing.T) {
+	metadata := &resolvedSearchMetadata{
+		MovieDetails: &tmdb.MovieDetails{
+			Title:            "Spirited Away",
+			OriginalTitle:    "千と千尋の神隠し",
+			OriginalLanguage: "ja",
+			ReleaseDate:      "2001-07-20",
+		},
+		MovieAlternativeTitles: &tmdb.MovieAlternativeTitlesResponse{
+			Titles: []tmdb.AlternativeTitle{
+				{ISO3166_1: "JP", Title: "Sen to Chihiro no Kamikakushi", Type: "Romaji"},
+			},
+		},
+	}
+
+	got := buildMovieQueriesFromMetadata(metadata, "original", false)
+	want := []string{"Sen to Chihiro no Kamikakushi"}
 
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("buildMovieQueriesFromMetadata() = %#v, want %#v", got, want)
@@ -168,6 +235,41 @@ func TestBuildSeriesQueriesFromMetadataUsesOriginalTitleWhenRequested(t *testing
 
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("buildSeriesQueriesFromMetadata() = %#v, want %#v", got, want)
+	}
+}
+
+func TestBuildSeriesQueriesFromMetadataUsesRomanizedJapaneseOriginalTitle(t *testing.T) {
+	metadata := &resolvedSearchMetadata{
+		TVDetails: &tmdb.TVDetails{
+			Name:             "Attack on Titan",
+			OriginalName:     "進撃の巨人",
+			OriginalLanguage: "ja",
+			FirstAirDate:     "2013-04-07",
+		},
+		TVAlternativeTitles: &tmdb.TVAlternativeTitlesResponse{
+			Results: []tmdb.AlternativeTitle{
+				{ISO3166_1: "JP", Title: "Shingeki no Kyojin", Type: "Romaji"},
+			},
+		},
+	}
+
+	got := buildSeriesQueriesFromMetadata(metadata, "original", false, "1", "2", config.SeriesSearchScopeSeasonEpisode)
+	want := []string{"Shingeki no Kyojin S01E02"}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("buildSeriesQueriesFromMetadata() = %#v, want %#v", got, want)
+	}
+}
+
+func TestPickRomanizedAlternativeTitleRequiresExactRomajiType(t *testing.T) {
+	alts := []tmdb.AlternativeTitle{
+		{ISO3166_1: "JP", Title: "TenSura", Type: "Romaji (Short)"},
+		{ISO3166_1: "JP", Title: "Tensei Shitara Slime Datta Ken 3rd Season", Type: "Romaji (Season 3)"},
+		{ISO3166_1: "JP", Title: "Tensei shitara Slime Datta Ken", Type: "Romaji"},
+	}
+
+	if got := pickRomanizedAlternativeTitle(alts); got != "Tensei shitara Slime Datta Ken" {
+		t.Fatalf("pickRomanizedAlternativeTitle() = %q, want %q", got, "Tensei shitara Slime Datta Ken")
 	}
 }
 

--- a/pkg/services/metadata/tmdb/client.go
+++ b/pkg/services/metadata/tmdb/client.go
@@ -88,6 +88,22 @@ type TVTranslationsResponse struct {
 	Translations []TVTranslationEntry `json:"translations"`
 }
 
+type AlternativeTitle struct {
+	ISO3166_1 string `json:"iso_3166_1"`
+	Title     string `json:"title"`
+	Type      string `json:"type"`
+}
+
+type MovieAlternativeTitlesResponse struct {
+	ID     int                `json:"id"`
+	Titles []AlternativeTitle `json:"titles"`
+}
+
+type TVAlternativeTitlesResponse struct {
+	ID      int                `json:"id"`
+	Results []AlternativeTitle `json:"results"`
+}
+
 type MovieTranslationEntry struct {
 	ISO639_1    string               `json:"iso_639_1"`
 	ISO3166_1   string               `json:"iso_3166_1"`
@@ -367,6 +383,26 @@ func (c *Client) GetMovieTranslations(movieID int) (*MovieTranslationsResponse, 
 	return &out, nil
 }
 
+func (c *Client) GetMovieAlternativeTitles(movieID int) (*MovieAlternativeTitlesResponse, error) {
+	if c.apiKey == "" {
+		return nil, fmt.Errorf("TMDB API key not configured")
+	}
+	endpoint := fmt.Sprintf("https://api.themoviedb.org/3/movie/%d/alternative_titles", movieID)
+	resp, err := c.doRequest(endpoint, url.Values{})
+	if err != nil {
+		return nil, fmt.Errorf("TMDB movie alternative titles: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("TMDB returned status: %d", resp.StatusCode)
+	}
+	var out MovieAlternativeTitlesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("TMDB alternative titles decode: %w", err)
+	}
+	return &out, nil
+}
+
 func movieTitleFromTranslations(translations *MovieTranslationsResponse, language string) string {
 	if translations == nil || language == "" {
 		return ""
@@ -509,6 +545,26 @@ func (c *Client) GetTVTranslations(tmdbID int) (*TVTranslationsResponse, error) 
 	var out TVTranslationsResponse
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 		return nil, fmt.Errorf("TMDB TV translations decode: %w", err)
+	}
+	return &out, nil
+}
+
+func (c *Client) GetTVAlternativeTitles(tmdbID int) (*TVAlternativeTitlesResponse, error) {
+	if c.apiKey == "" {
+		return nil, fmt.Errorf("TMDB API key not configured")
+	}
+	endpoint := fmt.Sprintf("https://api.themoviedb.org/3/tv/%d/alternative_titles", tmdbID)
+	resp, err := c.doRequest(endpoint, url.Values{})
+	if err != nil {
+		return nil, fmt.Errorf("TMDB TV alternative titles: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("TMDB returned status: %d", resp.StatusCode)
+	}
+	var out TVAlternativeTitlesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("TMDB alternative titles decode: %w", err)
 	}
 	return &out, nil
 }


### PR DESCRIPTION
## Summary
- improve metadata resolution and validation for anime and other title-language-sensitive searches
- add TMDB alternative-title support and prefer exact Romaji titles for Japanese originals when `Title language = original`
- tighten ID-search parameter selection against Newznab caps and improve parser coverage for anime episode naming patterns

## Highlights
- load TMDB alternative titles for movies and series in addition to details, translations, and external IDs
- for Japanese originals, only use a TMDB alternative title when its type is exactly `Romaji`; otherwise keep the original title
- keep other languages unchanged: the Romaji rule only applies to `original` + TMDB original language `ja`
- log resolved metadata more clearly with `original_title` and, when applicable, `alternative_title`
- allow Newznab movie ID searches to use `tmdbid` when supported, and TV ID searches to use `tvdbid`, `tmdbid`, or `imdbid` based on caps
- keep `search_mode=id` strict so movie requests stay `t=movie` and series requests stay `t=tvsearch`
- extend release parsing/validation so patterns like `S1 - 01` and `S4 - 03` are treated as season/episode matches
- preserve the merged search-validation UI/model from `#123` as the base while layering the anime metadata work on top

## Testing
- `go test ./pkg/indexer/newznab`
- `go test ./pkg/search/...`
- `go test ./pkg/server/stremio`
- `go test ./pkg/services/metadata/tmdb`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for parsing dashed season/episode format (e.g., S4 - 03)
  * Integrated alternative titles from TMDB, including Romanized alternatives for Japanese content
  * Enhanced title selection logic to prefer original and Romanized alternatives when available

* **Bug Fixes**
  * Improved fallback support for ID parameters when indexer capability data is unavailable

* **Tests**
  * Added test coverage for dashed season/episode parsing and Romanized Japanese title handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->