### PR TITLE
fix(playback): refresh deferred sessions and fix easynews query suffixes

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -10,7 +10,7 @@ import { LogsPage } from "@/components/LogsPage"
 import { NZBHistoryPage } from "@/components/NZBHistoryPage"
 import { ProfilePage } from "@/components/ProfilePage"
 import StreamManagement from './components/StreamManagement'
-import { apiFetch, UNAUTHORIZED_EVENT } from './api'
+import { apiFetch, getApiUrl, UNAUTHORIZED_EVENT } from './api'
 import { AlertCircle, Loader2 } from "lucide-react"
 
 import { useAdminRuntime } from './hooks/useAdminRuntime'
@@ -139,7 +139,7 @@ function App() {
 
   const handleLogout = useCallback(() => {
     hasLoggedOutRef.current = true
-    fetch('/api/auth/logout', {
+    fetch(getApiUrl('/api/auth/logout'), {
       method: 'POST',
       credentials: 'include',
     }).catch(() => {})

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -10,7 +10,7 @@ import { LogsPage } from "@/components/LogsPage"
 import { NZBHistoryPage } from "@/components/NZBHistoryPage"
 import { ProfilePage } from "@/components/ProfilePage"
 import StreamManagement from './components/StreamManagement'
-import { apiFetch } from './api'
+import { apiFetch, UNAUTHORIZED_EVENT } from './api'
 import { AlertCircle, Loader2 } from "lucide-react"
 
 import { useAdminRuntime } from './hooks/useAdminRuntime'
@@ -124,12 +124,8 @@ function App() {
     localStorage.setItem('auth_token', token)
   }
 
-  const handleLogout = () => {
+  const clearAuthState = useCallback(() => {
     hasLoggedOutRef.current = true
-    fetch('/api/auth/logout', {
-      method: 'POST',
-      credentials: 'include',
-    }).catch(() => {})
     setAuthenticated(false)
     setCurrentUser(null)
     setAuthToken('')
@@ -139,7 +135,28 @@ function App() {
       ws.close()
     }
     window.ws = null
-  }
+  }, [ws])
+
+  const handleLogout = useCallback(() => {
+    hasLoggedOutRef.current = true
+    fetch('/api/auth/logout', {
+      method: 'POST',
+      credentials: 'include',
+    }).catch(() => {})
+    clearAuthState()
+  }, [clearAuthState])
+
+  useEffect(() => {
+    const handleUnauthorized = () => {
+      if (!authenticated || hasLoggedOutRef.current) return
+      clearAuthState()
+    }
+
+    window.addEventListener(UNAUTHORIZED_EVENT, handleUnauthorized)
+    return () => {
+      window.removeEventListener(UNAUTHORIZED_EVENT, handleUnauthorized)
+    }
+  }, [authenticated, clearAuthState])
 
   useEffect(() => {
     const root = window.document.documentElement;

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -4,9 +4,21 @@ export function getApiUrl(path) {
   return `${prefix}${path}`
 }
 
+export const UNAUTHORIZED_EVENT = 'streamnzb:unauthorized'
+
+export function notifyUnauthorized(detail = {}) {
+  if (typeof window === 'undefined') return
+  window.dispatchEvent(new CustomEvent(UNAUTHORIZED_EVENT, { detail }))
+}
+
 export async function apiFetch(path, options = {}) {
   const url = getApiUrl(path)
-  const res = await fetch(url, { credentials: 'include', ...options })
+  const headers = new Headers(options.headers || {})
+  const storedToken = typeof window !== 'undefined' ? window.localStorage.getItem('auth_token') || '' : ''
+  if (storedToken && !headers.has('Authorization')) {
+    headers.set('Authorization', `Bearer ${storedToken}`)
+  }
+  const res = await fetch(url, { credentials: 'include', ...options, headers })
   let data = null
   const contentType = res.headers.get('content-type')
   if (contentType && contentType.includes('application/json')) {
@@ -15,8 +27,12 @@ export async function apiFetch(path, options = {}) {
     } catch (_) {}
   }
   if (!res.ok) {
+    if (res.status === 401) {
+      notifyUnauthorized({ path, status: res.status })
+    }
     const err = new Error((data && (data.error || data.message)) || res.statusText)
     if (data && data.errors) err.fieldErrors = data.errors
+    err.status = res.status
     throw err
   }
   return data

--- a/frontend/src/hooks/useAdminRuntime.js
+++ b/frontend/src/hooks/useAdminRuntime.js
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 
-import { apiFetch, getApiUrl } from '../api'
+import { apiFetch, getApiUrl, notifyUnauthorized } from '../api'
 
 const MAX_HISTORY = 60
 const MAX_LOGS = 200
@@ -155,25 +155,18 @@ export function useAdminRuntime({
               setCurrentUser(msg.payload.username)
               setMustChangePassword(msg.payload.must_change_password || false)
               const currentSocket = socket
-              fetch(getApiUrl('/api/config'), { credentials: 'include' })
-                .then((res) => (res.ok ? res.json() : null))
+              apiFetch('/api/config')
                 .then((data) => {
                   if (data && isActiveSocket(currentSocket)) setConfig(data)
                 })
                 .catch(() => {})
-              fetch(getApiUrl('/api/indexer/caps'), { credentials: 'include' })
-                .then((res) => (res.ok ? res.json() : null))
+              apiFetch('/api/indexer/caps')
                 .then((data) => {
                   if (data && isActiveSocket(currentSocket)) setIndexerCaps(data)
                 })
                 .catch(() => {})
             } else {
-              // The initial HTTP auth check is the authoritative gate for the
-              // admin UI. If the WS channel briefly reports unauthenticated,
-              // don't throw the whole app back to the login screen; just
-              // surface a connection issue and let reconnect / normal API
-              // auth continue to work.
-              setError('Realtime connection is not authenticated')
+              notifyUnauthorized({ source: 'ws_auth_info' })
               socket.close()
             }
             break

--- a/pkg/indexer/easynews/client.go
+++ b/pkg/indexer/easynews/client.go
@@ -359,7 +359,7 @@ func buildEasynewsGPSQuery(query, season, episode, scope, category string) strin
 		if seasonErr == nil && episodeErr == nil {
 			suffix = fmt.Sprintf("S%02dE%02d", seasonNum, episodeNum)
 		}
-		if strings.HasSuffix(strings.ToLower(query), strings.ToLower(" "+suffix)) || strings.EqualFold(query, suffix) {
+		if easynewsQueryContainsToken(query, suffix) {
 			return query
 		}
 		if query == "" {
@@ -375,7 +375,7 @@ func buildEasynewsGPSQuery(query, season, episode, scope, category string) strin
 		if seasonErr == nil {
 			suffix = fmt.Sprintf("S%02d", seasonNum)
 		}
-		if strings.HasSuffix(strings.ToLower(query), strings.ToLower(" "+suffix)) || strings.EqualFold(query, suffix) {
+		if easynewsQueryContainsToken(query, suffix) {
 			return query
 		}
 		if query == "" {
@@ -385,6 +385,19 @@ func buildEasynewsGPSQuery(query, season, episode, scope, category string) strin
 	default:
 		return query
 	}
+}
+
+func easynewsQueryContainsToken(query, token string) bool {
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return false
+	}
+	for _, part := range strings.Fields(query) {
+		if strings.EqualFold(strings.TrimSpace(part), token) {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *Client) searchInternal(ctx context.Context, query, season, episode, scope, category string, strictMode bool) ([]easynewsResult, int, error) {

--- a/pkg/indexer/easynews/client_test.go
+++ b/pkg/indexer/easynews/client_test.go
@@ -134,6 +134,15 @@ func TestBuildEasynewsGPSQuery(t *testing.T) {
 			want:     "The Last of Us S01E02",
 		},
 		{
+			name:     "tv query with extra terms does not duplicate episode token",
+			query:    "The Boys S05E01 1080p",
+			season:   "5",
+			episode:  "1",
+			scope:    config.SeriesSearchScopeSeasonEpisode,
+			category: "5000",
+			want:     "The Boys S05E01 1080p",
+		},
+		{
 			name:     "season param appends season only",
 			query:    "The Last of Us",
 			season:   "1",

--- a/pkg/server/stremio/handlers_playback.go
+++ b/pkg/server/stremio/handlers_playback.go
@@ -718,6 +718,9 @@ func (s *Server) ensureDeferredSessionsForPlaylist(list *playlistResult, key Str
 		return
 	}
 	n := len(list.Candidates)
+	createdCount := 0
+	reusedCount := 0
+	replacedCount := 0
 	for i := 0; i < n; i++ {
 		cand := list.Candidates[i]
 		if cand.Release == nil || cand.Release.Link == "" {
@@ -734,9 +737,31 @@ func (s *Server) ensureDeferredSessionsForPlaylist(list *playlistResult, key Str
 				idx = ii
 			}
 		}
-		if _, err := s.sessionManager.CreateDeferredSessionWithFetcher(playPath, downloadURL, cand.Release, idx, list.Params.ContentIDs, list.Params.ContentType, list.Params.ID, list.Params.ContentTitle, streamID(stream), s.segmentFetcherForStream(stream), s.providerHostsForStream(stream)); err != nil {
+		_, outcome, err := s.sessionManager.CreateDeferredSessionWithFetcherOutcome(playPath, downloadURL, cand.Release, idx, list.Params.ContentIDs, list.Params.ContentType, list.Params.ID, list.Params.ContentTitle, streamID(stream), s.segmentFetcherForStream(stream), s.providerHostsForStream(stream))
+		if err != nil {
 			logger.Debug("Create deferred session for play list failed", "slot", playPath, "err", err)
+			continue
 		}
+		switch outcome {
+		case session.DeferredSessionCreateCreated:
+			createdCount++
+		case session.DeferredSessionCreateExisting:
+			reusedCount++
+		case session.DeferredSessionCreateReplaced:
+			replacedCount++
+		}
+	}
+	if replacedCount > 0 || reusedCount > 0 {
+		logger.Debug(
+			"Deferred sessions refreshed",
+			"stream", key.StreamID,
+			"type", key.ContentType,
+			"id", key.ID,
+			"candidates", n,
+			"created", createdCount,
+			"reused", reusedCount,
+			"replaced", replacedCount,
+		)
 	}
 }
 

--- a/pkg/server/stremio/handlers_playback.go
+++ b/pkg/server/stremio/handlers_playback.go
@@ -751,7 +751,7 @@ func (s *Server) ensureDeferredSessionsForPlaylist(list *playlistResult, key Str
 			replacedCount++
 		}
 	}
-	if replacedCount > 0 || reusedCount > 0 {
+	if createdCount > 0 || replacedCount > 0 || reusedCount > 0 {
 		logger.Debug(
 			"Deferred sessions refreshed",
 			"stream", key.StreamID,
@@ -812,7 +812,7 @@ func (s *Server) resolveStreamSlotFromPlaylist(key StreamSlotKey, index int, lis
 		}
 	}
 	sessionID := requestedSlotPath
-	_, err := s.sessionManager.CreateDeferredSessionWithFetcher(sessionID, downloadURL, rel, idx, list.Params.ContentIDs, list.Params.ContentType, list.Params.ID, list.Params.ContentTitle, streamID(stream), s.segmentFetcherForStream(stream), s.providerHostsForStream(stream))
+	_, _, err := s.sessionManager.CreateDeferredSessionWithFetcherOutcome(sessionID, downloadURL, rel, idx, list.Params.ContentIDs, list.Params.ContentType, list.Params.ID, list.Params.ContentTitle, streamID(stream), s.segmentFetcherForStream(stream), s.providerHostsForStream(stream))
 	if err != nil {
 		return nil, fmt.Errorf("create deferred session: %w", err)
 	}
@@ -1119,7 +1119,9 @@ func (s *Server) handlePlay(w http.ResponseWriter, r *http.Request, streamConfig
 			}(sessionID, sess.Done())
 		}
 
+		s.sessionManager.BeginPlaybackStartup(sessionID)
 		preparedStream, prepareErr := s.preparePlaybackStream(mergedCtx, sess, requestedSessionID, sessionID, wantTimeOffset)
+		s.sessionManager.EndPlaybackStartup(sessionID)
 		if prepareErr != nil {
 			mergedCancel()
 			if isPlayPrepareCancellation(prepareErr) {

--- a/pkg/session/manager.go
+++ b/pkg/session/manager.go
@@ -67,6 +67,7 @@ type Session struct {
 	PlaybackValidatedAt time.Time // when probe/prepare proved the file is playable; separate from playback end bookkeeping
 	PlaybackStartedAt   time.Time // when ActivePlays went from 0 to >0; used to evict stuck sessions
 	PlaybackEndedAt     time.Time // when ActivePlays went to 0; used to evict session soon after stream stops
+	playbackStarting    int       // number of in-flight playback startups; prevents background refresh from replacing the session mid-startup
 	Clients             map[string]time.Time
 	mu                  sync.Mutex
 
@@ -421,6 +422,10 @@ const PostPlaybackEvictTTL = 15 * time.Minute
 // clientStaleTTL is how long a Clients map entry is kept before it is treated as stale in cleanup().
 // Matches the 60-second window used in GetActiveSessions.
 const clientStaleTTL = 60 * time.Second
+
+// deferredSessionReplaceGrace is a short protection window after a session was last touched.
+// It avoids replacing a slot that was just handed to playback while startup bookkeeping is still catching up.
+const deferredSessionReplaceGrace = 5 * time.Second
 
 type failoverOrderEntry struct {
 	order     []string
@@ -827,15 +832,24 @@ func (m *Manager) CreateDeferredSessionWithFetcherOutcome(sessionID, downloadURL
 	}()
 
 	if existing, ok := m.sessions[sessionID]; ok {
+		now := time.Now()
 		existing.mu.Lock()
-		existing.LastAccess = time.Now()
-		replaceable := existing.ActivePlays == 0 && existing.PlaybackValidatedAt.IsZero()
-		sameDownloadURL := existing.downloadURL == downloadURL
+		existingURL := existing.downloadURL
+		lastAccess := existing.LastAccess
+		replaceable := existing.ActivePlays == 0 &&
+			existing.PlaybackValidatedAt.IsZero() &&
+			!existing.nzbDownloadInFlight &&
+			existing.playbackStarting == 0 &&
+			now.Sub(lastAccess) >= deferredSessionReplaceGrace
+		sameDownloadURL := existingURL == downloadURL
+		if sameDownloadURL || !replaceable {
+			existing.LastAccess = now
+		}
 		existing.mu.Unlock()
 		if !sameDownloadURL && replaceable {
 			logger.Trace("session CreateDeferredSession replacing stale deferred session",
 				"id", sessionID,
-				"old_download_url", existing.downloadURL,
+				"old_download_url", existingURL,
 				"new_download_url", downloadURL)
 			delete(m.sessions, sessionID)
 			replaced = existing
@@ -1338,6 +1352,7 @@ func (s *Session) closeWithLogging(debugLog bool, reason string) {
 		s.playback = nil
 	}
 	s.selectedPlaybackFile = ""
+	s.playbackStarting = 0
 
 	// Release heavyweight references so a closed session cannot pin NZB / unpack /
 	// loader graphs or deferred-download state after it has been removed.
@@ -1472,8 +1487,37 @@ func (m *Manager) MarkPlaybackValidated(id string) {
 		if s.PlaybackValidatedAt.IsZero() {
 			s.PlaybackValidatedAt = time.Now()
 		}
+		s.playbackStarting = 0
 		s.mu.Unlock()
 	}
+}
+
+func (m *Manager) BeginPlaybackStartup(id string) {
+	m.mu.RLock()
+	s := m.sessions[id]
+	m.mu.RUnlock()
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	s.playbackStarting++
+	s.LastAccess = time.Now()
+	s.mu.Unlock()
+}
+
+func (m *Manager) EndPlaybackStartup(id string) {
+	m.mu.RLock()
+	s := m.sessions[id]
+	m.mu.RUnlock()
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	if s.playbackStarting > 0 {
+		s.playbackStarting--
+	}
+	s.LastAccess = time.Now()
+	s.mu.Unlock()
 }
 
 func (m *Manager) EndPlayback(id, ip string) {

--- a/pkg/session/manager.go
+++ b/pkg/session/manager.go
@@ -1493,31 +1493,31 @@ func (m *Manager) MarkPlaybackValidated(id string) {
 }
 
 func (m *Manager) BeginPlaybackStartup(id string) {
+	now := time.Now()
 	m.mu.RLock()
 	s := m.sessions[id]
-	m.mu.RUnlock()
-	if s == nil {
-		return
+	if s != nil {
+		s.mu.Lock()
+		s.playbackStarting++
+		s.LastAccess = now
+		s.mu.Unlock()
 	}
-	s.mu.Lock()
-	s.playbackStarting++
-	s.LastAccess = time.Now()
-	s.mu.Unlock()
+	m.mu.RUnlock()
 }
 
 func (m *Manager) EndPlaybackStartup(id string) {
+	now := time.Now()
 	m.mu.RLock()
 	s := m.sessions[id]
+	if s != nil {
+		s.mu.Lock()
+		if s.playbackStarting > 0 {
+			s.playbackStarting--
+		}
+		s.LastAccess = now
+		s.mu.Unlock()
+	}
 	m.mu.RUnlock()
-	if s == nil {
-		return
-	}
-	s.mu.Lock()
-	if s.playbackStarting > 0 {
-		s.playbackStarting--
-	}
-	s.LastAccess = time.Now()
-	s.mu.Unlock()
 }
 
 func (m *Manager) EndPlayback(id, ip string) {

--- a/pkg/session/manager.go
+++ b/pkg/session/manager.go
@@ -798,21 +798,51 @@ func buildLoaderFiles(ctx context.Context, ownerID string, contentFiles []*nzb.F
 	return loaderFiles
 }
 
+type DeferredSessionCreateOutcome string
+
+const (
+	DeferredSessionCreateCreated  DeferredSessionCreateOutcome = "created"
+	DeferredSessionCreateExisting DeferredSessionCreateOutcome = "existing"
+	DeferredSessionCreateReplaced DeferredSessionCreateOutcome = "replaced"
+)
+
 func (m *Manager) CreateDeferredSession(sessionID, downloadURL string, rel *release.Release, idx indexer.Indexer, contentIDs *AvailReportMeta, contentType, contentID, contentTitle, streamName string) (*Session, error) {
 	return m.CreateDeferredSessionWithFetcher(sessionID, downloadURL, rel, idx, contentIDs, contentType, contentID, contentTitle, streamName, nil, nil)
 }
 
 func (m *Manager) CreateDeferredSessionWithFetcher(sessionID, downloadURL string, rel *release.Release, idx indexer.Indexer, contentIDs *AvailReportMeta, contentType, contentID, contentTitle, streamName string, segmentFetcher loader.SegmentFetcher, providerHosts []string) (*Session, error) {
+	session, _, err := m.CreateDeferredSessionWithFetcherOutcome(sessionID, downloadURL, rel, idx, contentIDs, contentType, contentID, contentTitle, streamName, segmentFetcher, providerHosts)
+	return session, err
+}
+
+func (m *Manager) CreateDeferredSessionWithFetcherOutcome(sessionID, downloadURL string, rel *release.Release, idx indexer.Indexer, contentIDs *AvailReportMeta, contentType, contentID, contentTitle, streamName string, segmentFetcher loader.SegmentFetcher, providerHosts []string) (*Session, DeferredSessionCreateOutcome, error) {
 	logger.Trace("session CreateDeferredSession start", "id", sessionID)
 	m.mu.Lock()
-	defer m.mu.Unlock()
+	var replaced *Session
+	defer func() {
+		m.mu.Unlock()
+		if replaced != nil {
+			replaced.closeWithLogging(false, "replaced_stale_deferred_session")
+		}
+	}()
 
 	if existing, ok := m.sessions[sessionID]; ok {
 		existing.mu.Lock()
 		existing.LastAccess = time.Now()
+		replaceable := existing.ActivePlays == 0 && existing.PlaybackValidatedAt.IsZero()
+		sameDownloadURL := existing.downloadURL == downloadURL
 		existing.mu.Unlock()
-		logger.Trace("session CreateDeferredSession existing", "id", sessionID)
-		return existing, nil
+		if !sameDownloadURL && replaceable {
+			logger.Trace("session CreateDeferredSession replacing stale deferred session",
+				"id", sessionID,
+				"old_download_url", existing.downloadURL,
+				"new_download_url", downloadURL)
+			delete(m.sessions, sessionID)
+			replaced = existing
+		} else {
+			logger.Trace("session CreateDeferredSession existing", "id", sessionID)
+			return existing, DeferredSessionCreateExisting, nil
+		}
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -839,7 +869,10 @@ func (m *Manager) CreateDeferredSessionWithFetcher(sessionID, downloadURL string
 	session.segmentFetcher = attachProviderTracking(session, trackedFetcher)
 	m.sessions[sessionID] = session
 	logger.Trace("session CreateDeferredSession done", "id", sessionID)
-	return session, nil
+	if replaced != nil {
+		return session, DeferredSessionCreateReplaced, nil
+	}
+	return session, DeferredSessionCreateCreated, nil
 }
 
 func (s *Session) GetOrDownloadNZB(manager *Manager) (*nzb.NZB, error) {

--- a/pkg/session/manager_test.go
+++ b/pkg/session/manager_test.go
@@ -314,6 +314,85 @@ func TestCreateDeferredSessionTracksUsedProviderHosts(t *testing.T) {
 	}
 }
 
+func TestCreateDeferredSessionReplacesStaleDeferredSessionWhenSourceChanges(t *testing.T) {
+	logger.Init("ERROR")
+
+	m := &Manager{sessions: make(map[string]*Session)}
+	first, outcome, err := m.CreateDeferredSessionWithFetcherOutcome(
+		"sess-replace",
+		"https://example.invalid/get?nzb=1",
+		&release.Release{Title: "Old Release"},
+		&fakeIndexer{},
+		nil,
+		"series",
+		"tt1190634:5:1",
+		"The Boys",
+		"Stream01",
+		nil,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("CreateDeferredSession(first) returned error: %v", err)
+	}
+	if outcome != DeferredSessionCreateCreated {
+		t.Fatalf("expected first session to be created, got %q", outcome)
+	}
+
+	second, outcome, err := m.CreateDeferredSessionWithFetcherOutcome(
+		"sess-replace",
+		"https://example.invalid/get?nzb=2",
+		&release.Release{Title: "New Release"},
+		&fakeIndexer{},
+		nil,
+		"series",
+		"tt1190634:5:1",
+		"The Boys",
+		"Stream01",
+		nil,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("CreateDeferredSession(second) returned error: %v", err)
+	}
+	if outcome != DeferredSessionCreateReplaced {
+		t.Fatalf("expected second session to replace the stale session, got %q", outcome)
+	}
+	if first == second {
+		t.Fatal("expected stale deferred session to be replaced")
+	}
+	if second.Release == nil || second.Release.Title != "New Release" {
+		t.Fatalf("expected replacement session to carry new release, got %#v", second.Release)
+	}
+	select {
+	case <-first.Done():
+	default:
+		t.Fatal("expected replaced session to be closed")
+	}
+
+	third, outcome, err := m.CreateDeferredSessionWithFetcherOutcome(
+		"sess-replace",
+		"https://example.invalid/get?nzb=2",
+		&release.Release{Title: "Newest Release"},
+		&fakeIndexer{},
+		nil,
+		"series",
+		"tt1190634:5:1",
+		"The Boys",
+		"Stream01",
+		nil,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("CreateDeferredSession(third) returned error: %v", err)
+	}
+	if outcome != DeferredSessionCreateExisting {
+		t.Fatalf("expected third session to reuse the current session, got %q", outcome)
+	}
+	if third != second {
+		t.Fatal("expected matching deferred session to be reused")
+	}
+}
+
 func TestServeProviderTrackingUsesDepthCounter(t *testing.T) {
 	s := &Session{}
 

--- a/pkg/session/manager_test.go
+++ b/pkg/session/manager_test.go
@@ -337,6 +337,9 @@ func TestCreateDeferredSessionReplacesStaleDeferredSessionWhenSourceChanges(t *t
 	if outcome != DeferredSessionCreateCreated {
 		t.Fatalf("expected first session to be created, got %q", outcome)
 	}
+	first.mu.Lock()
+	first.LastAccess = time.Now().Add(-2 * deferredSessionReplaceGrace)
+	first.mu.Unlock()
 
 	second, outcome, err := m.CreateDeferredSessionWithFetcherOutcome(
 		"sess-replace",
@@ -390,6 +393,169 @@ func TestCreateDeferredSessionReplacesStaleDeferredSessionWhenSourceChanges(t *t
 	}
 	if third != second {
 		t.Fatal("expected matching deferred session to be reused")
+	}
+}
+
+func TestCreateDeferredSessionDoesNotReplaceActiveOrStartingSession(t *testing.T) {
+	logger.Init("ERROR")
+
+	m := &Manager{sessions: make(map[string]*Session)}
+	first, outcome, err := m.CreateDeferredSessionWithFetcherOutcome(
+		"sess-protected",
+		"https://example.invalid/get?nzb=1",
+		&release.Release{Title: "Old Release"},
+		&fakeIndexer{},
+		nil,
+		"series",
+		"tt1190634:5:1",
+		"The Boys",
+		"Stream01",
+		nil,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("CreateDeferredSession(first) returned error: %v", err)
+	}
+	if outcome != DeferredSessionCreateCreated {
+		t.Fatalf("expected first session to be created, got %q", outcome)
+	}
+
+	first.mu.Lock()
+	first.LastAccess = time.Now().Add(-2 * deferredSessionReplaceGrace)
+	first.ActivePlays = 1
+	first.mu.Unlock()
+
+	second, outcome, err := m.CreateDeferredSessionWithFetcherOutcome(
+		"sess-protected",
+		"https://example.invalid/get?nzb=2",
+		&release.Release{Title: "New Release"},
+		&fakeIndexer{},
+		nil,
+		"series",
+		"tt1190634:5:1",
+		"The Boys",
+		"Stream01",
+		nil,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("CreateDeferredSession(second) returned error: %v", err)
+	}
+	if outcome != DeferredSessionCreateExisting {
+		t.Fatalf("expected active session to be reused, got %q", outcome)
+	}
+	if second != first {
+		t.Fatal("expected active session to stay in place")
+	}
+
+	first.mu.Lock()
+	first.ActivePlays = 0
+	first.playbackStarting = 1
+	first.LastAccess = time.Now().Add(-2 * deferredSessionReplaceGrace)
+	first.mu.Unlock()
+
+	third, outcome, err := m.CreateDeferredSessionWithFetcherOutcome(
+		"sess-protected",
+		"https://example.invalid/get?nzb=3",
+		&release.Release{Title: "Newest Release"},
+		&fakeIndexer{},
+		nil,
+		"series",
+		"tt1190634:5:1",
+		"The Boys",
+		"Stream01",
+		nil,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("CreateDeferredSession(third) returned error: %v", err)
+	}
+	if outcome != DeferredSessionCreateExisting {
+		t.Fatalf("expected startup-protected session to be reused, got %q", outcome)
+	}
+	if third != first {
+		t.Fatal("expected startup-protected session to stay in place")
+	}
+
+	first.mu.Lock()
+	first.playbackStarting = 0
+	first.nzbDownloadInFlight = true
+	first.LastAccess = time.Now().Add(-2 * deferredSessionReplaceGrace)
+	first.mu.Unlock()
+
+	fourth, outcome, err := m.CreateDeferredSessionWithFetcherOutcome(
+		"sess-protected",
+		"https://example.invalid/get?nzb=4",
+		&release.Release{Title: "Final Release"},
+		&fakeIndexer{},
+		nil,
+		"series",
+		"tt1190634:5:1",
+		"The Boys",
+		"Stream01",
+		nil,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("CreateDeferredSession(fourth) returned error: %v", err)
+	}
+	if outcome != DeferredSessionCreateExisting {
+		t.Fatalf("expected downloading session to be reused, got %q", outcome)
+	}
+	if fourth != first {
+		t.Fatal("expected downloading session to stay in place")
+	}
+}
+
+func TestCreateDeferredSessionDoesNotReplaceRecentlyAccessedSession(t *testing.T) {
+	logger.Init("ERROR")
+
+	m := &Manager{sessions: make(map[string]*Session)}
+	first, outcome, err := m.CreateDeferredSessionWithFetcherOutcome(
+		"sess-grace",
+		"https://example.invalid/get?nzb=1",
+		&release.Release{Title: "Old Release"},
+		&fakeIndexer{},
+		nil,
+		"series",
+		"tt1190634:5:1",
+		"The Boys",
+		"Stream01",
+		nil,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("CreateDeferredSession(first) returned error: %v", err)
+	}
+	if outcome != DeferredSessionCreateCreated {
+		t.Fatalf("expected first session to be created, got %q", outcome)
+	}
+
+	first.mu.Lock()
+	first.LastAccess = time.Now()
+	first.mu.Unlock()
+
+	second, outcome, err := m.CreateDeferredSessionWithFetcherOutcome(
+		"sess-grace",
+		"https://example.invalid/get?nzb=2",
+		&release.Release{Title: "New Release"},
+		&fakeIndexer{},
+		nil,
+		"series",
+		"tt1190634:5:1",
+		"The Boys",
+		"Stream01",
+		nil,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("CreateDeferredSession(second) returned error: %v", err)
+	}
+	if outcome != DeferredSessionCreateExisting {
+		t.Fatalf("expected recently accessed session to be reused, got %q", outcome)
+	}
+	if second != first {
+		t.Fatal("expected recently accessed session to stay in place")
 	}
 }
 


### PR DESCRIPTION
## Summary
- refresh deferred playback sessions when rebuilt search results reuse existing slot IDs
- prevent duplicate Easynews episode tokens in text queries
- log the admin UI out cleanly when auth becomes invalid after restarts or token rotation

## Highlights
- replace stale unplayed deferred sessions when the same slot is rebuilt with a different release after a cache or search refresh
- keep active, startup, in-flight, and recently touched sessions intact so in-flight playback is not disrupted
- reduce session refresh log noise by keeping a compact debug summary and moving per-slot replacement details to trace logs
- fix Easynews text query construction so an existing `SxxEyy` token is not appended twice
- attach the stored bearer token to admin API requests when available
- emit a global unauthorized event on `401` responses or websocket unauthenticated state
- clear frontend auth state, close the websocket, and return the UI to login instead of leaving it in a half-authenticated broken state

## Testing
- `go test ./pkg/session ./pkg/indexer/easynews ./pkg/server/stremio`
- `./node_modules/.bin/vite build`
- manual verification: rotate `admin_token`, restart the server, and confirm the admin UI returns to login after auth failure
