### PR TITLE
feat(search): add multilingual title validation

### DIFF
--- a/frontend/src/Settings.jsx
+++ b/frontend/src/Settings.jsx
@@ -33,6 +33,37 @@ function normalizeSeriesScopeFromLegacy(scope, legacyUseSeasonEpisodeParams) {
   return ''
 }
 
+function normalizeSearchTitleLanguage(value) {
+  const trimmed = String(value || '').trim()
+  return trimmed.toLowerCase() === 'original' ? '' : trimmed
+}
+
+function normalizeSearchTitleLanguages(values) {
+  const list = Array.isArray(values) ? values : []
+  const normalized = []
+  const seen = new Set()
+  for (const value of list) {
+    const language = normalizeSearchTitleLanguage(value)
+    const key = language.toLowerCase()
+    if (seen.has(key)) continue
+    seen.add(key)
+    normalized.push(language)
+  }
+  return normalized
+}
+
+function normalizeSearchQueryLanguages(query) {
+  const searchMode = String(query?.search_mode || '').trim().toLowerCase()
+  const searchTitleLanguage = normalizeSearchTitleLanguage(query?.search_title_language || '')
+  const searchTitleLanguages = normalizeSearchTitleLanguages(query?.search_title_languages)
+  if (searchMode === 'id') {
+    if (searchTitleLanguages.length > 0) return searchTitleLanguages
+    if (searchTitleLanguage === '') return ['en-US', '']
+    return [searchTitleLanguage]
+  }
+  return []
+}
+
 function Settings({
   initialConfig,
   sendCommand,
@@ -132,7 +163,8 @@ function Settings({
           movie_categories: query.movie_categories || '',
           extra_search_terms: query.extra_search_terms || '',
           search_result_limit: Number(query.search_result_limit || 0),
-          search_title_language: query.search_title_language || '',
+          search_title_language: normalizeSearchTitleLanguage(query.search_title_language || ''),
+          search_title_languages: normalizeSearchQueryLanguages(query),
           include_year: normalizeQueryYearSetting(query.search_mode, query.include_year, query.include_year_in_text_search),
         })) || [],
         series_search_queries: initialConfig.series_search_queries?.map((query) => ({
@@ -141,7 +173,8 @@ function Settings({
           tv_categories: query.tv_categories || '',
           extra_search_terms: query.extra_search_terms || '',
           search_result_limit: Number(query.search_result_limit || 0),
-          search_title_language: query.search_title_language || '',
+          search_title_language: normalizeSearchTitleLanguage(query.search_title_language || ''),
+          search_title_languages: normalizeSearchQueryLanguages(query),
           include_year: normalizeQueryYearSetting(query.search_mode, query.include_year, query.include_year_in_text_search),
           series_search_scope: normalizeSeriesScopeFromLegacy(query.series_search_scope, query.use_season_episode_params),
         })) || []

--- a/frontend/src/components/SearchQuerySettings.jsx
+++ b/frontend/src/components/SearchQuerySettings.jsx
@@ -1,13 +1,15 @@
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, focusDialogCloseButton } from "@/components/ui/dialog"
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
 import { ConfirmDialog } from "@/components/ConfirmDialog"
 import { apiFetch } from "@/api"
-import { Copy, Plus, Settings, Trash2 } from "lucide-react"
+import { CircleHelp, Copy, Plus, Settings, Trash2, X } from "lucide-react"
 
 const CACHE_CLEARED_SUFFIX = ' Search cache cleared.'
 
@@ -45,36 +47,74 @@ const SERIES_SCOPE_OPTIONS = [
   { value: 'none', label: 'None' },
 ]
 
-const YEAR_HINT = 'Adds the metadata year to text searches and also checks it during result validation. With ID searches it only affects validation.'
+const YEAR_HINT_ITEMS = [
+  {
+    label: 'Text Search',
+    text: 'Adds the metadata year to the outgoing query and also checks it during validation.',
+  },
+  {
+    label: 'ID Search',
+    text: 'Does not change the ID request itself. It only affects validation.',
+  },
+]
 const TV_SCOPE_HINT_ITEMS = [
   {
     label: 'Season/Episode',
-    text: 'Targets one episode. ID mode uses season and episode params, and Text mode searches with an S01E01-style query.',
+    text: 'Targets one episode. ID uses params, Text uses an S01E01-style query.',
   },
   {
     label: 'Season',
-    text: 'Broadens to the whole season. Validation still keeps only releases that can contain the requested episode.',
+    text: 'Broadens to the whole season, then validation trims back to releases that can contain the episode.',
   },
   {
     label: 'None',
-    text: 'Searches only by series title or ID. Validation trims the broader results back to releases that can contain the requested episode.',
+    text: 'Searches only by series title or ID. Validation trims the broader results back to episode-capable releases.',
   },
 ]
 const TITLE_LANGUAGE_HINT_ITEMS = [
   {
     label: 'Text Search',
-    text: 'Builds the outgoing search title from the selected metadata language.',
+    text: 'Uses exactly one metadata language for the outgoing query.',
   },
   {
     label: 'ID Search',
-    text: 'Does not change the ID request itself. It only changes which metadata title is used for result validation.',
+    text: 'Does not change the ID request itself. Selected languages are used only for validation.',
   },
   {
     label: 'Normalization',
-    text: 'Uses the same normalized title basis for search and validation. Examples: `König der Löwen` becomes `Koenig der Loewen`, and `Your Friends & Neighbors` becomes `Your Friends Neighbors`.',
+    text: 'Search and validation use the same normalized title basis.',
   },
 ]
-const SEARCH_LIMIT_HINT = '0 uses Max. For Newznab indexers, StreamNZB reads the max from caps. If caps are unavailable, it falls back to 2000. Any explicit value is sent as-is.'
+const SEARCH_LIMIT_HINT_ITEMS = [
+  {
+    label: 'Max',
+    text: '0 uses Max.',
+  },
+  {
+    label: 'Newznab',
+    text: 'Reads the max from caps. If caps are unavailable, it falls back to 2000.',
+  },
+  {
+    label: 'Explicit',
+    text: 'Any explicit value is sent as-is.',
+  },
+]
+const EXTRA_TERMS_HINT_ITEMS = [
+  {
+    label: 'Usage',
+    text: 'Optional terms for text and ID searches.',
+  },
+  {
+    label: 'Syntax',
+    text: 'Use quotes for exact phrases, `!term` to exclude words, `*` as wildcard, `|` or `OR` for alternatives, and parentheses for groups like `(1080p|720p)`.',
+  },
+]
+const DEFAULT_ID_TITLE_LANGUAGES = ['en-US', '']
+
+function normalizeDraftSearchTitleLanguage(value) {
+  if (value === null) return null
+  return normalizeSearchTitleLanguage(value)
+}
 
 function normalizeSeriesSearchScope(scope) {
   switch ((scope || '').trim().toLowerCase()) {
@@ -143,8 +183,75 @@ function normalizeQueryYearSetting(searchMode, includeYear, legacyIncludeYearInT
   return String(searchMode || '').trim().toLowerCase() !== 'id'
 }
 
+function normalizeSearchTitleLanguage(value) {
+  const trimmed = String(value || '').trim()
+  return trimmed.toLowerCase() === 'original' ? '' : trimmed
+}
+
+function normalizeSearchTitleLanguages(values) {
+  const list = Array.isArray(values) ? values : []
+  const normalized = []
+  const seen = new Set()
+  for (const value of list) {
+    const language = normalizeSearchTitleLanguage(value)
+    const key = language.toLowerCase()
+    if (seen.has(key)) continue
+    seen.add(key)
+    normalized.push(language)
+  }
+  return normalized
+}
+
+function defaultIDTitleLanguages() {
+  return [...DEFAULT_ID_TITLE_LANGUAGES]
+}
+
+function resolvedIDTitleLanguages(searchMode, singleLanguage, languages) {
+  if (String(searchMode || '').trim().toLowerCase() !== 'id') {
+    return []
+  }
+  const normalizedLanguages = normalizeSearchTitleLanguages(languages)
+  if (normalizedLanguages.length > 0) {
+    return normalizedLanguages
+  }
+  const normalizedSingle = normalizeSearchTitleLanguage(singleLanguage)
+  if (normalizedSingle === '') {
+    return defaultIDTitleLanguages()
+  }
+  return [normalizedSingle]
+}
+
+function draftTitleLanguages(searchMode, singleLanguage, languages) {
+  if (String(searchMode || '').trim().toLowerCase() !== 'id') {
+    return []
+  }
+  if (Array.isArray(languages)) {
+    return normalizeSearchTitleLanguages(languages)
+  }
+  return resolvedIDTitleLanguages(searchMode, singleLanguage, languages)
+}
+
+function remainingTitleLanguageOptions(selectedLanguages) {
+  const selected = new Set(normalizeSearchTitleLanguages(selectedLanguages).map((value) => value.toLowerCase()))
+  return TITLE_LANGUAGE_OPTIONS.filter((option) => !selected.has(normalizeSearchTitleLanguage(option.value).toLowerCase()))
+}
+
 function titleLanguageLabel(value) {
-  return TITLE_LANGUAGE_OPTIONS.find((option) => option.value === value)?.label || 'Original'
+  return TITLE_LANGUAGE_OPTIONS.find((option) => option.value === normalizeSearchTitleLanguage(value))?.label || 'Original'
+}
+
+function titleLanguagesSummary(values) {
+  const labels = normalizeSearchTitleLanguages(values).map((value) => titleLanguageLabel(value))
+  if (labels.length === 0) return 'Original'
+  return labels.join(' + ')
+}
+
+function selectedTitleLanguagesForMode(searchMode, singleLanguage, languages) {
+  if (String(searchMode || '').trim().toLowerCase() === 'id') {
+    return draftTitleLanguages(searchMode, singleLanguage, languages)
+  }
+  if (singleLanguage === null) return []
+  return [normalizeSearchTitleLanguage(singleLanguage)]
 }
 
 function assignedStreamsForQuery(streamsByName, kind, queryName) {
@@ -174,6 +281,7 @@ function emptyDraft(kind) {
     extra_search_terms: '',
     search_result_limit: 0,
     search_title_language: '',
+    search_title_languages: defaultIDTitleLanguages(),
     include_year: false,
     series_search_scope: kind === 'series' ? 'season_episode' : undefined,
   }
@@ -182,6 +290,7 @@ function emptyDraft(kind) {
 function normalizeDraft(kind, draft) {
   const value = draft || {}
   const searchMode = value.search_mode || 'id'
+  const searchTitleLanguage = normalizeDraftSearchTitleLanguage(value.search_title_language)
   return {
     name: (value.name || '').trim(),
     search_mode: searchMode,
@@ -189,7 +298,8 @@ function normalizeDraft(kind, draft) {
     search_result_limit: value.search_result_limit ?? 0,
     movie_categories: kind === 'movie' ? (value.movie_categories ?? '2000') : undefined,
     tv_categories: kind === 'series' ? (value.tv_categories ?? '5000') : undefined,
-    search_title_language: value.search_title_language || '',
+    search_title_language: searchTitleLanguage,
+    search_title_languages: draftTitleLanguages(searchMode, searchTitleLanguage, value.search_title_languages),
     include_year: normalizeQueryYearSetting(searchMode, value.include_year, value.include_year_in_text_search),
     series_search_scope: kind === 'series'
       ? normalizeSeriesScopeSelection(value.series_search_scope)
@@ -199,6 +309,12 @@ function normalizeDraft(kind, draft) {
 
 function persistableDraft(kind, draft) {
   const next = normalizeDraft(kind, draft)
+  next.search_title_language = next.search_mode === 'text'
+    ? normalizeSearchTitleLanguage(next.search_title_language ?? '')
+    : (normalizeSearchTitleLanguages(next.search_title_languages)[0] ?? '')
+  next.search_title_languages = next.search_mode === 'id'
+    ? draftTitleLanguages(next.search_mode, next.search_title_language, next.search_title_languages)
+    : []
   if (kind === 'series') {
     const resolvedScope = resolveSeriesSearchScope(next.series_search_scope)
     next.series_search_scope = resolvedScope
@@ -214,7 +330,10 @@ function comparableQuerySignature(kind, draft) {
     tv_categories: kind === 'series' ? String(value.tv_categories ?? '').trim() : '',
     extra_search_terms: String(value.extra_search_terms || '').trim(),
     search_result_limit: Number(value.search_result_limit || 0),
-    search_title_language: String(value.search_title_language || '').trim(),
+    search_title_language: value.search_title_language === null
+      ? null
+      : normalizeSearchTitleLanguage(String(value.search_title_language || '').trim()),
+    search_title_languages: draftTitleLanguages(value.search_mode, value.search_title_language, value.search_title_languages),
     include_year: value.include_year !== false,
     series_search_scope: kind === 'series' ? normalizeSeriesScopeSelection(value.series_search_scope) : undefined,
   })
@@ -242,41 +361,249 @@ function extractScopedQueryFieldErrors(fieldErrors, kind, index) {
 }
 
 function summarizeQuery(query, kind) {
-  const search = []
-  if (query.search_mode) search.push(`Mode: ${query.search_mode.toUpperCase()}`)
-  if (kind === 'movie' && query.movie_categories) search.push(`Movie: ${query.movie_categories}`)
-  if (kind === 'series' && query.tv_categories) search.push(`TV: ${query.tv_categories}`)
-  search.push(`Limit: ${Number(query.search_result_limit || 0) === 0 ? 'Max' : query.search_result_limit}`)
+  const primary = []
+  const validation = []
+  const extra = []
+
+  if (query.search_mode) primary.push(`Mode: ${query.search_mode.toUpperCase()}`)
+  if (kind === 'movie' && query.movie_categories) primary.push(`Movie: ${query.movie_categories}`)
+  if (kind === 'series' && query.tv_categories) primary.push(`TV: ${query.tv_categories}`)
+  primary.push(`Limit: ${Number(query.search_result_limit || 0) === 0 ? 'Max' : query.search_result_limit}`)
+
+  if ((query.search_mode || 'id') === 'id') {
+    validation.push(`Title: ${titleLanguagesSummary(query.search_title_languages)}`)
+  } else {
+    validation.push(`Title: ${titleLanguageLabel(query.search_title_language || '')}`)
+  }
+  validation.push(`Year: ${query.include_year === false ? 'Off' : 'On'}`)
   if (kind === 'series') {
     const scope = normalizeSeriesScopeSelection(query.series_search_scope)
     const scopeLabel = SERIES_SCOPE_OPTIONS.find((option) => option.value === scope)?.label || 'Season/Episode'
-    search.push(`Scope: ${scopeLabel}`)
+    validation.push(`Scope: ${scopeLabel}`)
   }
-  search.push(`Year: ${query.include_year === false ? 'Off' : 'On'}`)
-  search.push(`Title: ${titleLanguageLabel(query.search_title_language || '')}`)
-  if (query.extra_search_terms) search.push(`Extra: ${truncateCompactValue(query.extra_search_terms)}`)
-  return search
+
+  if (query.extra_search_terms) extra.push(`Extra: ${truncateCompactValue(query.extra_search_terms)}`)
+
+  return { primary, validation, extra }
+}
+
+function CompactRow({ items = [] }) {
+  if (!Array.isArray(items) || items.length === 0) return null
+  return (
+    <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+      {items.map((part) => (
+        <span key={part} className="rounded-full border border-border px-2 py-1">{part}</span>
+      ))}
+    </div>
+  )
+}
+
+function LabelWithHelp({ label, items = [] }) {
+  const [open, setOpen] = useState(false)
+  const containerRef = useRef(null)
+
+  useEffect(() => {
+    if (!open) return undefined
+
+    const handlePointerDown = (event) => {
+      if (!containerRef.current?.contains(event.target)) {
+        setOpen(false)
+      }
+    }
+
+    const handleEscape = (event) => {
+      if (event.key === 'Escape') {
+        setOpen(false)
+      }
+    }
+
+    document.addEventListener('mousedown', handlePointerDown)
+    document.addEventListener('touchstart', handlePointerDown)
+    document.addEventListener('keydown', handleEscape)
+
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown)
+      document.removeEventListener('touchstart', handlePointerDown)
+      document.removeEventListener('keydown', handleEscape)
+    }
+  }, [open])
+
+  if (!Array.isArray(items) || items.length === 0) {
+    return <Label className="text-sm font-medium">{label}</Label>
+  }
+
+  return (
+    <div ref={containerRef} className="relative flex items-center gap-2">
+      <Label className="text-sm font-medium">{label}</Label>
+      <button
+        type="button"
+        className="inline-flex h-5 w-5 items-center justify-center rounded-full text-muted-foreground transition hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+        aria-expanded={open}
+        aria-haspopup="dialog"
+        aria-label={`${label} help`}
+        onClick={() => setOpen((current) => !current)}
+      >
+        <CircleHelp className="h-4 w-4" />
+      </button>
+      {open ? (
+        <div className="absolute left-0 top-full z-30 mt-2 w-72 rounded-md border border-border bg-background p-3 text-xs leading-relaxed text-muted-foreground shadow-md">
+          <div className="space-y-1.5">
+            {items.map((item) => (
+              <div key={item.label}>
+                <span className="font-medium text-foreground/80">{item.label}:</span>{' '}
+                <span>{item.text}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+function TitleLanguageSelector({ searchMode, singleLanguage, languages, onSingleChange, onLanguagesChange, onErrorChange, error }) {
+  const normalizedMode = String(searchMode || '').trim().toLowerCase()
+  const isIDMode = normalizedMode === 'id'
+  const selectedLanguages = selectedTitleLanguagesForMode(searchMode, singleLanguage, languages)
+  const availableValues = remainingTitleLanguageOptions(selectedLanguages)
+
+  const handleAdd = (value) => {
+    if (isIDMode) {
+      onErrorChange?.('')
+      onLanguagesChange([...selectedLanguages, value])
+      return
+    }
+    if (selectedLanguages.length > 0) {
+      onErrorChange?.('Text search can use only one title language.')
+      return
+    }
+    onErrorChange?.('')
+    onSingleChange(value)
+  }
+
+  const handleRemove = (value) => {
+    if (isIDMode) {
+      onErrorChange?.('')
+      onLanguagesChange(selectedLanguages.filter((currentValue) => currentValue !== value))
+      return
+    }
+    onErrorChange?.('')
+    onSingleChange(null)
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between gap-3">
+        <LabelWithHelp label="Title Language" items={TITLE_LANGUAGE_HINT_ITEMS} />
+        <DropdownMenu>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon"
+                  className={`h-8 w-8 ${error ? 'border-destructive text-destructive' : ''}`}
+                  disabled={availableValues.length === 0}
+                >
+                  <Plus className="h-4 w-4" />
+                </Button>
+              </DropdownMenuTrigger>
+            </TooltipTrigger>
+            <TooltipContent>
+              {availableValues.length === 0 ? 'No more languages to add' : 'Add title language'}
+            </TooltipContent>
+          </Tooltip>
+          <DropdownMenuContent align="end" className="max-h-80 w-60 overflow-y-auto">
+            {availableValues.length === 0 ? (
+              <DropdownMenuItem disabled>No more languages available</DropdownMenuItem>
+            ) : (
+              availableValues.map((option) => (
+                <DropdownMenuItem key={option.value || 'original'} onClick={() => handleAdd(option.value)}>
+                  {option.label}
+                </DropdownMenuItem>
+              ))
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+      <div className={`min-h-14 rounded-md border px-3 py-3 ${error ? 'border-destructive/60 bg-destructive/5' : 'border-border/60'} flex items-center`}>
+        <div className="flex w-full flex-wrap items-center gap-2">
+          {selectedLanguages.map((language) => (
+            <Badge key={`${normalizedMode}-${language || 'original'}`} variant="secondary" className="flex items-center gap-1 rounded-full px-3 py-1">
+              <span>{titleLanguageLabel(language)}</span>
+              <button
+                type="button"
+                className="rounded-full text-muted-foreground transition hover:text-foreground"
+                onClick={() => handleRemove(language)}
+                aria-label={`Remove ${titleLanguageLabel(language)}`}
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </Badge>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
 }
 
 
-function QueryDraftFields({ kind, draft, setDraft, editing = false, fieldErrors = {} }) {
+function QueryDraftFields({ kind, draft, setDraft, editing = false, fieldErrors = {}, onUIErrorChange }) {
   const normalizedScope = kind === 'series'
     ? normalizeSeriesScopeSelection(draft.series_search_scope)
     : ''
+  const titleLanguageFieldKey = draft.search_mode === 'id' ? 'search_title_languages' : 'search_title_language'
+  const [titleLanguageUIError, setTitleLanguageUIError] = useState('')
+
+  const clearTitleLanguageUIError = () => {
+    setTitleLanguageUIError('')
+    onUIErrorChange?.('')
+  }
 
   const update = (key, value) => {
+    if (key === 'search_mode' || key === 'search_title_language' || key === 'search_title_languages') {
+      clearTitleLanguageUIError()
+    }
     setDraft((current) => {
       if (key === 'search_mode') {
+        const nextMode = value
+        const nextTitleLanguages = nextMode === 'id'
+          ? resolvedIDTitleLanguages(nextMode, current.search_title_language, current.search_title_languages)
+          : current.search_title_language === null
+            ? []
+            : [normalizeSearchTitleLanguage(current.search_title_language)]
         return {
           ...current,
-          search_mode: value,
-          include_year: value === 'text' ? true : current.include_year,
+          search_mode: nextMode,
+          search_title_languages: nextTitleLanguages,
+          include_year: nextMode === 'text' ? true : current.include_year,
         }
       }
       if (key === 'series_search_scope') {
         return {
           ...current,
           series_search_scope: normalizeSeriesScopeSelection(value),
+        }
+      }
+      if (key === 'search_title_language') {
+        return {
+          ...current,
+          search_title_language: normalizeDraftSearchTitleLanguage(value),
+        }
+      }
+      if (key === 'search_title_languages') {
+        if (String(current.search_mode || '').trim().toLowerCase() === 'text') {
+          const nextLanguages = normalizeSearchTitleLanguages(value)
+          return {
+            ...current,
+            search_title_languages: nextLanguages.slice(0, 1),
+            search_title_language: nextLanguages.length > 0 ? nextLanguages[0] : null,
+          }
+        }
+        return {
+          ...current,
+          search_title_languages: normalizeSearchTitleLanguages(value),
         }
       }
       const next = { ...current, [key]: value }
@@ -295,10 +622,11 @@ function QueryDraftFields({ kind, draft, setDraft, editing = false, fieldErrors 
   const controlWideClass = `${controlBaseClass} min-[360px]:w-[14rem]`
   const controlMediumClass = `${controlBaseClass} min-[360px]:w-[13rem]`
   const controlNarrowClass = `${controlBaseClass} min-[360px]:w-[9rem]`
+  const sectionCardClass = "rounded-lg border border-border/60 bg-background/80"
 
   return (
-    <div className="space-y-4">
-      <div className="rounded-md border border-border/60 p-3">
+    <div className="space-y-5">
+      <div className={`${sectionCardClass} p-3`}>
         <div className={rowClass}>
           <div className={inlineRowClass}>
             <div className={inlineLabelClass}>
@@ -311,7 +639,7 @@ function QueryDraftFields({ kind, draft, setDraft, editing = false, fieldErrors 
         </div>
       </div>
 
-      <div className="rounded-md border border-border/60">
+      <div className={sectionCardClass}>
         <div className="p-3">
           <div className={rowClass}>
             <div className={inlineRowClass}>
@@ -349,7 +677,7 @@ function QueryDraftFields({ kind, draft, setDraft, editing = false, fieldErrors 
           <div className={rowClass}>
             <div className={inlineRowClass}>
               <div className={inlineLabelClass}>
-                <Label className="text-sm font-medium">Limit</Label>
+                <LabelWithHelp label="Limit" items={SEARCH_LIMIT_HINT_ITEMS} />
               </div>
               <div className={controlNarrowClass}>
                 <Input
@@ -363,7 +691,45 @@ function QueryDraftFields({ kind, draft, setDraft, editing = false, fieldErrors 
                 />
               </div>
             </div>
-            <p className="text-sm text-muted-foreground">{SEARCH_LIMIT_HINT}</p>
+          </div>
+        </div>
+      </div>
+
+      <div className={sectionCardClass}>
+        <div className="relative p-3">
+          <div className={rowClass}>
+            <TitleLanguageSelector
+              searchMode={draft.search_mode}
+              singleLanguage={draft.search_title_language}
+              languages={draft.search_title_languages}
+              onSingleChange={(value) => update('search_title_language', value)}
+              onLanguagesChange={(value) => update('search_title_languages', value)}
+              onErrorChange={(message) => {
+                setTitleLanguageUIError(message || '')
+                onUIErrorChange?.(message || '')
+              }}
+              error={titleLanguageUIError || fieldErrors[titleLanguageFieldKey]}
+            />
+          </div>
+        </div>
+        <div className="relative p-3">
+          <div className="absolute left-3 right-3 top-0 border-t border-border/60" />
+          <div className={rowClass}>
+            <div className={inlineRowClass}>
+              <div className={inlineLabelClass}>
+                <LabelWithHelp label="Year" items={YEAR_HINT_ITEMS} />
+              </div>
+              <div className={controlMediumClass}>
+                <select
+                  className={`flex h-9 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 ${fieldClass('include_year')}`}
+                  value={draft.include_year === false ? 'off' : 'on'}
+                  onChange={(event) => update('include_year', event.target.value === 'on')}
+                >
+                  <option value="on">{draft.search_mode === 'text' ? 'Search + Validation' : 'Validation'}</option>
+                  <option value="off">Ignore</option>
+                </select>
+              </div>
+            </div>
           </div>
         </div>
         {kind === 'series' && (
@@ -372,7 +738,7 @@ function QueryDraftFields({ kind, draft, setDraft, editing = false, fieldErrors 
             <div className={rowClass}>
               <div className={inlineRowClass}>
                 <div className={inlineLabelClass}>
-                  <Label className="text-sm font-medium">Scope</Label>
+                  <LabelWithHelp label="Scope" items={TV_SCOPE_HINT_ITEMS} />
                 </div>
                 <div className={controlMediumClass}>
                   <select
@@ -386,84 +752,21 @@ function QueryDraftFields({ kind, draft, setDraft, editing = false, fieldErrors 
                   </select>
                 </div>
               </div>
-              <div className="space-y-1 text-sm text-muted-foreground">
-                {TV_SCOPE_HINT_ITEMS.map((item) => (
-                  <p key={item.label}>
-                    <span className="font-medium text-foreground/80">{item.label}:</span>{' '}
-                    {item.text}
-                  </p>
-                ))}
-              </div>
             </div>
           </div>
         )}
       </div>
 
-      <div className="rounded-md border border-border/60">
-        <div className="p-3">
-          <div className={rowClass}>
-            <div className={inlineRowClass}>
-              <div className={inlineLabelClass}>
-                <Label className="text-sm font-medium">Year</Label>
-              </div>
-              <div className={controlMediumClass}>
-                <select
-                  className={`flex h-9 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 ${fieldClass('include_year')}`}
-                  value={draft.include_year === false ? 'off' : 'on'}
-                  onChange={(event) => update('include_year', event.target.value === 'on')}
-                >
-                  <option value="on">{draft.search_mode === 'text' ? 'Search + Validation' : 'Validation'}</option>
-                  <option value="off">Ignore</option>
-                </select>
-              </div>
-            </div>
-            <p className="text-sm text-muted-foreground">{YEAR_HINT}</p>
-          </div>
-        </div>
-        <div className="relative p-3">
-          <div className="absolute left-3 right-3 top-0 border-t border-border/60" />
-          <div className={rowClass}>
-            <div className={inlineRowClass}>
-              <div className={inlineLabelClass}>
-                <Label className="text-sm font-medium">Title Language</Label>
-              </div>
-              <div className={controlMediumClass}>
-                <select
-                  className={`flex h-9 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 ${fieldClass('search_title_language')}`}
-                  value={draft.search_title_language || ''}
-                  onChange={(event) => update('search_title_language', event.target.value)}
-                >
-                  {TITLE_LANGUAGE_OPTIONS.map((option) => (
-                    <option key={option.value || 'original'} value={option.value}>
-                      {option.label}
-                    </option>
-                  ))}
-                </select>
-              </div>
-            </div>
-            <div className="space-y-1 text-sm text-muted-foreground">
-              {TITLE_LANGUAGE_HINT_ITEMS.map((item) => (
-                <p key={item.label}>
-                  <span className="font-medium text-foreground/80">{item.label}:</span>{' '}
-                  {item.text}
-                </p>
-              ))}
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <div className="rounded-md border border-border/60 p-3">
+      <div className={`${sectionCardClass} p-3`}>
         <div className={rowClass}>
           <div className="space-y-3">
             <div>
-              <Label className="text-sm font-medium">Extra Terms</Label>
+              <LabelWithHelp label="Extra Terms" items={EXTRA_TERMS_HINT_ITEMS} />
             </div>
             <div className="w-full">
               <Input className={`h-9 ${fieldClass('extra_search_terms')}`} placeholder={'"The Walking Dead" !cam (1080p|720p)'} value={draft.extra_search_terms || ''} onChange={(event) => update('extra_search_terms', event.target.value)} />
             </div>
           </div>
-          <p className="text-sm text-muted-foreground">Optional terms for text and ID searches. Use quotes for exact phrases, `!term` to exclude words, `*` as wildcard, `|` or `OR` for alternatives, and parentheses to group like `(1080p|720p)`.</p>
         </div>
       </div>
     </div>
@@ -489,6 +792,7 @@ function QueryDialog({ open, onOpenChange, kind, initialValue, existingNames = [
   const [draft, setDraft] = useState(() => normalizeDraft(kind, initialValue))
   const [wasOpen, setWasOpen] = useState(open)
   const [validationError, setValidationError] = useState('')
+  const [uiValidationError, setUIValidationError] = useState('')
   const [fieldErrors, setFieldErrors] = useState({})
   const [showDiscardConfirm, setShowDiscardConfirm] = useState(false)
   const [saving, setSaving] = useState(false)
@@ -501,6 +805,7 @@ function QueryDialog({ open, onOpenChange, kind, initialValue, existingNames = [
       }
       setDraft(nextDraft)
       setValidationError('')
+      setUIValidationError('')
       setFieldErrors({})
     }
     setWasOpen(open)
@@ -520,6 +825,7 @@ function QueryDialog({ open, onOpenChange, kind, initialValue, existingNames = [
       return
     }
     onClearStatus?.()
+    setUIValidationError('')
     onOpenChange(false)
   }
 
@@ -537,6 +843,12 @@ function QueryDialog({ open, onOpenChange, kind, initialValue, existingNames = [
     if (!category || category === '0') {
       nextFieldErrors[kind === 'movie' ? 'movie_categories' : 'tv_categories'] = 'Category is required.'
     }
+    if (next.search_mode === 'id' && draftTitleLanguages(next.search_mode, next.search_title_language, next.search_title_languages).length === 0) {
+      nextFieldErrors.search_title_languages = 'Add at least one title language.'
+    }
+    if (next.search_mode === 'text' && selectedTitleLanguagesForMode(next.search_mode, next.search_title_language, next.search_title_languages).length === 0) {
+      nextFieldErrors.search_title_language = 'Add at least one title language.'
+    }
     if (Number.isNaN(limit) || limit < 0) {
       nextFieldErrors.search_result_limit = 'Limit must be 0 or greater.'
     }
@@ -546,6 +858,7 @@ function QueryDialog({ open, onOpenChange, kind, initialValue, existingNames = [
       return
     }
     setFieldErrors({})
+    setUIValidationError('')
     setValidationError('')
     next.search_result_limit = limit
     setSaving(true)
@@ -581,12 +894,12 @@ function QueryDialog({ open, onOpenChange, kind, initialValue, existingNames = [
           <DialogDescription>{dialogDescription(kind)}</DialogDescription>
         </DialogHeader>
         <div className="min-h-0 flex-1 overflow-y-auto pr-1">
-          <QueryDraftFields kind={kind} draft={draft} setDraft={setDraft} editing={editing} fieldErrors={fieldErrors} />
+          <QueryDraftFields kind={kind} draft={draft} setDraft={setDraft} editing={editing} fieldErrors={fieldErrors} onUIErrorChange={setUIValidationError} />
         </div>
         <DialogFooter className="flex items-center justify-between gap-3">
           <div className="min-h-9 flex-1">
-            {validationError && (
-              <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">{validationError}</div>
+            {(uiValidationError || validationError) && (
+              <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">{uiValidationError || validationError}</div>
             )}
           </div>
           <div className="flex flex-row items-center justify-end gap-2">
@@ -739,13 +1052,13 @@ function QuerySection({ title, description, kind, items, names, update, remove, 
                       </div>
                       <div className="min-w-0 font-semibold sm:order-1">{query.name || defaultQueryName(kind, index)}</div>
                     </div>
-                    {summary.length === 0 ? (
+                    {!summary.primary.length && !summary.validation.length && !summary.extra.length ? (
                       <p className="text-sm text-muted-foreground">No values set.</p>
                     ) : (
-                      <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
-                        {summary.map((part) => (
-                          <span key={part} className="rounded-full border border-border px-2 py-1">{part}</span>
-                        ))}
+                      <div className="space-y-3">
+                        <CompactRow items={summary.primary} />
+                        <CompactRow items={summary.validation} />
+                        <CompactRow items={summary.extra} />
                       </div>
                     )}
                   </div>

--- a/pkg/core/config/config.go
+++ b/pkg/core/config/config.go
@@ -77,12 +77,13 @@ type SearchQueryConfig struct {
 	SearchResultLimit int    `json:"search_result_limit,omitempty"`
 	IncludeYear       *bool  `json:"include_year,omitempty"`
 	// Legacy transport-vs-query hint kept only so older local draft configs still load cleanly.
-	UseSeasonEpisodeParams     *bool  `json:"use_season_episode_params,omitempty"`
-	SeriesSearchScope          string `json:"series_search_scope,omitempty"`
-	EnableSeriesSeasonSearch   *bool  `json:"enable_series_season_search,omitempty"`
-	EnableSeriesCompleteSearch *bool  `json:"enable_series_complete_search,omitempty"`
-	EnableSeriesPackSearch     *bool  `json:"enable_series_pack_search,omitempty"`
-	SearchTitleLanguage        string `json:"search_title_language,omitempty"`
+	UseSeasonEpisodeParams     *bool    `json:"use_season_episode_params,omitempty"`
+	SeriesSearchScope          string   `json:"series_search_scope,omitempty"`
+	EnableSeriesSeasonSearch   *bool    `json:"enable_series_season_search,omitempty"`
+	EnableSeriesCompleteSearch *bool    `json:"enable_series_complete_search,omitempty"`
+	EnableSeriesPackSearch     *bool    `json:"enable_series_pack_search,omitempty"`
+	SearchTitleLanguage        string   `json:"search_title_language,omitempty"`
+	SearchTitleLanguages       []string `json:"search_title_languages,omitempty"`
 	// Legacy year field kept only so older local draft configs still load cleanly.
 	LegacyIncludeYearInTextSearch *bool  `json:"include_year_in_text_search,omitempty"`
 	MovieCategories               string `json:"movie_categories,omitempty"`
@@ -163,6 +164,39 @@ func NormalizeAvailNZBMode(mode string) string {
 	default:
 		return "on"
 	}
+}
+
+func NormalizeSearchTitleLanguage(language string) string {
+	trimmed := strings.TrimSpace(language)
+	if strings.EqualFold(trimmed, "original") {
+		return ""
+	}
+	return trimmed
+}
+
+func NormalizeSearchTitleLanguages(languages []string) []string {
+	if len(languages) == 0 {
+		return nil
+	}
+	normalized := make([]string, 0, len(languages))
+	seen := make(map[string]bool, len(languages))
+	for _, language := range languages {
+		value := NormalizeSearchTitleLanguage(language)
+		key := strings.ToLower(value)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		normalized = append(normalized, value)
+	}
+	if len(normalized) == 0 {
+		return nil
+	}
+	return normalized
+}
+
+func DefaultIDSearchTitleLanguages() []string {
+	return []string{"en-US", ""}
 }
 
 func NormalizeSeriesSearchScope(scope string) string {
@@ -332,8 +366,7 @@ func (sq *SearchQueryConfig) AsIndexerSearchConfig() *IndexerSearchConfig {
 		out.DisableIdSearch = sq.DisableIdSearch
 		out.DisableStringSearch = sq.DisableStringSearch
 	}
-	if sq.SearchTitleLanguage != "" {
-		s := sq.SearchTitleLanguage
+	if s := NormalizeSearchTitleLanguage(sq.SearchTitleLanguage); s != "" {
 		out.SearchTitleLanguage = &s
 	}
 	if sq.MovieCategories != "" {
@@ -606,40 +639,44 @@ func (c *Config) applyStreamModelUpgradeDefaults() bool {
 func (c *Config) ensureDefaultMigrationSearchQueries() bool {
 	changed := false
 	if c.ensureMovieSearchQuery(SearchQueryConfig{
-		Name:              "DefaultMovieText",
-		SearchMode:        "text",
-		SearchResultLimit: 0,
-		MovieCategories:   "2000",
-		IncludeYear:       ptrBool(true),
+		Name:                "DefaultMovieText",
+		SearchMode:          "text",
+		SearchResultLimit:   0,
+		MovieCategories:     "2000",
+		IncludeYear:         ptrBool(true),
+		SearchTitleLanguage: "",
 	}) {
 		changed = true
 	}
 	if c.ensureMovieSearchQuery(SearchQueryConfig{
-		Name:              "DefaultMovieID",
-		SearchMode:        "id",
-		SearchResultLimit: 0,
-		MovieCategories:   "2000",
-		IncludeYear:       ptrBool(false),
+		Name:                 "DefaultMovieID",
+		SearchMode:           "id",
+		SearchResultLimit:    0,
+		MovieCategories:      "2000",
+		IncludeYear:          ptrBool(false),
+		SearchTitleLanguages: DefaultIDSearchTitleLanguages(),
 	}) {
 		changed = true
 	}
 	if c.ensureSeriesSearchQuery(SearchQueryConfig{
-		Name:              "DefaultTVText",
-		SearchMode:        "text",
-		SearchResultLimit: 0,
-		TVCategories:      "5000",
-		IncludeYear:       ptrBool(true),
-		SeriesSearchScope: SeriesSearchScopeSeasonEpisode,
+		Name:                "DefaultTVText",
+		SearchMode:          "text",
+		SearchResultLimit:   0,
+		TVCategories:        "5000",
+		IncludeYear:         ptrBool(true),
+		SeriesSearchScope:   SeriesSearchScopeSeasonEpisode,
+		SearchTitleLanguage: "",
 	}) {
 		changed = true
 	}
 	if c.ensureSeriesSearchQuery(SearchQueryConfig{
-		Name:              "DefaultTVID",
-		SearchMode:        "id",
-		SearchResultLimit: 0,
-		TVCategories:      "5000",
-		IncludeYear:       ptrBool(false),
-		SeriesSearchScope: SeriesSearchScopeSeasonEpisode,
+		Name:                 "DefaultTVID",
+		SearchMode:           "id",
+		SearchResultLimit:    0,
+		TVCategories:         "5000",
+		IncludeYear:          ptrBool(false),
+		SeriesSearchScope:    SeriesSearchScopeSeasonEpisode,
+		SearchTitleLanguages: DefaultIDSearchTitleLanguages(),
 	}) {
 		changed = true
 	}
@@ -664,6 +701,24 @@ func backfillLegacySearchQuerySettingsForQuery(query *SearchQueryConfig, isSerie
 	}
 	if query.LegacyIncludeYearInTextSearch != nil {
 		query.LegacyIncludeYearInTextSearch = nil
+		changed = true
+	}
+	normalizedSingleLanguage := NormalizeSearchTitleLanguage(query.SearchTitleLanguage)
+	if query.SearchTitleLanguage != normalizedSingleLanguage {
+		query.SearchTitleLanguage = normalizedSingleLanguage
+		changed = true
+	}
+	normalizedLanguages := NormalizeSearchTitleLanguages(query.SearchTitleLanguages)
+	if len(query.SearchTitleLanguages) != len(normalizedLanguages) || strings.Join(query.SearchTitleLanguages, "\x00") != strings.Join(normalizedLanguages, "\x00") {
+		query.SearchTitleLanguages = normalizedLanguages
+		changed = true
+	}
+	if strings.EqualFold(strings.TrimSpace(query.SearchMode), "id") && len(query.SearchTitleLanguages) == 0 {
+		if query.SearchTitleLanguage == "" {
+			query.SearchTitleLanguages = DefaultIDSearchTitleLanguages()
+		} else {
+			query.SearchTitleLanguages = NormalizeSearchTitleLanguages([]string{query.SearchTitleLanguage})
+		}
 		changed = true
 	}
 	if isSeries {

--- a/pkg/core/config/config_test.go
+++ b/pkg/core/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -89,6 +90,9 @@ func TestDefaultSearchQuerySettingsMatchExpectedModes(t *testing.T) {
 	if cfg.MovieSearchQueries[1].IncludeYear == nil || *cfg.MovieSearchQueries[1].IncludeYear {
 		t.Fatalf("expected DefaultMovieID year disabled")
 	}
+	if got := cfg.MovieSearchQueries[1].SearchTitleLanguages; !strings.EqualFold(strings.Join(got, "|"), strings.Join([]string{"en-US", ""}, "|")) {
+		t.Fatalf("expected DefaultMovieID title languages [en-US original], got %#v", got)
+	}
 	if cfg.SeriesSearchQueries[0].SearchResultLimit != 0 {
 		t.Fatalf("expected DefaultTVText limit max/0, got %d", cfg.SeriesSearchQueries[0].SearchResultLimit)
 	}
@@ -101,13 +105,16 @@ func TestDefaultSearchQuerySettingsMatchExpectedModes(t *testing.T) {
 	if cfg.SeriesSearchQueries[1].IncludeYear == nil || *cfg.SeriesSearchQueries[1].IncludeYear {
 		t.Fatalf("expected DefaultTVID year disabled")
 	}
+	if got := cfg.SeriesSearchQueries[1].SearchTitleLanguages; !strings.EqualFold(strings.Join(got, "|"), strings.Join([]string{"en-US", ""}, "|")) {
+		t.Fatalf("expected DefaultTVID title languages [en-US original], got %#v", got)
+	}
 }
 
 func TestBackfillLegacySearchQuerySettings(t *testing.T) {
 	cfg := &Config{
 		MovieSearchQueries: []SearchQueryConfig{
 			{Name: "DefaultMovieText", SearchMode: "text"},
-			{Name: "DefaultMovieID", SearchMode: "id", LegacyIncludeYearInTextSearch: ptrBool(true)},
+			{Name: "DefaultMovieID", SearchMode: "id", LegacyIncludeYearInTextSearch: ptrBool(true), SearchTitleLanguage: "original"},
 		},
 		SeriesSearchQueries: []SearchQueryConfig{
 			{Name: "DefaultTVText", SearchMode: "text", UseSeasonEpisodeParams: ptrBool(false)},
@@ -125,6 +132,9 @@ func TestBackfillLegacySearchQuerySettings(t *testing.T) {
 	if cfg.MovieSearchQueries[1].IncludeYear == nil || !*cfg.MovieSearchQueries[1].IncludeYear {
 		t.Fatal("expected DefaultMovieID year enabled after backfill from legacy year field")
 	}
+	if got := cfg.MovieSearchQueries[1].SearchTitleLanguages; !reflect.DeepEqual(got, []string{"en-US", ""}) {
+		t.Fatalf("expected DefaultMovieID title languages [en-US original] after backfill, got %#v", got)
+	}
 	if cfg.SeriesSearchQueries[0].IncludeYear == nil || !*cfg.SeriesSearchQueries[0].IncludeYear {
 		t.Fatal("expected DefaultTVText year enabled after backfill")
 	}
@@ -133,6 +143,9 @@ func TestBackfillLegacySearchQuerySettings(t *testing.T) {
 	}
 	if cfg.SeriesSearchQueries[1].IncludeYear == nil || *cfg.SeriesSearchQueries[1].IncludeYear {
 		t.Fatal("expected DefaultTVID year disabled after backfill")
+	}
+	if got := cfg.SeriesSearchQueries[1].SearchTitleLanguages; !reflect.DeepEqual(got, []string{"en-US", ""}) {
+		t.Fatalf("expected DefaultTVID title languages [en-US original] after backfill, got %#v", got)
 	}
 }
 

--- a/pkg/indexer/types.go
+++ b/pkg/indexer/types.go
@@ -30,26 +30,33 @@ type Usage struct {
 }
 
 type SearchRequest struct {
-	Query                  string
-	IMDbID                 string
-	TMDBID                 string
-	TVDBID                 string
-	Cat                    string
-	Limit                  int
-	Season                 string
-	Episode                string
-	SeriesSearchScope      string
-	SearchMode             string
-	DisableResultFiltering bool
-	EnableYearValidation   bool
-	IndexerMode            string
-	ValidationQuery        string
-	StreamLabel            string `json:"-"`
-	RequestLabel           string `json:"-"`
+	Query                   string
+	IMDbID                  string
+	TMDBID                  string
+	TVDBID                  string
+	Cat                     string
+	Limit                   int
+	Season                  string
+	Episode                 string
+	SeriesSearchScope       string
+	SearchMode              string
+	DisableResultFiltering  bool
+	EnableYearValidation    bool
+	IndexerMode             string
+	ValidationQuery         string
+	ValidationQueries       []string
+	ValidationQueryProfiles []ValidationQueryProfile
+	StreamLabel             string `json:"-"`
+	RequestLabel            string `json:"-"`
 
 	EffectiveByIndexer map[string]*config.IndexerSearchConfig `json:"-"`
 
 	OptionalOverrides *config.IndexerSearchConfig `json:"-"`
+}
+
+type ValidationQueryProfile struct {
+	Languages []string
+	Query     string
 }
 
 type SearchResponse struct {

--- a/pkg/media/unpack/archive.go
+++ b/pkg/media/unpack/archive.go
@@ -84,11 +84,11 @@ func blueprintTargetMatches(cachedTarget, requestedTarget EpisodeTarget) bool {
 }
 
 func GetMediaStream(ctx context.Context, files []UnpackableFile, cachedBP interface{}, password string) (ReadSeekCloser, string, int64, interface{}, error) {
-	return GetMediaStreamForEpisodeWithHints(ctx, files, cachedBP, password, EpisodeTarget{}, StreamSelectionHints{})
+	return GetMediaStreamForEpisodeWithHints(ctx, files, cachedBP, password, EpisodeTarget{}, StreamSelectionHints{AllowLargestDirectFallback: true})
 }
 
 func GetMediaStreamForEpisode(ctx context.Context, files []UnpackableFile, cachedBP interface{}, password string, target EpisodeTarget) (ReadSeekCloser, string, int64, interface{}, error) {
-	return GetMediaStreamForEpisodeWithHints(ctx, files, cachedBP, password, target, StreamSelectionHints{})
+	return GetMediaStreamForEpisodeWithHints(ctx, files, cachedBP, password, target, StreamSelectionHints{AllowLargestDirectFallback: true})
 }
 
 func GetMediaStreamForEpisodeWithHints(ctx context.Context, files []UnpackableFile, cachedBP interface{}, password string, target EpisodeTarget, hints StreamSelectionHints) (ReadSeekCloser, string, int64, interface{}, error) {
@@ -230,13 +230,22 @@ func GetMediaStreamForEpisodeWithHints(ctx context.Context, files []UnpackableFi
 			}
 		}
 		extractedName := ExtractFilename(largestFile.Name())
-		if target.Valid() && !hints.AllowLargestDirectFallback {
-			err := fmt.Errorf("%w: no direct media candidate matched season=%d episode=%d", ErrEpisodeTargetNotFound, target.Season, target.Episode)
-			logger.Warn("Refusing largest-file fallback for targeted episode request",
-				"target", target,
-				"name", extractedName,
-				"index", largestIdx,
-				"size", largestFile.Size())
+		if !hints.AllowLargestDirectFallback {
+			err := fmt.Errorf("%w: largest direct fallback disabled", io.EOF)
+			if target.Valid() {
+				err = fmt.Errorf("%w: no direct media candidate matched season=%d episode=%d", ErrEpisodeTargetNotFound, target.Season, target.Episode)
+				logger.Warn("Refusing largest-file fallback for targeted episode request",
+					"target", target,
+					"name", extractedName,
+					"index", largestIdx,
+					"size", largestFile.Size())
+			} else {
+				logger.Warn("Refusing largest-file fallback by selection hints",
+					"target", target,
+					"name", extractedName,
+					"index", largestIdx,
+					"size", largestFile.Size())
+			}
 			return nil, "", 0, &FailedBlueprint{Err: err, Target: target}, err
 		}
 		if !isPlausibleLargestDirectFallbackName(extractedName) {

--- a/pkg/media/unpack/archive.go
+++ b/pkg/media/unpack/archive.go
@@ -32,6 +32,10 @@ type FailedBlueprint struct {
 	Target EpisodeTarget
 }
 
+type StreamSelectionHints struct {
+	AllowLargestDirectFallback bool
+}
+
 func isPlausibleLargestDirectFallbackName(name string) bool {
 	trimmed := strings.TrimSpace(name)
 	if trimmed == "" {
@@ -80,10 +84,14 @@ func blueprintTargetMatches(cachedTarget, requestedTarget EpisodeTarget) bool {
 }
 
 func GetMediaStream(ctx context.Context, files []UnpackableFile, cachedBP interface{}, password string) (ReadSeekCloser, string, int64, interface{}, error) {
-	return GetMediaStreamForEpisode(ctx, files, cachedBP, password, EpisodeTarget{})
+	return GetMediaStreamForEpisodeWithHints(ctx, files, cachedBP, password, EpisodeTarget{}, StreamSelectionHints{})
 }
 
 func GetMediaStreamForEpisode(ctx context.Context, files []UnpackableFile, cachedBP interface{}, password string, target EpisodeTarget) (ReadSeekCloser, string, int64, interface{}, error) {
+	return GetMediaStreamForEpisodeWithHints(ctx, files, cachedBP, password, target, StreamSelectionHints{})
+}
+
+func GetMediaStreamForEpisodeWithHints(ctx context.Context, files []UnpackableFile, cachedBP interface{}, password string, target EpisodeTarget, hints StreamSelectionHints) (ReadSeekCloser, string, int64, interface{}, error) {
 	if err := contextErr(ctx); err != nil {
 		return nil, "", 0, nil, err
 	}
@@ -222,7 +230,7 @@ func GetMediaStreamForEpisode(ctx context.Context, files []UnpackableFile, cache
 			}
 		}
 		extractedName := ExtractFilename(largestFile.Name())
-		if target.Valid() {
+		if target.Valid() && !hints.AllowLargestDirectFallback {
 			err := fmt.Errorf("%w: no direct media candidate matched season=%d episode=%d", ErrEpisodeTargetNotFound, target.Season, target.Episode)
 			logger.Warn("Refusing largest-file fallback for targeted episode request",
 				"target", target,

--- a/pkg/media/unpack/archive_test.go
+++ b/pkg/media/unpack/archive_test.go
@@ -138,6 +138,41 @@ func TestGetMediaStreamAllowsPlausibleLargestDirectFallback(t *testing.T) {
 	}
 }
 
+func TestGetMediaStreamForEpisodeWithHintsRefusesLargestDirectFallbackWhenDisabled(t *testing.T) {
+	discardTestLogger(t)
+
+	files := []UnpackableFile{
+		&sizedUnpackableFile{
+			memoryUnpackableFile: &memoryUnpackableFile{name: "abc12345", data: []byte("video")},
+			size:                 80 * 1024 * 1024,
+		},
+	}
+
+	stream, name, _, _, err := GetMediaStreamForEpisodeWithHints(
+		context.Background(),
+		files,
+		nil,
+		"",
+		EpisodeTarget{},
+		StreamSelectionHints{AllowLargestDirectFallback: false},
+	)
+	if err == nil {
+		if stream != nil {
+			stream.Close()
+		}
+		t.Fatal("expected disabled largest direct fallback to fail")
+	}
+	if !errors.Is(err, io.EOF) {
+		t.Fatalf("expected io.EOF, got %v", err)
+	}
+	if name != "" {
+		t.Fatalf("expected no selected file, got %q", name)
+	}
+	if stream != nil {
+		t.Fatal("expected no stream when fallback is disabled")
+	}
+}
+
 func TestGetMediaStreamForEpisodeAllowsLargestDirectFallbackWhenHinted(t *testing.T) {
 	discardTestLogger(t)
 

--- a/pkg/media/unpack/archive_test.go
+++ b/pkg/media/unpack/archive_test.go
@@ -138,6 +138,34 @@ func TestGetMediaStreamAllowsPlausibleLargestDirectFallback(t *testing.T) {
 	}
 }
 
+func TestGetMediaStreamForEpisodeAllowsLargestDirectFallbackWhenHinted(t *testing.T) {
+	discardTestLogger(t)
+
+	files := []UnpackableFile{
+		&sizedUnpackableFile{
+			memoryUnpackableFile: &memoryUnpackableFile{name: "abc12345", data: []byte("video")},
+			size:                 80 * 1024 * 1024,
+		},
+	}
+
+	stream, name, _, _, err := GetMediaStreamForEpisodeWithHints(
+		context.Background(),
+		files,
+		nil,
+		"",
+		EpisodeTarget{Season: 1, Episode: 1},
+		StreamSelectionHints{AllowLargestDirectFallback: true},
+	)
+	if err != nil {
+		t.Fatalf("expected hinted targeted fallback to succeed, got %v", err)
+	}
+	defer stream.Close()
+
+	if name != "abc12345" {
+		t.Fatalf("expected plausible fallback name, got %q", name)
+	}
+}
+
 func TestPlausibleLargestDirectFallbackAllowsCommonReleasePunctuation(t *testing.T) {
 	if !isPlausibleLargestDirectFallbackName("Movie, Title '11 [1080p]") {
 		t.Fatal("expected common release punctuation to remain plausible")

--- a/pkg/search/search.go
+++ b/pkg/search/search.go
@@ -11,23 +11,15 @@ import (
 )
 
 func validationQueriesForRequest(req indexer.SearchRequest) []string {
-	if len(req.ValidationQueries) > 0 {
-		queries := make([]string, 0, len(req.ValidationQueries))
-		for _, query := range req.ValidationQueries {
-			trimmed := strings.TrimSpace(query)
-			if trimmed == "" {
-				continue
-			}
-			queries = append(queries, trimmed)
-		}
-		if len(queries) > 0 {
-			return queries
-		}
+	profiles := validationProfilesForRequest(req)
+	if len(profiles) == 0 {
+		return nil
 	}
-	if trimmed := strings.TrimSpace(req.ValidationQuery); trimmed != "" {
-		return []string{trimmed}
+	queries := make([]string, 0, len(profiles))
+	for _, profile := range profiles {
+		queries = append(queries, profile.Query)
 	}
-	return nil
+	return queries
 }
 
 func validationProfilesForRequest(req indexer.SearchRequest) []indexer.ValidationQueryProfile {

--- a/pkg/search/search.go
+++ b/pkg/search/search.go
@@ -10,12 +10,68 @@ import (
 	"streamnzb/pkg/release"
 )
 
-func compactValidationQueryForLog(query string) string {
-	query = strings.Join(strings.Fields(strings.TrimSpace(query)), " ")
-	if len(query) <= 96 {
-		return query
+func validationQueriesForRequest(req indexer.SearchRequest) []string {
+	if len(req.ValidationQueries) > 0 {
+		queries := make([]string, 0, len(req.ValidationQueries))
+		for _, query := range req.ValidationQueries {
+			trimmed := strings.TrimSpace(query)
+			if trimmed == "" {
+				continue
+			}
+			queries = append(queries, trimmed)
+		}
+		if len(queries) > 0 {
+			return queries
+		}
 	}
-	return strings.TrimSpace(query[:93]) + "..."
+	if trimmed := strings.TrimSpace(req.ValidationQuery); trimmed != "" {
+		return []string{trimmed}
+	}
+	return nil
+}
+
+func validationProfilesForRequest(req indexer.SearchRequest) []indexer.ValidationQueryProfile {
+	if len(req.ValidationQueryProfiles) > 0 {
+		profiles := make([]indexer.ValidationQueryProfile, 0, len(req.ValidationQueryProfiles))
+		for _, profile := range req.ValidationQueryProfiles {
+			query := strings.TrimSpace(profile.Query)
+			if query == "" {
+				continue
+			}
+			languages := make([]string, 0, len(profile.Languages))
+			for _, language := range profile.Languages {
+				trimmedLanguage := strings.TrimSpace(language)
+				if trimmedLanguage == "" {
+					continue
+				}
+				languages = append(languages, trimmedLanguage)
+			}
+			profiles = append(profiles, indexer.ValidationQueryProfile{
+				Languages: languages,
+				Query:     query,
+			})
+		}
+		if len(profiles) > 0 {
+			return profiles
+		}
+	}
+	if len(req.ValidationQueries) > 0 {
+		profiles := make([]indexer.ValidationQueryProfile, 0, len(req.ValidationQueries))
+		for _, query := range req.ValidationQueries {
+			trimmed := strings.TrimSpace(query)
+			if trimmed == "" {
+				continue
+			}
+			profiles = append(profiles, indexer.ValidationQueryProfile{Query: trimmed})
+		}
+		if len(profiles) > 0 {
+			return profiles
+		}
+	}
+	if trimmed := strings.TrimSpace(req.ValidationQuery); trimmed != "" {
+		return []indexer.ValidationQueryProfile{{Query: trimmed}}
+	}
+	return nil
 }
 
 func RunIndexerSearches(idx indexer.Indexer, req indexer.SearchRequest, contentType string) ([]*release.Release, error) {
@@ -26,8 +82,8 @@ func RunIndexerSearches(idx indexer.Indexer, req indexer.SearchRequest, contentT
 	runIDSearch := strings.EqualFold(strings.TrimSpace(req.SearchMode), "id")
 	searchReq := req
 
-	validationQuery := req.ValidationQuery
-	if strings.TrimSpace(validationQuery) == "" {
+	validationQueries := validationQueriesForRequest(req)
+	if len(validationQueries) == 0 {
 		mode := "text"
 		if runIDSearch {
 			mode = "id"
@@ -117,40 +173,47 @@ func RunIndexerSearches(idx indexer.Indexer, req indexer.SearchRequest, contentT
 		}
 	}
 
-	var validationStats ValidationStats
-	releases, validationStats = ValidateSearchResultsWithStats(releases, contentType, validationQuery, req.Season, req.Episode, true, req.EnableYearValidation)
-	validationAttrs := []any{
-		"stream", req.StreamLabel,
-		"request", req.RequestLabel,
-		"mode", func() string {
-			if runIDSearch {
-				return "id"
-			}
-			return "text"
-		}(),
-		"type", contentType,
-		"validation_query", compactValidationQueryForLog(validationQuery),
-		"raw_results", validationStats.RawResults,
-		"final_results", validationStats.FinalResults,
-		"rejected_results", validationStats.RejectedResults,
-		"dropped_title", validationStats.DroppedTitle,
-		"dropped_year", validationStats.DroppedYear,
+	releases, _ = ValidateSearchResultsWithStatsForQueries(releases, contentType, validationQueries, req.Season, req.Episode, true, req.EnableYearValidation)
+	for _, profile := range validationProfilesForRequest(req) {
+		_, profileStats := ValidateSearchResultsWithStats(rawReleases, contentType, profile.Query, req.Season, req.Episode, true, req.EnableYearValidation)
+		validationAttrs := []any{
+			"stream", req.StreamLabel,
+			"request", req.RequestLabel,
+			"mode", func() string {
+				if runIDSearch {
+					return "id"
+				}
+				return "text"
+			}(),
+			"type", contentType,
+			"raw_results", profileStats.RawResults,
+			"final_results", profileStats.FinalResults,
+			"rejected_results", profileStats.RejectedResults,
+			"dropped_title", profileStats.DroppedTitle,
+			"dropped_year", profileStats.DroppedYear,
+			"validation_query", profile.Query,
+		}
+		if len(profile.Languages) == 1 {
+			validationAttrs = append(validationAttrs, "title_language", profile.Languages[0])
+		} else if len(profile.Languages) > 1 {
+			validationAttrs = append(validationAttrs, "title_languages", profile.Languages)
+		}
+		if contentType == "series" {
+			validationAttrs = append(validationAttrs,
+				"scope", config.NormalizeSeriesSearchScope(req.SeriesSearchScope),
+				"expected_season", profileStats.ExpectedSeason,
+				"expected_episode", profileStats.ExpectedEpisode,
+				"dropped_episode_request", profileStats.DroppedEpisodeRequest,
+				"dropped_season", profileStats.DroppedSeason,
+				"accepted_exact_episode", profileStats.AcceptedExactEpisode,
+				"accepted_multi_episode", profileStats.AcceptedMultiEpisode,
+				"accepted_season_pack", profileStats.AcceptedSeasonPack,
+				"accepted_complete_pack", profileStats.AcceptedCompletePack,
+				"accepted_season_match", profileStats.AcceptedSeasonMatch,
+			)
+		}
+		logger.Debug("Search request validation", validationAttrs...)
 	}
-	if contentType == "series" {
-		validationAttrs = append(validationAttrs,
-			"scope", config.NormalizeSeriesSearchScope(req.SeriesSearchScope),
-			"expected_season", validationStats.ExpectedSeason,
-			"expected_episode", validationStats.ExpectedEpisode,
-			"dropped_episode_request", validationStats.DroppedEpisodeRequest,
-			"dropped_season", validationStats.DroppedSeason,
-			"accepted_exact_episode", validationStats.AcceptedExactEpisode,
-			"accepted_multi_episode", validationStats.AcceptedMultiEpisode,
-			"accepted_season_pack", validationStats.AcceptedSeasonPack,
-			"accepted_complete_pack", validationStats.AcceptedCompletePack,
-			"accepted_season_match", validationStats.AcceptedSeasonMatch,
-		)
-	}
-	logger.Debug("Search request validation", validationAttrs...)
 
 	switch {
 	case !runIDSearch:

--- a/pkg/search/search_test.go
+++ b/pkg/search/search_test.go
@@ -381,6 +381,21 @@ func TestRunIndexerSearchesUsesValidationQueriesWhenPresent(t *testing.T) {
 	}
 }
 
+func TestValidationQueriesForRequestUsesProfiles(t *testing.T) {
+	req := indexer.SearchRequest{
+		ValidationQueryProfiles: []indexer.ValidationQueryProfile{
+			{Languages: []string{"en-US"}, Query: "Witch Hat Atelier"},
+			{Languages: []string{"original"}, Query: "Tongari Boushi no Atelier"},
+		},
+	}
+
+	got := validationQueriesForRequest(req)
+	want := []string{"Witch Hat Atelier", "Tongari Boushi no Atelier"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("validationQueriesForRequest() = %#v, want %#v", got, want)
+	}
+}
+
 func TestValidationProfilesForRequestPreferExplicitProfiles(t *testing.T) {
 	req := indexer.SearchRequest{
 		ValidationQueryProfiles: []indexer.ValidationQueryProfile{

--- a/pkg/search/search_test.go
+++ b/pkg/search/search_test.go
@@ -3,6 +3,7 @@ package search
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -212,6 +213,21 @@ func TestValidateSearchResultsWithStatsAllowsOptionalAndWordMatches(t *testing.T
 	}
 }
 
+func TestValidateSearchResultsWithStatsForQueriesMatchesAnyExpectedTitle(t *testing.T) {
+	releases := []*release.Release{
+		{Title: "Koenig.der.Loewen.1994.1080p.BluRay.x264-GROUP"},
+	}
+
+	filtered, stats := ValidateSearchResultsWithStatsForQueries(releases, "movie", []string{"The Lion King 1994", "Koenig der Loewen 1994"}, "", "", true, true)
+
+	if len(filtered) != 1 {
+		t.Fatalf("expected multilingual validation to accept a matching alternate title, got %d results", len(filtered))
+	}
+	if stats.DroppedTitle != 0 || stats.DroppedYear != 0 {
+		t.Fatalf("expected no validation drops, got %+v", stats)
+	}
+}
+
 func TestValidateSearchResultsWithStatsAllowsDashedSeasonEpisodePattern(t *testing.T) {
 	releases := []*release.Release{
 		{Title: "[SubsPlease] Tensei Shitara Slime Datta Ken S4 - 03 (720p) [370B1C65]"},
@@ -334,5 +350,52 @@ func TestRunIndexerSearchesSkipsWithoutValidationBasis(t *testing.T) {
 	}
 	if len(idx.reqs) != 0 {
 		t.Fatalf("expected no Search call without validation basis, got %d", len(idx.reqs))
+	}
+}
+
+func TestRunIndexerSearchesUsesValidationQueriesWhenPresent(t *testing.T) {
+	idx := &staticIndexer{
+		name: "SceneNZBs",
+		resp: &indexer.SearchResponse{
+			Channel: indexer.Channel{
+				Items: []indexer.Item{
+					{Title: "Koenig.der.Loewen.1994.1080p.BluRay.x264-GROUP", ActualIndexer: "SceneNZBs"},
+				},
+			},
+		},
+	}
+	req := indexer.SearchRequest{
+		SearchMode:           "id",
+		IMDbID:               "tt0110357",
+		TMDBID:               "8587",
+		ValidationQueries:    []string{"The Lion King 1994", "Koenig der Loewen 1994"},
+		EnableYearValidation: true,
+	}
+
+	got, err := RunIndexerSearches(idx, req, "movie")
+	if err != nil {
+		t.Fatalf("RunIndexerSearches() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected multilingual validation queries to keep the result, got %d", len(got))
+	}
+}
+
+func TestValidationProfilesForRequestPreferExplicitProfiles(t *testing.T) {
+	req := indexer.SearchRequest{
+		ValidationQueryProfiles: []indexer.ValidationQueryProfile{
+			{Languages: []string{"en-US"}, Query: "Witch Hat Atelier"},
+			{Languages: []string{"original"}, Query: "Tongari Boushi no Atelier"},
+		},
+		ValidationQueries: []string{"ignored"},
+	}
+
+	got := validationProfilesForRequest(req)
+	want := []indexer.ValidationQueryProfile{
+		{Languages: []string{"en-US"}, Query: "Witch Hat Atelier"},
+		{Languages: []string{"original"}, Query: "Tongari Boushi no Atelier"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("validationProfilesForRequest() = %#v, want %#v", got, want)
 	}
 }

--- a/pkg/search/validation.go
+++ b/pkg/search/validation.go
@@ -202,12 +202,93 @@ type ValidationStats struct {
 	DroppedYear           int
 }
 
+type validationExpectation struct {
+	Title string
+	Year  int
+}
+
+func validationExpectationsForQueries(contentType string, validationQueries []string) []validationExpectation {
+	expectations := make([]validationExpectation, 0, len(validationQueries))
+	seen := make(map[string]bool, len(validationQueries))
+	for _, validationQuery := range validationQueries {
+		trimmed := strings.TrimSpace(validationQuery)
+		if trimmed == "" {
+			continue
+		}
+		var title string
+		var year int
+		if contentType == "movie" {
+			title, year = parseValidationQuery(trimmed)
+		} else {
+			title, year = parseSeriesValidationQuery(trimmed)
+		}
+		if title == "" {
+			continue
+		}
+		key := title + "\x00" + strconv.Itoa(year)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		expectations = append(expectations, validationExpectation{
+			Title: title,
+			Year:  year,
+		})
+	}
+	return expectations
+}
+
+func titleMatchesAnyExpectation(expectations []validationExpectation, gotTitle string) bool {
+	if len(expectations) == 0 {
+		return true
+	}
+	for _, expectation := range expectations {
+		if expectation.Title == "" {
+			continue
+		}
+		if normalizedTitleMatches(expectation.Title, gotTitle) {
+			return true
+		}
+	}
+	return false
+}
+
+func anyExpectationHasYear(expectations []validationExpectation) bool {
+	for _, expectation := range expectations {
+		if expectation.Year > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func yearMatchesAnyExpectation(expectations []validationExpectation, gotYear int) bool {
+	for _, expectation := range expectations {
+		if expectation.Year <= 0 {
+			continue
+		}
+		if movieYearMatches(expectation.Year, gotYear) {
+			return true
+		}
+	}
+	return false
+}
+
 func ValidateSearchResults(releases []*release.Release, contentType, validationQuery, season, episode string, enableTitleValidation, enableYearValidation bool) []*release.Release {
 	filtered, _ := ValidateSearchResultsWithStats(releases, contentType, validationQuery, season, episode, enableTitleValidation, enableYearValidation)
 	return filtered
 }
 
+func ValidateSearchResultsForQueries(releases []*release.Release, contentType string, validationQueries []string, season, episode string, enableTitleValidation, enableYearValidation bool) []*release.Release {
+	filtered, _ := ValidateSearchResultsWithStatsForQueries(releases, contentType, validationQueries, season, episode, enableTitleValidation, enableYearValidation)
+	return filtered
+}
+
 func ValidateSearchResultsWithStats(releases []*release.Release, contentType, validationQuery, season, episode string, enableTitleValidation, enableYearValidation bool) ([]*release.Release, ValidationStats) {
+	return ValidateSearchResultsWithStatsForQueries(releases, contentType, []string{validationQuery}, season, episode, enableTitleValidation, enableYearValidation)
+}
+
+func ValidateSearchResultsWithStatsForQueries(releases []*release.Release, contentType string, validationQueries []string, season, episode string, enableTitleValidation, enableYearValidation bool) ([]*release.Release, ValidationStats) {
 	stats := ValidationStats{}
 	if contentType != "movie" && contentType != "series" {
 		stats.RawResults = len(releases)
@@ -219,17 +300,13 @@ func ValidateSearchResultsWithStats(releases []*release.Release, contentType, va
 	stats.ExpectedSeason = expectSeason
 	stats.ExpectedEpisode = expectEpisode
 
-	var expectTitle string
-	var expectYear int
-	if contentType == "movie" {
-		expectTitle, expectYear = parseValidationQuery(validationQuery)
-	} else {
-		expectTitle, expectYear = parseSeriesValidationQuery(validationQuery)
+	expectations := validationExpectationsForQueries(contentType, validationQueries)
+	if len(expectations) > 0 {
+		stats.ExpectedTitle = expectations[0].Title
+		stats.ExpectedYear = expectations[0].Year
 	}
-	stats.ExpectedTitle = expectTitle
-	stats.ExpectedYear = expectYear
-	stats.TitleValidationApplied = enableTitleValidation && expectTitle != ""
-	stats.YearValidationApplied = enableYearValidation && expectYear > 0
+	stats.TitleValidationApplied = enableTitleValidation && len(expectations) > 0
+	stats.YearValidationApplied = enableYearValidation && anyExpectationHasYear(expectations)
 
 	var out []*release.Release
 	for _, rel := range releases {
@@ -247,20 +324,20 @@ func ValidateSearchResultsWithStats(releases []*release.Release, contentType, va
 		}
 
 		if contentType == "movie" {
-			if stats.TitleValidationApplied && !normalizedTitleMatches(expectTitle, parsed.Title) {
+			if stats.TitleValidationApplied && !titleMatchesAnyExpectation(expectations, parsed.Title) {
 				stats.DroppedTitle++
 				logger.Trace("ValidateSearchResults dropped: title",
-					"expect_title", expectTitle,
+					"expect_title", stats.ExpectedTitle,
 					"got_title", parsed.Title,
 					"release", rel.Title,
 				)
 				continue
 			}
 		} else {
-			if stats.TitleValidationApplied && !normalizedTitleMatches(expectTitle, parsed.Title) {
+			if stats.TitleValidationApplied && !titleMatchesAnyExpectation(expectations, parsed.Title) {
 				stats.DroppedTitle++
 				logger.Trace("ValidateSearchResults dropped: title",
-					"expect_title", expectTitle,
+					"expect_title", stats.ExpectedTitle,
 					"got_title", parsed.Title,
 					"release", rel.Title,
 				)
@@ -290,10 +367,10 @@ func ValidateSearchResultsWithStats(releases []*release.Release, contentType, va
 			}
 		}
 
-		if stats.YearValidationApplied && !movieYearMatches(expectYear, parsed.Year) {
+		if stats.YearValidationApplied && !yearMatchesAnyExpectation(expectations, parsed.Year) {
 			stats.DroppedYear++
 			logger.Trace("ValidateSearchResults dropped: year",
-				"expect_year", expectYear,
+				"expect_year", stats.ExpectedYear,
 				"got_year", parsed.Year,
 				"release", rel.Title,
 			)

--- a/pkg/server/api/websocket.go
+++ b/pkg/server/api/websocket.go
@@ -767,6 +767,13 @@ func (s *Server) validateConfigWithPlan(cfg *config.Config, plan configValidatio
 			if mode != "id" && mode != "text" {
 				errors[fmt.Sprintf("%s.%d.search_mode", prefix, i)] = "Search mode must be id or text"
 			}
+			titleLanguages := config.NormalizeSearchTitleLanguages(query.SearchTitleLanguages)
+			if mode == "text" && len(titleLanguages) > 1 {
+				errors[fmt.Sprintf("%s.%d.search_title_languages", prefix, i)] = "Text search can use only one title language"
+			}
+			if mode == "id" && len(titleLanguages) == 0 && config.NormalizeSearchTitleLanguage(query.SearchTitleLanguage) == "" {
+				errors[fmt.Sprintf("%s.%d.search_title_languages", prefix, i)] = "Add at least one title language"
+			}
 			if prefix == "series_search_queries" {
 				rawScope := strings.ToLower(strings.TrimSpace(query.SeriesSearchScope))
 				if rawScope != "" {

--- a/pkg/server/api/websocket.go
+++ b/pkg/server/api/websocket.go
@@ -768,10 +768,15 @@ func (s *Server) validateConfigWithPlan(cfg *config.Config, plan configValidatio
 				errors[fmt.Sprintf("%s.%d.search_mode", prefix, i)] = "Search mode must be id or text"
 			}
 			titleLanguages := config.NormalizeSearchTitleLanguages(query.SearchTitleLanguages)
+			if mode == "id" && len(titleLanguages) == 0 {
+				if rawSingle := strings.TrimSpace(query.SearchTitleLanguage); rawSingle != "" {
+					titleLanguages = []string{config.NormalizeSearchTitleLanguage(rawSingle)}
+				}
+			}
 			if mode == "text" && len(titleLanguages) > 1 {
 				errors[fmt.Sprintf("%s.%d.search_title_languages", prefix, i)] = "Text search can use only one title language"
 			}
-			if mode == "id" && len(titleLanguages) == 0 && config.NormalizeSearchTitleLanguage(query.SearchTitleLanguage) == "" {
+			if mode == "id" && len(titleLanguages) == 0 {
 				errors[fmt.Sprintf("%s.%d.search_title_languages", prefix, i)] = "Add at least one title language"
 			}
 			if prefix == "series_search_queries" {

--- a/pkg/server/api/websocket_test.go
+++ b/pkg/server/api/websocket_test.go
@@ -157,3 +157,20 @@ func TestValidateConfigRejectsOutOfRangePlaybackStartupTimeout(t *testing.T) {
 		t.Fatalf("expected playback startup timeout validation error, got %#v", errs)
 	}
 }
+
+func TestValidateConfigWithPlanAllowsLegacyOriginalIDTitleLanguage(t *testing.T) {
+	s := &Server{}
+
+	cfg := &config.Config{
+		MovieSearchQueries: []config.SearchQueryConfig{{
+			Name:                "MovieQuery01",
+			SearchMode:          "id",
+			SearchTitleLanguage: "original",
+		}},
+	}
+
+	errs := s.validateConfigWithPlan(cfg, configValidationPlan{validateMovieSearchQueries: true})
+	if got := errs["movie_search_queries.0.search_title_languages"]; got != "" {
+		t.Fatalf("expected legacy original title language to be accepted, got %q", got)
+	}
+}

--- a/pkg/server/stremio/handlers_attempts_test.go
+++ b/pkg/server/stremio/handlers_attempts_test.go
@@ -97,6 +97,48 @@ func TestRecordAttemptParamsDerivesCompletePackMatchType(t *testing.T) {
 	}
 }
 
+func TestAllowLargestDirectFallbackForSessionMovie(t *testing.T) {
+	sess := &session.Session{ContentType: "movie"}
+	if !allowLargestDirectFallbackForSession(sess) {
+		t.Fatal("expected movie sessions to allow largest direct fallback")
+	}
+}
+
+func TestAllowLargestDirectFallbackForSessionExactEpisodeOnly(t *testing.T) {
+	exact := &session.Session{
+		ContentType: "series",
+		ContentID:   "tt2261227:2:3",
+		Release: &release.Release{
+			Title: "Altered.Carbon.S02E03.1080p.NF.WEB-DL.DDP5.1.Atmos.H.264.mkv",
+		},
+	}
+	if !allowLargestDirectFallbackForSession(exact) {
+		t.Fatal("expected exact episode sessions to allow largest direct fallback")
+	}
+
+	seasonPack := &session.Session{
+		ContentType: "series",
+		ContentID:   "tt2261227:2:3",
+		Release: &release.Release{
+			Title: "Altered.Carbon.S02.COMPLETE.1080p.NF.WEB-DL.DDP5.1.Atmos.H.264.mkv",
+		},
+	}
+	if allowLargestDirectFallbackForSession(seasonPack) {
+		t.Fatal("did not expect season pack sessions to allow largest direct fallback")
+	}
+
+	completePack := &session.Session{
+		ContentType: "series",
+		ContentID:   "tt3032476:1:2",
+		Release: &release.Release{
+			Title: "The.Good.Place.Complete.Series.1080p.NF.WEB-DL.DD5.1.x264-GROUP",
+		},
+	}
+	if allowLargestDirectFallbackForSession(completePack) {
+		t.Fatal("did not expect complete pack sessions to allow largest direct fallback")
+	}
+}
+
 func TestCacheReturnedPlaybackBlueprintReplacesStaleBlueprint(t *testing.T) {
 	sess := &session.Session{}
 	stale := &unpack.DirectBlueprint{FileName: "Show.S01E04.mkv", FileIndex: 1, Target: unpack.EpisodeTarget{Season: 1, Episode: 4}}

--- a/pkg/server/stremio/handlers_playback.go
+++ b/pkg/server/stremio/handlers_playback.go
@@ -1612,7 +1612,10 @@ func (s *Server) openPlaybackSource(ctx context.Context, sess *session.Session) 
 	if sess.ContentIDs != nil {
 		target = unpack.EpisodeTarget{Season: sess.ContentIDs.Season, Episode: sess.ContentIDs.Episode}
 	}
-	stream, name, size, bp, err := unpack.GetMediaStreamForEpisode(ctx, unpackFiles, sess.Blueprint, password, target)
+	hints := unpack.StreamSelectionHints{
+		AllowLargestDirectFallback: allowLargestDirectFallbackForSession(sess),
+	}
+	stream, name, size, bp, err := unpack.GetMediaStreamForEpisodeWithHints(ctx, unpackFiles, sess.Blueprint, password, target, hints)
 	cacheReturnedPlaybackBlueprint(sess, bp)
 	if err != nil {
 		logger.Error("Failed to open media stream", "id", sessionID, "err", err)
@@ -1910,6 +1913,20 @@ func matchTypeForSession(sess *session.Session, contentType string) string {
 		return "season_match"
 	default:
 		return ""
+	}
+}
+
+func allowLargestDirectFallbackForSession(sess *session.Session) bool {
+	if sess == nil {
+		return false
+	}
+	switch strings.TrimSpace(sess.ContentType) {
+	case "movie":
+		return true
+	case "series":
+		return matchTypeForSession(sess, "series") == "exact_episode"
+	default:
+		return false
 	}
 }
 
@@ -2258,7 +2275,10 @@ func (s *Server) handleDebugPlay(w http.ResponseWriter, r *http.Request, streamC
 	if sess.ContentIDs != nil {
 		target = unpack.EpisodeTarget{Season: sess.ContentIDs.Season, Episode: sess.ContentIDs.Episode}
 	}
-	stream, name, size, bp, err := unpack.GetMediaStreamForEpisode(mergedCtx, unpackFiles, sess.Blueprint, password, target)
+	hints := unpack.StreamSelectionHints{
+		AllowLargestDirectFallback: allowLargestDirectFallbackForSession(sess),
+	}
+	stream, name, size, bp, err := unpack.GetMediaStreamForEpisodeWithHints(mergedCtx, unpackFiles, sess.Blueprint, password, target, hints)
 	cacheReturnedPlaybackBlueprint(sess, bp)
 	if err != nil {
 		logger.Error("Failed to open media stream", "err", err)

--- a/pkg/server/stremio/handlers_search.go
+++ b/pkg/server/stremio/handlers_search.go
@@ -1431,11 +1431,7 @@ func (s *Server) buildSearchParamsFromBase(base *SearchParams, searchQuery *conf
 	req.ValidationQueryProfiles = nil
 	req.ValidationQueries = nil
 	validationLanguages := validationTitleLanguages(searchMode, searchTitleLanguage, searchTitleLanguages)
-	if contentType == "movie" {
-		req.ValidationQueryProfiles = validationQueryProfilesFromMetadata(params.Metadata, contentType, validationLanguages, includeYear)
-	} else {
-		req.ValidationQueryProfiles = validationQueryProfilesFromMetadata(params.Metadata, contentType, validationLanguages, includeYear)
-	}
+	req.ValidationQueryProfiles = validationQueryProfilesFromMetadata(params.Metadata, contentType, validationLanguages, includeYear)
 	req.ValidationQueries = validationQueriesFromProfiles(req.ValidationQueryProfiles)
 	req.ValidationQuery = ""
 	if len(req.ValidationQueries) > 0 {

--- a/pkg/server/stremio/handlers_search.go
+++ b/pkg/server/stremio/handlers_search.go
@@ -108,6 +108,29 @@ func metadataAlternativeTitle(metadata *resolvedSearchMetadata, contentType stri
 	return ""
 }
 
+func metadataFallbackTitle(metadata *resolvedSearchMetadata, contentType string) string {
+	original := strings.TrimSpace(metadataOriginalTitle(metadata, contentType))
+	if metadata == nil || original == "" || hasLatinLetter(original) {
+		return ""
+	}
+	if metadataAlternativeTitle(metadata, contentType) != "" {
+		return ""
+	}
+	if !strings.EqualFold(strings.TrimSpace(metadataOriginalLanguage(metadata, contentType)), "ja") {
+		return ""
+	}
+	if contentType == "movie" {
+		if fallback := strings.TrimSpace(preferredMovieEnglishTitle(metadata)); fallback != "" && !strings.EqualFold(fallback, original) {
+			return fallback
+		}
+		return ""
+	}
+	if fallback := strings.TrimSpace(preferredSeriesEnglishTitle(metadata)); fallback != "" && !strings.EqualFold(fallback, original) {
+		return fallback
+	}
+	return ""
+}
+
 func metadataDisplayYear(metadata *resolvedSearchMetadata, contentType string) string {
 	if metadata == nil {
 		return ""
@@ -197,6 +220,16 @@ func pickRomanizedAlternativeTitle(alternatives []tmdb.AlternativeTitle) string 
 	return ""
 }
 
+func preferredMovieEnglishTitle(metadata *resolvedSearchMetadata) string {
+	if metadata == nil || metadata.MovieDetails == nil {
+		return ""
+	}
+	if localized := localizedMovieTitleForLanguage(metadata.MovieTranslations, "en-US"); localized != "" {
+		return localized
+	}
+	return strings.TrimSpace(metadata.MovieDetails.Title)
+}
+
 func preferredMovieOriginalTitle(metadata *resolvedSearchMetadata) string {
 	if metadata == nil || metadata.MovieDetails == nil {
 		return ""
@@ -216,7 +249,20 @@ func preferredMovieOriginalTitle(metadata *resolvedSearchMetadata) string {
 			return alt
 		}
 	}
+	if english := preferredMovieEnglishTitle(metadata); english != "" {
+		return english
+	}
 	return title
+}
+
+func preferredSeriesEnglishTitle(metadata *resolvedSearchMetadata) string {
+	if metadata == nil || metadata.TVDetails == nil {
+		return ""
+	}
+	if localized := localizedTVTitleForLanguage(metadata.TVTranslations, "en-US"); localized != "" {
+		return localized
+	}
+	return strings.TrimSpace(metadata.TVDetails.Name)
 }
 
 func preferredSeriesOriginalTitle(metadata *resolvedSearchMetadata) string {
@@ -237,6 +283,9 @@ func preferredSeriesOriginalTitle(metadata *resolvedSearchMetadata) string {
 		if alt := pickRomanizedAlternativeTitle(metadata.TVAlternativeTitles.Results); alt != "" {
 			return alt
 		}
+	}
+	if english := preferredSeriesEnglishTitle(metadata); english != "" {
+		return english
 	}
 	return title
 }
@@ -365,6 +414,24 @@ func buildMovieValidationQueryFromMetadata(metadata *resolvedSearchMetadata, lan
 	return title
 }
 
+func buildMovieValidationQueriesFromMetadata(metadata *resolvedSearchMetadata, languages []string, includeYear bool) []string {
+	queries := make([]string, 0, len(languages))
+	seen := make(map[string]bool, len(languages))
+	for _, language := range languages {
+		query := strings.TrimSpace(buildMovieValidationQueryFromMetadata(metadata, language, includeYear))
+		if query == "" {
+			continue
+		}
+		key := strings.ToLower(query)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		queries = append(queries, query)
+	}
+	return queries
+}
+
 func buildMovieOriginalQueryFromMetadata(metadata *resolvedSearchMetadata) string {
 	return strings.TrimSpace(preferredMovieOriginalTitle(metadata))
 }
@@ -438,29 +505,207 @@ func buildSeriesValidationQueryFromMetadata(metadata *resolvedSearchMetadata, la
 	return title
 }
 
+func buildSeriesValidationQueriesFromMetadata(metadata *resolvedSearchMetadata, languages []string, includeYear bool) []string {
+	queries := make([]string, 0, len(languages))
+	seen := make(map[string]bool, len(languages))
+	for _, language := range languages {
+		query := strings.TrimSpace(buildSeriesValidationQueryFromMetadata(metadata, language, includeYear))
+		if query == "" {
+			continue
+		}
+		key := strings.ToLower(query)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		queries = append(queries, query)
+	}
+	return queries
+}
+
 func buildSeriesOriginalQueryFromMetadata(metadata *resolvedSearchMetadata) string {
 	return strings.TrimSpace(preferredSeriesOriginalTitle(metadata))
 }
 
-func searchRequestNormalisationLogValues(metadata *resolvedSearchMetadata, contentType, language string, includeYear bool, season, episode, scope string) (string, string, string, bool) {
-	var originalTitle string
-	var selectedTitle string
-	if contentType == "movie" {
-		originalTitle = buildMovieOriginalQueryFromMetadata(metadata)
-		selectedTitle = buildMovieSearchQueryFromMetadata(metadata, language, false)
-	} else {
-		originalTitle = buildSeriesOriginalQueryFromMetadata(metadata)
-		selectedTitle = buildSeriesSearchTitleFromMetadata(metadata, language)
+func uniqueTitleLogValues(values []string) []string {
+	if len(values) == 0 {
+		return nil
 	}
-	if selectedTitle == "" {
-		return "", "", "", false
+	out := make([]string, 0, len(values))
+	seen := make(map[string]bool, len(values))
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		key := strings.ToLower(trimmed)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, trimmed)
 	}
+	return out
+}
 
-	normalized := strings.TrimSpace(release.NormalizeTitleForSearchQuery(selectedTitle))
-	if normalized == "" || strings.EqualFold(normalized, selectedTitle) {
-		return "", "", "", false
+func validationTitleLanguages(searchMode, language string, languages []string) []string {
+	if strings.EqualFold(strings.TrimSpace(searchMode), "id") {
+		normalized := config.NormalizeSearchTitleLanguages(languages)
+		if len(normalized) > 0 {
+			return normalized
+		}
+		single := config.NormalizeSearchTitleLanguage(language)
+		if single != "" {
+			return []string{single}
+		}
+		return config.DefaultIDSearchTitleLanguages()
 	}
-	return strings.TrimSpace(originalTitle), selectedTitle, normalized, true
+	single := config.NormalizeSearchTitleLanguage(language)
+	if single == "" {
+		return []string{""}
+	}
+	return []string{single}
+}
+
+type titleLogEntry struct {
+	Languages       []string
+	InputTitle      string
+	NormalizedTitle string
+}
+
+func searchRequestNormalisationLogEntries(metadata *resolvedSearchMetadata, contentType string, languages []string) ([]titleLogEntry, bool) {
+	grouped := make(map[string]*titleLogEntry, len(languages))
+	order := make([]string, 0, len(languages))
+	changed := false
+	for _, language := range languages {
+		var selectedTitle string
+		if contentType == "movie" {
+			selectedTitle = buildMovieSearchQueryFromMetadata(metadata, language, false)
+		} else {
+			selectedTitle = buildSeriesSearchTitleFromMetadata(metadata, language)
+		}
+		selectedTitle = strings.TrimSpace(selectedTitle)
+		if selectedTitle == "" {
+			continue
+		}
+		normalized := strings.TrimSpace(release.NormalizeTitleForSearchQuery(selectedTitle))
+		if normalized == "" {
+			continue
+		}
+		logLanguage := searchTitleLanguageForLog(language)
+		key := strings.ToLower(selectedTitle) + "\x00" + strings.ToLower(normalized)
+		entry, ok := grouped[key]
+		if !ok {
+			entry = &titleLogEntry{
+				Languages:       []string{logLanguage},
+				InputTitle:      selectedTitle,
+				NormalizedTitle: normalized,
+			}
+			grouped[key] = entry
+			order = append(order, key)
+		} else {
+			exists := false
+			for _, existing := range entry.Languages {
+				if strings.EqualFold(existing, logLanguage) {
+					exists = true
+					break
+				}
+			}
+			if !exists {
+				entry.Languages = append(entry.Languages, logLanguage)
+			}
+		}
+		if !strings.EqualFold(strings.TrimSpace(normalized), strings.TrimSpace(selectedTitle)) {
+			changed = true
+		}
+	}
+	entries := make([]titleLogEntry, 0, len(order))
+	for _, key := range order {
+		entry := grouped[key]
+		if entry == nil {
+			continue
+		}
+		entries = append(entries, *entry)
+	}
+	if len(entries) == 0 {
+		return nil, false
+	}
+	if len(entries) > 1 {
+		changed = true
+	}
+	for _, entry := range entries {
+		if len(entry.Languages) > 1 {
+			changed = true
+			break
+		}
+	}
+	if !changed {
+		return nil, false
+	}
+	return entries, true
+}
+
+func validationQueryProfilesFromMetadata(metadata *resolvedSearchMetadata, contentType string, languages []string, includeYear bool) []indexer.ValidationQueryProfile {
+	grouped := make(map[string]*indexer.ValidationQueryProfile, len(languages))
+	order := make([]string, 0, len(languages))
+	for _, language := range languages {
+		var query string
+		if contentType == "movie" {
+			query = strings.TrimSpace(buildMovieValidationQueryFromMetadata(metadata, language, includeYear))
+		} else {
+			query = strings.TrimSpace(buildSeriesValidationQueryFromMetadata(metadata, language, includeYear))
+		}
+		if query == "" {
+			continue
+		}
+		logLanguage := searchTitleLanguageForLog(language)
+		key := strings.ToLower(query)
+		profile, ok := grouped[key]
+		if !ok {
+			profile = &indexer.ValidationQueryProfile{
+				Languages: []string{logLanguage},
+				Query:     query,
+			}
+			grouped[key] = profile
+			order = append(order, key)
+			continue
+		}
+		exists := false
+		for _, existing := range profile.Languages {
+			if strings.EqualFold(existing, logLanguage) {
+				exists = true
+				break
+			}
+		}
+		if !exists {
+			profile.Languages = append(profile.Languages, logLanguage)
+		}
+	}
+	profiles := make([]indexer.ValidationQueryProfile, 0, len(order))
+	for _, key := range order {
+		if profile := grouped[key]; profile != nil {
+			profiles = append(profiles, *profile)
+		}
+	}
+	return profiles
+}
+
+func validationQueriesFromProfiles(profiles []indexer.ValidationQueryProfile) []string {
+	queries := make([]string, 0, len(profiles))
+	seen := make(map[string]bool, len(profiles))
+	for _, profile := range profiles {
+		query := strings.TrimSpace(profile.Query)
+		if query == "" {
+			continue
+		}
+		key := strings.ToLower(query)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		queries = append(queries, query)
+	}
+	return queries
 }
 
 func buildMovieQueriesFromMetadata(metadata *resolvedSearchMetadata, language string, includeYear bool) []string {
@@ -535,6 +780,11 @@ func logMetadataLookupFinished(streamLabel, contentType, id string, params *Sear
 	}
 	if alternativeTitle := metadataAlternativeTitle(params.Metadata, contentType); alternativeTitle != "" {
 		attrs = append(attrs, "alternative_title", alternativeTitle)
+	} else if fallbackTitle := metadataFallbackTitle(params.Metadata, contentType); fallbackTitle != "" {
+		attrs = append(attrs,
+			"fallback_reason", "no_romaji",
+			"fallback_title", fallbackTitle,
+		)
 	}
 	if contentType == "series" {
 		attrs = append(attrs,
@@ -573,11 +823,23 @@ func logStreamConfiguration(streamLabel, contentType string, stream *auth.Stream
 }
 
 func searchTitleLanguageForLog(language string) string {
-	trimmed := strings.TrimSpace(language)
+	trimmed := config.NormalizeSearchTitleLanguage(language)
 	if trimmed == "" {
 		return "original"
 	}
 	return trimmed
+}
+
+func searchTitleLanguagesForLog(languages []string) []string {
+	normalized := config.NormalizeSearchTitleLanguages(languages)
+	if len(normalized) == 0 {
+		return []string{"original"}
+	}
+	values := make([]string, 0, len(normalized))
+	for _, language := range normalized {
+		values = append(values, searchTitleLanguageForLog(language))
+	}
+	return values
 }
 
 func searchLimitForLog(limit int) any {
@@ -653,7 +915,11 @@ func (s *Server) runConfiguredSearchRequests(contentType, id, streamLabel string
 		applyStreamIndexerSelection(&profileParams.Req, stream)
 		profileParams.Req.DisableResultFiltering = stream == nil || strings.TrimSpace(stream.FilterSortingMode) == "" || strings.EqualFold(strings.TrimSpace(stream.FilterSortingMode), "none") || streamUsesAIOStreamsProfile(stream)
 		searchMode := strings.ToLower(strings.TrimSpace(searchQuery.SearchMode))
-		if strings.TrimSpace(profileParams.Req.ValidationQuery) == "" {
+		validationQueries := append([]string(nil), profileParams.Req.ValidationQueries...)
+		if len(validationQueries) == 0 && strings.TrimSpace(profileParams.Req.ValidationQuery) != "" {
+			validationQueries = []string{profileParams.Req.ValidationQuery}
+		}
+		if len(validationQueries) == 0 {
 			logger.Debug("Skipping search request without validation basis",
 				"stream", streamLabel,
 				"request", searchQuery.Name,
@@ -662,6 +928,7 @@ func (s *Server) runConfiguredSearchRequests(contentType, id, streamLabel string
 			)
 			continue
 		}
+		titleLanguages := validationTitleLanguages(searchQuery.SearchMode, searchQuery.SearchTitleLanguage, searchQuery.SearchTitleLanguages)
 		if searchMode == "id" && !hasUsableIDSearchIdentifier(profileParams.Req, contentType) {
 			logger.Debug("Skipping search request without resolved metadata identifiers",
 				"stream", streamLabel,
@@ -694,10 +961,14 @@ func (s *Server) runConfiguredSearchRequests(contentType, id, streamLabel string
 			"search_mode", searchQuery.SearchMode,
 			"type", contentType,
 			"id", id,
-			"title_language", searchTitleLanguageForLog(searchQuery.SearchTitleLanguage),
 			"year", profileParams.Req.EnableYearValidation,
 			"extra_terms", searchQuery.ExtraSearchTerms,
 			"limit", searchLimitForLog(effectiveLimit),
+		}
+		if searchMode == "id" {
+			configAttrs = append(configAttrs, "title_languages", searchTitleLanguagesForLog(titleLanguages))
+		} else {
+			configAttrs = append(configAttrs, "title_language", searchTitleLanguageForLog(searchQuery.SearchTitleLanguage))
 		}
 		if contentType == "series" {
 			configAttrs = append(configAttrs,
@@ -710,26 +981,25 @@ func (s *Server) runConfiguredSearchRequests(contentType, id, streamLabel string
 			)
 		}
 		logger.Debug("Search request config", configAttrs...)
-		logIncludeYear := true
-		if searchQuery.IncludeYear != nil {
-			logIncludeYear = *searchQuery.IncludeYear
-		}
-		if originalTitle, inputTitle, normalizedTitle, ok := searchRequestNormalisationLogValues(
+		if entries, ok := searchRequestNormalisationLogEntries(
 			profileParams.Metadata,
 			contentType,
-			searchQuery.SearchTitleLanguage,
-			logIncludeYear,
-			profileParams.Req.Season,
-			profileParams.Req.Episode,
-			profileParams.Req.SeriesSearchScope,
+			titleLanguages,
 		); ok {
-			logger.Debug("Search request normalisation",
-				"stream", streamLabel,
-				"request", searchQuery.Name,
-				"original_title", originalTitle,
-				"input_title", inputTitle,
-				"normalised_title", normalizedTitle,
-			)
+			for _, entry := range entries {
+				attrs := []any{
+					"stream", streamLabel,
+					"request", searchQuery.Name,
+					"input_title", entry.InputTitle,
+					"normalised_title", entry.NormalizedTitle,
+				}
+				if len(entry.Languages) == 1 {
+					attrs = append(attrs, "title_language", entry.Languages[0])
+				} else {
+					attrs = append(attrs, "title_languages", entry.Languages)
+				}
+				logger.Debug("Search request normalisation", attrs...)
+			}
 		}
 		queryVariants := profileParams.PreparedQueries
 		if searchMode == "id" || len(queryVariants) == 0 {
@@ -1138,12 +1408,14 @@ func (s *Server) buildSearchParamsFromBase(base *SearchParams, searchQuery *conf
 	req := &params.Req
 	searchMode := ""
 	searchTitleLanguage := ""
+	searchTitleLanguages := []string(nil)
 	includeYear := true
 	scope := config.NormalizeSeriesSearchScope(req.SeriesSearchScope)
 	var queryIndexerConfig *config.IndexerSearchConfig
 	if searchQuery != nil {
 		searchMode = strings.ToLower(strings.TrimSpace(searchQuery.SearchMode))
-		searchTitleLanguage = strings.TrimSpace(searchQuery.SearchTitleLanguage)
+		searchTitleLanguage = config.NormalizeSearchTitleLanguage(searchQuery.SearchTitleLanguage)
+		searchTitleLanguages = config.NormalizeSearchTitleLanguages(searchQuery.SearchTitleLanguages)
 		queryIndexerConfig = searchQuery.AsIndexerSearchConfig()
 		if searchQuery.IncludeYear != nil {
 			includeYear = *searchQuery.IncludeYear
@@ -1156,10 +1428,18 @@ func (s *Server) buildSearchParamsFromBase(base *SearchParams, searchQuery *conf
 	req.EnableYearValidation = includeYear
 	req.SearchMode = "text"
 	req.Query = ""
+	req.ValidationQueryProfiles = nil
+	req.ValidationQueries = nil
+	validationLanguages := validationTitleLanguages(searchMode, searchTitleLanguage, searchTitleLanguages)
 	if contentType == "movie" {
-		req.ValidationQuery = buildMovieValidationQueryFromMetadata(params.Metadata, searchTitleLanguage, includeYear)
+		req.ValidationQueryProfiles = validationQueryProfilesFromMetadata(params.Metadata, contentType, validationLanguages, includeYear)
 	} else {
-		req.ValidationQuery = buildSeriesValidationQueryFromMetadata(params.Metadata, searchTitleLanguage, includeYear)
+		req.ValidationQueryProfiles = validationQueryProfilesFromMetadata(params.Metadata, contentType, validationLanguages, includeYear)
+	}
+	req.ValidationQueries = validationQueriesFromProfiles(req.ValidationQueryProfiles)
+	req.ValidationQuery = ""
+	if len(req.ValidationQueries) > 0 {
+		req.ValidationQuery = req.ValidationQueries[0]
 	}
 	if searchMode == "id" {
 		req.SearchMode = "id"

--- a/pkg/server/stremio/handlers_search_test.go
+++ b/pkg/server/stremio/handlers_search_test.go
@@ -55,6 +55,120 @@ func TestBuildSeriesQueriesWithOptionsCanOmitYear(t *testing.T) {
 	}
 }
 
+func TestSearchRequestNormalisationLogEntriesSplitMultipleLanguages(t *testing.T) {
+	metadata := &resolvedSearchMetadata{
+		TVDetails: &tmdb.TVDetails{
+			Name:             "Witch Hat Atelier",
+			OriginalName:     "とんがり帽子のアトリエ",
+			OriginalLanguage: "ja",
+		},
+		TVAlternativeTitles: &tmdb.TVAlternativeTitlesResponse{
+			Results: []tmdb.AlternativeTitle{
+				{ISO3166_1: "JP", Title: "Tongari Boushi no Atelier", Type: "Romaji"},
+			},
+		},
+	}
+
+	got, ok := searchRequestNormalisationLogEntries(metadata, "series", []string{"en-US", ""})
+	if !ok {
+		t.Fatalf("expected normalisation log entries to be emitted")
+	}
+
+	want := []titleLogEntry{
+		{Languages: []string{"en-US"}, InputTitle: "Witch Hat Atelier", NormalizedTitle: "Witch Hat Atelier"},
+		{Languages: []string{"original"}, InputTitle: "Tongari Boushi no Atelier", NormalizedTitle: "Tongari Boushi no Atelier"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("searchRequestNormalisationLogEntries() = %#v, want %#v", got, want)
+	}
+}
+
+func TestValidationQueryProfilesFromMetadataSplitMultipleLanguages(t *testing.T) {
+	metadata := &resolvedSearchMetadata{
+		TVDetails: &tmdb.TVDetails{
+			Name:             "Witch Hat Atelier",
+			OriginalName:     "とんがり帽子のアトリエ",
+			OriginalLanguage: "ja",
+		},
+		TVAlternativeTitles: &tmdb.TVAlternativeTitlesResponse{
+			Results: []tmdb.AlternativeTitle{
+				{ISO3166_1: "JP", Title: "Tongari Boushi no Atelier", Type: "Romaji"},
+			},
+		},
+	}
+
+	got := validationQueryProfilesFromMetadata(metadata, "series", []string{"en-US", ""}, false)
+	want := []indexer.ValidationQueryProfile{
+		{Languages: []string{"en-US"}, Query: "Witch Hat Atelier"},
+		{Languages: []string{"original"}, Query: "Tongari Boushi no Atelier"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("validationQueryProfilesFromMetadata() = %#v, want %#v", got, want)
+	}
+}
+
+func TestValidationQueryProfilesFromMetadataMergesDuplicateQueriesAcrossLanguages(t *testing.T) {
+	metadata := &resolvedSearchMetadata{
+		TVDetails: &tmdb.TVDetails{
+			Name:             "Dragon Ball Z",
+			OriginalName:     "ドラゴンボールゼット",
+			OriginalLanguage: "ja",
+		},
+		TVTranslations: &tmdb.TVTranslationsResponse{
+			Translations: []tmdb.TVTranslationEntry{
+				{
+					ISO639_1:  "en",
+					ISO3166_1: "US",
+					Data: tmdb.TVTranslationData{
+						Name: "Dragon Ball Z",
+					},
+				},
+			},
+		},
+	}
+
+	got := validationQueryProfilesFromMetadata(metadata, "series", []string{"en-US", ""}, false)
+	want := []indexer.ValidationQueryProfile{
+		{Languages: []string{"en-US", "original"}, Query: "Dragon Ball Z"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("validationQueryProfilesFromMetadata() = %#v, want %#v", got, want)
+	}
+}
+
+func TestSearchRequestNormalisationLogEntriesMergesDuplicateTitlesAcrossLanguages(t *testing.T) {
+	metadata := &resolvedSearchMetadata{
+		TVDetails: &tmdb.TVDetails{
+			Name:             "Dragon Ball Z",
+			OriginalName:     "ドラゴンボールゼット",
+			OriginalLanguage: "ja",
+		},
+		TVTranslations: &tmdb.TVTranslationsResponse{
+			Translations: []tmdb.TVTranslationEntry{
+				{
+					ISO639_1:  "en",
+					ISO3166_1: "US",
+					Data: tmdb.TVTranslationData{
+						Name: "Dragon Ball Z",
+					},
+				},
+			},
+		},
+	}
+
+	got, ok := searchRequestNormalisationLogEntries(metadata, "series", []string{"en-US", ""})
+	if !ok {
+		t.Fatalf("expected normalisation log entries to be emitted")
+	}
+
+	want := []titleLogEntry{
+		{Languages: []string{"en-US", "original"}, InputTitle: "Dragon Ball Z", NormalizedTitle: "Dragon Ball Z"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("searchRequestNormalisationLogEntries() = %#v, want %#v", got, want)
+	}
+}
+
 func TestMetadataLogTitlesPreferOriginalAndJapaneseRomajiAlternative(t *testing.T) {
 	metadata := &resolvedSearchMetadata{
 		MovieDetails: &tmdb.MovieDetails{
@@ -127,6 +241,34 @@ func TestMetadataLogTitlesHandleMissingJapaneseAlternativeTitles(t *testing.T) {
 	}()
 
 	logMetadataLookupFinished("Stream01", "movie", "tt0245429", params)
+}
+
+func TestMetadataFallbackTitleReturnsEnglishWhenJapaneseRomajiMissing(t *testing.T) {
+	metadata := &resolvedSearchMetadata{
+		TVDetails: &tmdb.TVDetails{
+			Name:             "Dragon Ball Z",
+			OriginalName:     "ドラゴンボールゼット",
+			OriginalLanguage: "ja",
+		},
+		TVTranslations: &tmdb.TVTranslationsResponse{
+			Translations: []tmdb.TVTranslationEntry{
+				{
+					ISO639_1:  "en",
+					ISO3166_1: "US",
+					Data: tmdb.TVTranslationData{
+						Name: "Dragon Ball Z",
+					},
+				},
+			},
+		},
+	}
+
+	if got := metadataAlternativeTitle(metadata, "series"); got != "" {
+		t.Fatalf("metadataAlternativeTitle() = %q, want empty", got)
+	}
+	if got := metadataFallbackTitle(metadata, "series"); got != "Dragon Ball Z" {
+		t.Fatalf("metadataFallbackTitle() = %q, want %q", got, "Dragon Ball Z")
+	}
 }
 
 func TestBuildMovieQueriesFromMetadataAddsGermanTransliterationVariant(t *testing.T) {
@@ -210,6 +352,40 @@ func TestBuildMovieQueriesFromMetadataUsesRomanizedJapaneseOriginalTitle(t *test
 	}
 }
 
+func TestBuildMovieQueriesFromMetadataFallsBackToEnglishWhenJapaneseRomajiMissing(t *testing.T) {
+	metadata := &resolvedSearchMetadata{
+		MovieDetails: &tmdb.MovieDetails{
+			Title:            "Spirited Away",
+			OriginalTitle:    "千と千尋の神隠し",
+			OriginalLanguage: "ja",
+			ReleaseDate:      "2001-07-20",
+		},
+		MovieTranslations: &tmdb.MovieTranslationsResponse{
+			Translations: []tmdb.MovieTranslationEntry{
+				{
+					ISO639_1:  "en",
+					ISO3166_1: "US",
+					Data: tmdb.MovieTranslationData{
+						Title: "Spirited Away",
+					},
+				},
+			},
+		},
+		MovieAlternativeTitles: &tmdb.MovieAlternativeTitlesResponse{
+			Titles: []tmdb.AlternativeTitle{
+				{ISO3166_1: "JP", Title: "SenChihi", Type: "Romaji (Short)"},
+			},
+		},
+	}
+
+	got := buildMovieQueriesFromMetadata(metadata, "original", false)
+	want := []string{"Spirited Away"}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("buildMovieQueriesFromMetadata() = %#v, want %#v", got, want)
+	}
+}
+
 func TestBuildSeriesQueriesFromMetadataAddsGermanTransliterationVariant(t *testing.T) {
 	metadata := &resolvedSearchMetadata{
 		TVDetails: &tmdb.TVDetails{
@@ -285,6 +461,40 @@ func TestBuildSeriesQueriesFromMetadataUsesRomanizedJapaneseOriginalTitle(t *tes
 
 	got := buildSeriesQueriesFromMetadata(metadata, "original", false, "1", "2", config.SeriesSearchScopeSeasonEpisode)
 	want := []string{"Shingeki no Kyojin S01E02"}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("buildSeriesQueriesFromMetadata() = %#v, want %#v", got, want)
+	}
+}
+
+func TestBuildSeriesQueriesFromMetadataFallsBackToEnglishWhenJapaneseRomajiMissing(t *testing.T) {
+	metadata := &resolvedSearchMetadata{
+		TVDetails: &tmdb.TVDetails{
+			Name:             "Witch Hat Atelier",
+			OriginalName:     "とんがり帽子のアトリエ",
+			OriginalLanguage: "ja",
+			FirstAirDate:     "2025-01-01",
+		},
+		TVTranslations: &tmdb.TVTranslationsResponse{
+			Translations: []tmdb.TVTranslationEntry{
+				{
+					ISO639_1:  "en",
+					ISO3166_1: "US",
+					Data: tmdb.TVTranslationData{
+						Name: "Witch Hat Atelier",
+					},
+				},
+			},
+		},
+		TVAlternativeTitles: &tmdb.TVAlternativeTitlesResponse{
+			Results: []tmdb.AlternativeTitle{
+				{ISO3166_1: "JP", Title: "Tongari", Type: "Romaji (Short)"},
+			},
+		},
+	}
+
+	got := buildSeriesQueriesFromMetadata(metadata, "original", false, "1", "2", config.SeriesSearchScopeSeasonEpisode)
+	want := []string{"Witch Hat Atelier S01E02"}
 
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("buildSeriesQueriesFromMetadata() = %#v, want %#v", got, want)
@@ -423,7 +633,7 @@ func TestBuildSearchParamsFromBaseTextModeUsesRequestLanguageNotPerIndexerOverri
 	}
 }
 
-func TestSearchRequestNormalisationLogValuesIncludesOriginalTitle(t *testing.T) {
+func TestSearchRequestNormalisationLogEntriesIncludeSingleMovieTitle(t *testing.T) {
 	metadata := &resolvedSearchMetadata{
 		MovieDetails: &tmdb.MovieDetails{
 			Title:            "The Lion King",
@@ -444,30 +654,23 @@ func TestSearchRequestNormalisationLogValuesIncludesOriginalTitle(t *testing.T) 
 		},
 	}
 
-	originalTitle, inputTitle, normalizedTitle, ok := searchRequestNormalisationLogValues(
+	entries, ok := searchRequestNormalisationLogEntries(
 		metadata,
 		"movie",
-		"de-DE",
-		true,
-		"",
-		"",
-		"",
+		[]string{"de-DE"},
 	)
 	if !ok {
-		t.Fatal("expected normalisation log values")
+		t.Fatal("expected normalisation log entries")
 	}
-	if originalTitle != "The Lion King" {
-		t.Fatalf("originalTitle = %q, want %q", originalTitle, "The Lion King")
+	want := []titleLogEntry{
+		{Languages: []string{"de-DE"}, InputTitle: "König der Löwen", NormalizedTitle: "Koenig der Loewen"},
 	}
-	if inputTitle != "König der Löwen" {
-		t.Fatalf("inputTitle = %q, want %q", inputTitle, "König der Löwen")
-	}
-	if normalizedTitle != "Koenig der Loewen" {
-		t.Fatalf("normalizedTitle = %q, want %q", normalizedTitle, "Koenig der Loewen")
+	if !reflect.DeepEqual(entries, want) {
+		t.Fatalf("entries = %#v, want %#v", entries, want)
 	}
 }
 
-func TestSearchRequestNormalisationLogValuesOmitsSeriesScopeSuffix(t *testing.T) {
+func TestSearchRequestNormalisationLogEntriesOmitSeriesScopeSuffix(t *testing.T) {
 	metadata := &resolvedSearchMetadata{
 		TVDetails: &tmdb.TVDetails{
 			Name:             "The Rookie",
@@ -487,26 +690,19 @@ func TestSearchRequestNormalisationLogValuesOmitsSeriesScopeSuffix(t *testing.T)
 		},
 	}
 
-	originalTitle, inputTitle, normalizedTitle, ok := searchRequestNormalisationLogValues(
+	entries, ok := searchRequestNormalisationLogEntries(
 		metadata,
 		"series",
-		"de-DE",
-		false,
-		"1",
-		"2",
-		config.SeriesSearchScopeSeasonEpisode,
+		[]string{"de-DE"},
 	)
 	if !ok {
-		t.Fatal("expected normalisation log values")
+		t.Fatal("expected normalisation log entries")
 	}
-	if originalTitle != "The Rookie" {
-		t.Fatalf("originalTitle = %q, want %q", originalTitle, "The Rookie")
+	want := []titleLogEntry{
+		{Languages: []string{"de-DE"}, InputTitle: "König der Löwen", NormalizedTitle: "Koenig der Loewen"},
 	}
-	if inputTitle != "König der Löwen" {
-		t.Fatalf("inputTitle = %q, want %q", inputTitle, "König der Löwen")
-	}
-	if normalizedTitle != "Koenig der Loewen" {
-		t.Fatalf("normalizedTitle = %q, want %q", normalizedTitle, "Koenig der Loewen")
+	if !reflect.DeepEqual(entries, want) {
+		t.Fatalf("entries = %#v, want %#v", entries, want)
 	}
 }
 
@@ -563,6 +759,66 @@ func TestBuildSearchParamsFromBaseAlwaysBuildsValidationInputs(t *testing.T) {
 	}
 	if params.Req.ValidationQuery != "The Lion King" {
 		t.Fatalf("expected validation query to use the metadata title, got %q", params.Req.ValidationQuery)
+	}
+	if !reflect.DeepEqual(params.Req.ValidationQueries, []string{"The Lion King"}) {
+		t.Fatalf("expected validation queries to keep the deduped metadata title, got %#v", params.Req.ValidationQueries)
+	}
+}
+
+func TestBuildSearchParamsFromBaseIDModeBuildsValidationQueriesForMultipleLanguages(t *testing.T) {
+	srv := &Server{config: &config.Config{}}
+	base := &SearchParams{
+		ContentType: "movie",
+		ID:          "tmdb:123",
+		Req: indexer.SearchRequest{
+			TMDBID: "123",
+			Cat:    "2000",
+			Limit:  1000,
+		},
+		Metadata: &resolvedSearchMetadata{
+			MovieDetails: &tmdb.MovieDetails{
+				Title:            "The Lion King",
+				OriginalTitle:    "The Lion King",
+				OriginalLanguage: "en",
+				ReleaseDate:      "1994-06-15",
+			},
+			MovieTranslations: &tmdb.MovieTranslationsResponse{
+				Translations: []tmdb.MovieTranslationEntry{
+					{
+						ISO639_1:  "de",
+						ISO3166_1: "DE",
+						Data: tmdb.MovieTranslationData{
+							Title: "König der Löwen",
+						},
+					},
+				},
+			},
+		},
+		MovieTitleQueries:  make(map[string][]string),
+		SeriesTitleQueries: make(map[string][]string),
+	}
+
+	params, err := srv.buildSearchParamsFromBase(base, &config.SearchQueryConfig{
+		SearchMode:           "id",
+		SearchTitleLanguage:  "",
+		SearchTitleLanguages: []string{"", "de-DE"},
+		IncludeYear:          boolPtr(false),
+	})
+	if err != nil {
+		t.Fatalf("buildSearchParamsFromBase() error = %v", err)
+	}
+
+	if !reflect.DeepEqual(params.Req.ValidationQueries, []string{"The Lion King", "Koenig der Loewen"}) {
+		t.Fatalf("ValidationQueries = %#v, want %#v", params.Req.ValidationQueries, []string{"The Lion King", "Koenig der Loewen"})
+	}
+	if !reflect.DeepEqual(params.Req.ValidationQueryProfiles, []indexer.ValidationQueryProfile{
+		{Languages: []string{"original"}, Query: "The Lion King"},
+		{Languages: []string{"de-DE"}, Query: "Koenig der Loewen"},
+	}) {
+		t.Fatalf("ValidationQueryProfiles = %#v", params.Req.ValidationQueryProfiles)
+	}
+	if params.Req.ValidationQuery != "The Lion King" {
+		t.Fatalf("ValidationQuery = %q, want %q", params.Req.ValidationQuery, "The Lion King")
 	}
 }
 


### PR DESCRIPTION
## Summary
- add multi-language title validation for search requests, including a new ID-search UI for selecting multiple metadata languages
- improve metadata/title handling for Japanese originals, including clearer fallback logging when no exact Romaji title exists
- tighten validation and playback behavior with cleaner multilingual logs and a limited largest-file fallback for movies and exact-episode releases

## Highlights
- allow selecting multiple title languages for ID searches while keeping text searches limited to a single outgoing query language
- validate ID-search results against multiple title variants without duplicating work when multiple languages resolve to the same effective title
- log search normalization and validation per effective title, grouping languages when they collapse to the same title
- for Japanese originals, use exact TMDB `Romaji` when available; otherwise fall back to the English title instead of Japanese script
- log `fallback_reason=no_romaji` and `fallback_title=...` in metadata logs when that English fallback is used
- keep text searches single-language and use multiple title languages only for ID-search validation
- allow the largest-file playback fallback only for movies and exact-episode releases, while continuing to block season and complete packs

## Testing
- `go test ./pkg/core/config ./pkg/media/unpack ./pkg/search ./pkg/server/api ./pkg/server/stremio`
- `./node_modules/.bin/vite build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Multi-language title selection for ID-based searches with add/remove controls
  * Language-aware search validation and profile-based matching across multiple languages
  * English title fallback for Japanese-language content

* **Improvements**
  * Enhanced search query language input handling with normalization and deduplication
  * Improved media stream selection with configurable fallback behavior based on content type

<!-- end of auto-generated comment: release notes by coderabbit.ai -->