### PR TITLE
feat(indexers): support per-indexer user agents

### DIFF
--- a/frontend/src/components/IndexerSettings.jsx
+++ b/frontend/src/components/IndexerSettings.jsx
@@ -43,7 +43,7 @@ const INDEXER_PRESETS = [
   { name: 'NZBNDX', url: 'https://www.nzbndx.com', api_path: '/api', type: 'newznab', api_hits_day: 100, downloads_day: 50 },
   { name: 'NzbPlanet', url: 'https://api.nzbplanet.net', api_path: '/api', type: 'newznab', api_hits_day: 5000, downloads_day: 0, rate_limit_rps: 0, timeout_seconds: 5 },
   { name: 'NZBStars', url: 'https://nzbstars.com', api_path: '/api', type: 'newznab', api_hits_day: 100, downloads_day: 50 },
-  { name: 'SceneNZBs', url: 'https://scenenzbs.com', api_path: '/api', type: 'newznab', api_hits_day: 0, downloads_day: 400, rate_limit_rps: 5, timeout_seconds: 5 },
+  { name: 'SceneNZBs', url: 'https://scenenzbs.com', api_path: '/api', type: 'newznab', api_hits_day: 0, downloads_day: 400, rate_limit_rps: 5, timeout_seconds: 5, grab_header: 'SABnzbd/4.3.0' },
   { name: 'Tabula Rasa', url: 'https://www.tabula-rasa.pw', api_path: '/api/v1', type: 'newznab', api_hits_day: 100, downloads_day: 50 },
   { name: 'Usenet Crawler', url: 'https://www.usenet-crawler.com', api_path: '/api', type: 'newznab', api_hits_day: 100, downloads_day: 50 },
   { name: 'Easynews', url: '', api_path: '/api', type: 'easynews', api_hits_day: 100, downloads_day: 50 },
@@ -70,6 +70,8 @@ function normalizeIndexerDraft(draft) {
     username: value.username || '',
     password: value.password || '',
     proxy_url: (value.proxy_url || '').trim(),
+    query_header: value.type === 'easynews' ? '' : (value.query_header || '').trim(),
+    grab_header: (value.grab_header || '').trim(),
   }
 }
 
@@ -88,6 +90,8 @@ function getPresetDefaults(preset) {
     api_hits_day: Number(preset.api_hits_day || 0),
     downloads_day: Number(preset.downloads_day || 0),
     rate_limit_rps: Number(preset.rate_limit_rps || 0),
+    query_header: preset.query_header || '',
+    grab_header: preset.grab_header || '',
   }
 }
 
@@ -106,6 +110,8 @@ function summarizeIndexer(indexer, defaultProxyURL = '') {
   parts.push(`RPS: ${formatLimitValue(indexer.rate_limit_rps)}`)
   if (indexer.proxy_url) parts.push('Proxy: override')
   else if (defaultProxyURL) parts.push('Proxy: default')
+  if (indexer.grab_header) parts.push(`Grab UA: ${indexer.grab_header}`)
+  if (indexer.query_header) parts.push(`Query UA: ${indexer.query_header}`)
   if (indexer.search_results_cache_time > 0) parts.push(`Cache time: ${indexer.search_results_cache_time}m`)
   return parts
 }
@@ -267,234 +273,276 @@ function IndexerDialog({ open, onOpenChange, initialValue, onSave, onClearStatus
         </DialogHeader>
 
         <div className="min-h-0 flex-1 overflow-y-auto pr-1">
-        <div className="space-y-4">
-          <div className="rounded-md border border-border/60 p-3">
-            <div className={rowClass}>
-              <div className={labelClass}>
-                <Label className="text-sm font-medium">Name</Label>
-              </div>
-              <div className={controlNameClass}>
-                <Input ref={nameInputRef} className={`h-9 ${fieldClass('name')}`} value={draft.name} onChange={(event) => update('name', event.target.value)} placeholder="e.g. NzbPlanet" disabled={editing} />
-                {!editing && (
-                  <TooltipProvider delayDuration={100}>
-                    <Tooltip open={presetTooltipOpen && !presetMenuOpen} onOpenChange={setPresetTooltipOpen}>
-                      <DropdownMenu onOpenChange={(nextOpen) => {
-                        setPresetMenuOpen(nextOpen)
-                        if (nextOpen) setPresetTooltipOpen(false)
-                      }}>
-                        <TooltipTrigger asChild>
-                          <DropdownMenuTrigger asChild>
-                            <Button type="button" variant={selectedPresetName ? "secondary" : "outline"} size="icon" className="h-9 w-9 shrink-0" aria-label={selectedPresetName ? `Load preset (${selectedPresetName})` : 'Load preset'}>
-                              <Download className="h-4 w-4" />
-                            </Button>
-                          </DropdownMenuTrigger>
-                        </TooltipTrigger>
-                        <DropdownMenuContent
-                          align="end"
-                          className="max-h-80 w-56 overflow-y-auto"
-                          onCloseAutoFocus={(event) => {
-                            event.preventDefault()
-                          }}
-                        >
-                          {INDEXER_PRESETS.map((preset) => (
-                            <DropdownMenuItem
-                              key={preset.name}
-                              onClick={() => {
-                                const presetDefaults = getPresetDefaults(preset)
-                                setPresetTooltipOpen(false)
-                                setSaveError('')
-                                setFieldErrors({})
-                                setDraft((current) => ({
-                                  ...current,
-                                  name: preset.name,
-                                  url: preset.url,
-                                  api_path: preset.api_path,
-                                  type: preset.type,
-                                  timeout_seconds: presetDefaults.timeout_seconds,
-                                  api_hits_day: presetDefaults.api_hits_day,
-                                  downloads_day: presetDefaults.downloads_day,
-                                  rate_limit_rps: presetDefaults.rate_limit_rps,
-                                }))
-                                requestAnimationFrame(() => {
-                                  nameInputRef.current?.focus()
-                                  nameInputRef.current?.select?.()
-                                })
-                              }}
-                            >
-                              {preset.name}
-                            </DropdownMenuItem>
-                          ))}
-                        </DropdownMenuContent>
-                      </DropdownMenu>
-                      <TooltipContent>{selectedPresetName ? `Load preset (${selectedPresetName})` : 'Load preset'}</TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
-                )}
-              </div>
-            </div>
-          </div>
-
-          {!isEasynews && (
-            <div className="rounded-md border border-border/60">
-              <div className="p-3">
-                <div className={rowClass}>
-                  <div className={labelClass}>
-                    <Label className="text-sm font-medium">URL</Label>
-                  </div>
-                  <div className={controlWideClass}>
-                    <Input className={`h-9 ${fieldClass('url')}`} value={draft.url} onChange={(event) => update('url', event.target.value)} placeholder="https://api.nzbgeek.info" />
-                  </div>
-                </div>
-              </div>
-              <div className="relative p-3">
-                <div className="absolute left-3 right-3 top-0 border-t border-border/60" />
-                <div className={rowClass}>
-                  <div className={labelClass}>
-                    <Label className="text-sm font-medium">API Path</Label>
-                  </div>
-                  <div className={controlWideClass}>
-                    <Input className={`h-9 ${fieldClass('api_path')}`} value={draft.api_path} onChange={(event) => update('api_path', event.target.value)} placeholder="/api" />
-                  </div>
-                </div>
-                {hasProwlarrPlaceholder && (
-                  <div className="mt-3 flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-900">
-                    <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-                    <span>Replace <code>{PROWLARR_INDEXER_ID_PLACEHOLDER}</code> with the real Prowlarr indexer ID, for example <code>1/api</code>.</span>
-                  </div>
-                )}
-              </div>
-              <div className="relative p-3">
-                <div className="absolute left-3 right-3 top-0 border-t border-border/60" />
-                <div className={rowClass}>
-                  <div className={labelClass}>
-                    <Label className="text-sm font-medium">API Key</Label>
-                  </div>
-                  <div className={controlWideClass}>
-                    <Input className={`h-9 ${fieldClass('api_key')}`} type="password" value={draft.api_key} onChange={(event) => update('api_key', event.target.value)} />
-                  </div>
-                </div>
-              </div>
-            </div>
-          )}
-
-          {isEasynews && (
-            <div className="rounded-md border border-border/60">
-              <div className="p-3">
-                <div className={rowClass}>
-                  <div className={labelClass}>
-                    <Label className="text-sm font-medium">Username</Label>
-                  </div>
-                  <div className={controlWideClass}>
-                    <Input className={`h-9 ${fieldClass('username')}`} value={draft.username} onChange={(event) => update('username', event.target.value)} />
-                  </div>
-                </div>
-              </div>
-              <div className="relative p-3">
-                <div className="absolute left-3 right-3 top-0 border-t border-border/60" />
-                <div className={rowClass}>
-                  <div className={labelClass}>
-                    <Label className="text-sm font-medium">Password</Label>
-                  </div>
-                  <div className={controlWideClass}>
-                    <Input className={`h-9 ${fieldClass('password')}`} type="password" value={draft.password} onChange={(event) => update('password', event.target.value)} />
-                  </div>
-                </div>
-              </div>
-            </div>
-          )}
-
-          <div className="rounded-md border border-border/60 p-3">
-            <div className={rowClass}>
-              <div className={labelClass}>
-                <Label className="text-sm font-medium">HTTP(S) proxy</Label>
-                <p className="mt-1 text-xs text-muted-foreground">Optional proxy override</p>
-              </div>
-              <div className={controlWideClass}>
-                <Input
-                  className={`h-9 ${fieldClass('proxy_url')}`}
-                  value={draft.proxy_url}
-                  onChange={(event) => update('proxy_url', event.target.value)}
-                  placeholder="http://proxy:8888"
-                  autoComplete="off"
-                />
-              </div>
-            </div>
-          </div>
-
-          <div className="rounded-md border border-border/60">
-            <div className="p-3">
-              <div className="space-y-3">
-                <div className={rowClass}>
-                  <div className={labelClass}>
-                    <Label className="text-sm font-medium">Timeout (seconds)</Label>
-                  </div>
-                  <div className={controlNarrowClass}>
-                    <Input className={`h-9 ${fieldClass('timeout_seconds')}`} type="number" min={0} value={draft.timeout_seconds === 0 ? '' : draft.timeout_seconds} onChange={(event) => update('timeout_seconds', event.target.value === '' ? 0 : Number(event.target.value))} placeholder={String(getDefaultIndexerTimeoutSeconds(draft.type))} />
-                  </div>
-                </div>
-                {isEasynews && (
-                  <p className="text-sm text-muted-foreground">{EASYNEWS_TIMEOUT_HINT}</p>
-                )}
-              </div>
-            </div>
-            <div className="relative p-3">
-              <div className="absolute left-3 right-3 top-0 border-t border-border/60" />
+          <div className="space-y-4">
+            <div className="rounded-md border border-border/60 p-3">
               <div className={rowClass}>
                 <div className={labelClass}>
-                  <Label className="text-sm font-medium">Requests/Second</Label>
+                  <Label className="text-sm font-medium">Name</Label>
                 </div>
-                <div className={controlNarrowClass}>
-                  <Input className={`h-9 ${fieldClass('rate_limit_rps')}`} type="number" min={0} value={draft.rate_limit_rps === 0 ? '' : draft.rate_limit_rps} onChange={(event) => update('rate_limit_rps', event.target.value === '' ? 0 : Number(event.target.value))} placeholder="∞" />
+                <div className={controlNameClass}>
+                  <Input ref={nameInputRef} className={`h-9 ${fieldClass('name')}`} value={draft.name} onChange={(event) => update('name', event.target.value)} placeholder="e.g. NzbPlanet" disabled={editing} />
+                  {!editing && (
+                    <TooltipProvider delayDuration={100}>
+                      <Tooltip open={presetTooltipOpen && !presetMenuOpen} onOpenChange={setPresetTooltipOpen}>
+                        <DropdownMenu onOpenChange={(nextOpen) => {
+                          setPresetMenuOpen(nextOpen)
+                          if (nextOpen) setPresetTooltipOpen(false)
+                        }}>
+                          <TooltipTrigger asChild>
+                            <DropdownMenuTrigger asChild>
+                              <Button type="button" variant={selectedPresetName ? "secondary" : "outline"} size="icon" className="h-9 w-9 shrink-0" aria-label={selectedPresetName ? `Load preset (${selectedPresetName})` : 'Load preset'}>
+                                <Download className="h-4 w-4" />
+                              </Button>
+                            </DropdownMenuTrigger>
+                          </TooltipTrigger>
+                          <DropdownMenuContent
+                            align="end"
+                            className="max-h-80 w-56 overflow-y-auto"
+                            onCloseAutoFocus={(event) => {
+                              event.preventDefault()
+                            }}
+                          >
+                            {INDEXER_PRESETS.map((preset) => (
+                              <DropdownMenuItem
+                                key={preset.name}
+                                onClick={() => {
+                                  const presetDefaults = getPresetDefaults(preset)
+                                  setPresetTooltipOpen(false)
+                                  setSaveError('')
+                                  setFieldErrors({})
+                                  setDraft((current) => ({
+                                    ...current,
+                                    name: preset.name,
+                                    url: preset.url,
+                                    api_path: preset.api_path,
+                                    type: preset.type,
+                                    timeout_seconds: presetDefaults.timeout_seconds,
+                                    api_hits_day: presetDefaults.api_hits_day,
+                                    downloads_day: presetDefaults.downloads_day,
+                                    rate_limit_rps: presetDefaults.rate_limit_rps,
+                                    query_header: presetDefaults.query_header,
+                                    grab_header: presetDefaults.grab_header,
+                                  }))
+                                  requestAnimationFrame(() => {
+                                    nameInputRef.current?.focus()
+                                    nameInputRef.current?.select?.()
+                                  })
+                                }}
+                              >
+                                {preset.name}
+                              </DropdownMenuItem>
+                            ))}
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                        <TooltipContent>{selectedPresetName ? `Load preset (${selectedPresetName})` : 'Load preset'}</TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
+                  )}
                 </div>
               </div>
             </div>
-            {draft.type === 'aggregator' && (
-              <div className="relative p-3">
-                <div className="absolute left-3 right-3 top-0 border-t border-border/60" />
+
+            {!isEasynews && (
+              <div className="rounded-md border border-border/60">
+                <div className="p-3">
+                  <div className={rowClass}>
+                    <div className={labelClass}>
+                      <Label className="text-sm font-medium">URL</Label>
+                    </div>
+                    <div className={controlWideClass}>
+                      <Input className={`h-9 ${fieldClass('url')}`} value={draft.url} onChange={(event) => update('url', event.target.value)} placeholder="https://api.nzbgeek.info" />
+                    </div>
+                  </div>
+                </div>
+                <div className="relative p-3">
+                  <div className="absolute left-3 right-3 top-0 border-t border-border/60" />
+                  <div className={rowClass}>
+                    <div className={labelClass}>
+                      <Label className="text-sm font-medium">API Path</Label>
+                    </div>
+                    <div className={controlWideClass}>
+                      <Input className={`h-9 ${fieldClass('api_path')}`} value={draft.api_path} onChange={(event) => update('api_path', event.target.value)} placeholder="/api" />
+                    </div>
+                  </div>
+                  {hasProwlarrPlaceholder && (
+                    <div className="mt-3 flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-900">
+                      <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                      <span>Replace <code>{PROWLARR_INDEXER_ID_PLACEHOLDER}</code> with the real Prowlarr indexer ID, for example <code>1/api</code>.</span>
+                    </div>
+                  )}
+                </div>
+                <div className="relative p-3">
+                  <div className="absolute left-3 right-3 top-0 border-t border-border/60" />
+                  <div className={rowClass}>
+                    <div className={labelClass}>
+                      <Label className="text-sm font-medium">API Key</Label>
+                    </div>
+                    <div className={controlWideClass}>
+                      <Input className={`h-9 ${fieldClass('api_key')}`} type="password" value={draft.api_key} onChange={(event) => update('api_key', event.target.value)} />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {isEasynews && (
+              <div className="rounded-md border border-border/60">
+                <div className="p-3">
+                  <div className={rowClass}>
+                    <div className={labelClass}>
+                      <Label className="text-sm font-medium">Username</Label>
+                    </div>
+                    <div className={controlWideClass}>
+                      <Input className={`h-9 ${fieldClass('username')}`} value={draft.username} onChange={(event) => update('username', event.target.value)} />
+                    </div>
+                  </div>
+                </div>
+                <div className="relative p-3">
+                  <div className="absolute left-3 right-3 top-0 border-t border-border/60" />
+                  <div className={rowClass}>
+                    <div className={labelClass}>
+                      <Label className="text-sm font-medium">Password</Label>
+                    </div>
+                    <div className={controlWideClass}>
+                      <Input className={`h-9 ${fieldClass('password')}`} type="password" value={draft.password} onChange={(event) => update('password', event.target.value)} />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            <div className="rounded-md border border-border/60 p-3">
+              <div className={rowClass}>
+                <div className={labelClass}>
+                  <Label className="text-sm font-medium">HTTP(S) proxy</Label>
+                  <p className="mt-1 text-xs text-muted-foreground">Optional proxy override</p>
+                </div>
+                <div className={controlWideClass}>
+                  <Input
+                    className={`h-9 ${fieldClass('proxy_url')}`}
+                    value={draft.proxy_url}
+                    onChange={(event) => update('proxy_url', event.target.value)}
+                    placeholder="http://proxy:8888"
+                    autoComplete="off"
+                  />
+                </div>
+              </div>
+            </div>
+
+            <div className="rounded-md border border-border/60">
+              {!isEasynews && (
+                <div className="p-3">
+                  <div className={rowClass}>
+                    <div className={labelClass}>
+                      <Label className="text-sm font-medium">Indexer Query Header</Label>
+                      <p className="mt-1 text-xs text-muted-foreground">User-Agent for search and capability requests. Overrides the global setting for this indexer only.</p>
+                    </div>
+                    <div className={controlWideClass}>
+                      <Input
+                        className="h-9"
+                        value={draft.query_header}
+                        onChange={(event) => update('query_header', event.target.value)}
+                        placeholder="Prowlarr/2.3.0.5236"
+                        autoComplete="off"
+                      />
+                    </div>
+                  </div>
+                </div>
+              )}
+              <div className={!isEasynews ? "relative p-3" : "p-3"}>
+                {!isEasynews && <div className="absolute left-3 right-3 top-0 border-t border-border/60" />}
                 <div className={rowClass}>
                   <div className={labelClass}>
-                    <Label className="text-sm font-medium">Search Results Cache Time (minutes)</Label>
+                    <Label className="text-sm font-medium">Indexer Grab Header</Label>
+                    <p className="mt-1 text-xs text-muted-foreground">User-Agent for NZB download requests. Overrides the global setting for this indexer only.</p>
                   </div>
-                  <div className={controlNarrowClass}>
+                  <div className={controlWideClass}>
                     <Input
-                      className={`h-9 ${fieldClass('search_results_cache_time')}`}
-                      type="number"
-                      min={0}
-                      value={draft.search_results_cache_time === 0 ? '' : draft.search_results_cache_time}
-                      onChange={(event) => update('search_results_cache_time', event.target.value === '' ? 0 : Number(event.target.value))}
-                      placeholder="disabled"
+                      className="h-9"
+                      value={draft.grab_header}
+                      onChange={(event) => update('grab_header', event.target.value)}
+                      placeholder="SABnzbd/4.3.0"
+                      autoComplete="off"
                     />
                   </div>
                 </div>
-                <p className="mt-2 text-xs text-muted-foreground">
-                  NZBHydra2: adds <code>cachetime</code> to search API calls.
-                </p>
-              </div>
-            )}
-            <div className="relative p-3">
-              <div className="absolute left-3 right-3 top-0 border-t border-border/60" />
-              <div className={rowClass}>
-                <div className={labelClass}>
-                  <Label className="text-sm font-medium">Hits/Day</Label>
-                </div>
-                <div className={controlNarrowClass}>
-                  <Input className={`h-9 ${fieldClass('api_hits_day')}`} type="number" min={0} value={draft.api_hits_day === 0 ? '' : draft.api_hits_day} onChange={(event) => update('api_hits_day', event.target.value === '' ? 0 : Number(event.target.value))} placeholder="∞" />
-                </div>
               </div>
             </div>
-            <div className="relative p-3">
-              <div className="absolute left-3 right-3 top-0 border-t border-border/60" />
-              <div className={rowClass}>
-                <div className={labelClass}>
-                  <Label className="text-sm font-medium">DLs/Day</Label>
+
+            <div className="rounded-md border border-border/60">
+              <div className="p-3">
+                <div className="space-y-3">
+                  <div className={rowClass}>
+                    <div className={labelClass}>
+                      <Label className="text-sm font-medium">Timeout (seconds)</Label>
+                    </div>
+                    <div className={controlNarrowClass}>
+                      <Input className={`h-9 ${fieldClass('timeout_seconds')}`} type="number" min={0} value={draft.timeout_seconds === 0 ? '' : draft.timeout_seconds} onChange={(event) => update('timeout_seconds', event.target.value === '' ? 0 : Number(event.target.value))} placeholder={String(getDefaultIndexerTimeoutSeconds(draft.type))} />
+                    </div>
+                  </div>
+                  {isEasynews && (
+                    <p className="text-sm text-muted-foreground">{EASYNEWS_TIMEOUT_HINT}</p>
+                  )}
                 </div>
-                <div className={controlNarrowClass}>
-                  <Input className={`h-9 ${fieldClass('downloads_day')}`} type="number" min={0} value={draft.downloads_day === 0 ? '' : draft.downloads_day} onChange={(event) => update('downloads_day', event.target.value === '' ? 0 : Number(event.target.value))} placeholder="∞" />
+              </div>
+              <div className="relative p-3">
+                <div className="absolute left-3 right-3 top-0 border-t border-border/60" />
+                <div className={rowClass}>
+                  <div className={labelClass}>
+                    <Label className="text-sm font-medium">Requests/Second</Label>
+                  </div>
+                  <div className={controlNarrowClass}>
+                    <Input className={`h-9 ${fieldClass('rate_limit_rps')}`} type="number" min={0} value={draft.rate_limit_rps === 0 ? '' : draft.rate_limit_rps} onChange={(event) => update('rate_limit_rps', event.target.value === '' ? 0 : Number(event.target.value))} placeholder="∞" />
+                  </div>
+                </div>
+              </div>
+              {draft.type === 'aggregator' && (
+                <div className="relative p-3">
+                  <div className="absolute left-3 right-3 top-0 border-t border-border/60" />
+                  <div className={rowClass}>
+                    <div className={labelClass}>
+                      <Label className="text-sm font-medium">Search Results Cache Time (minutes)</Label>
+                    </div>
+                    <div className={controlNarrowClass}>
+                      <Input
+                        className={`h-9 ${fieldClass('search_results_cache_time')}`}
+                        type="number"
+                        min={0}
+                        value={draft.search_results_cache_time === 0 ? '' : draft.search_results_cache_time}
+                        onChange={(event) => update('search_results_cache_time', event.target.value === '' ? 0 : Number(event.target.value))}
+                        placeholder="disabled"
+                      />
+                    </div>
+                  </div>
+                  <p className="mt-2 text-xs text-muted-foreground">
+                    NZBHydra2: adds <code>cachetime</code> to search API calls.
+                  </p>
+                </div>
+              )}
+              <div className="relative p-3">
+                <div className="absolute left-3 right-3 top-0 border-t border-border/60" />
+                <div className={rowClass}>
+                  <div className={labelClass}>
+                    <Label className="text-sm font-medium">Hits/Day</Label>
+                  </div>
+                  <div className={controlNarrowClass}>
+                    <Input className={`h-9 ${fieldClass('api_hits_day')}`} type="number" min={0} value={draft.api_hits_day === 0 ? '' : draft.api_hits_day} onChange={(event) => update('api_hits_day', event.target.value === '' ? 0 : Number(event.target.value))} placeholder="∞" />
+                  </div>
+                </div>
+              </div>
+              <div className="relative p-3">
+                <div className="absolute left-3 right-3 top-0 border-t border-border/60" />
+                <div className={rowClass}>
+                  <div className={labelClass}>
+                    <Label className="text-sm font-medium">DLs/Day</Label>
+                  </div>
+                  <div className={controlNarrowClass}>
+                    <Input className={`h-9 ${fieldClass('downloads_day')}`} type="number" min={0} value={draft.downloads_day === 0 ? '' : draft.downloads_day} onChange={(event) => update('downloads_day', event.target.value === '' ? 0 : Number(event.target.value))} placeholder="∞" />
+                  </div>
                 </div>
               </div>
             </div>
           </div>
-        </div>
         </div>
 
         <DialogFooter className="flex items-center justify-between gap-3">
@@ -663,56 +711,56 @@ export function IndexerSettings({ fields = [], append, update, remove, replace, 
                   >
                     <CardContent className="pt-6">
                       <div className="min-w-0 flex-1 space-y-3">
-                          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                            <div className="flex items-center gap-2 self-end sm:order-2">
-                              <Tooltip>
-                                <TooltipTrigger asChild>
-                                  <div className="inline-flex h-9 w-20 items-center justify-center rounded-md border border-border/60 bg-muted/30 px-2">
-                                    <Switch
-                                      checked={normalized.enabled !== false}
-                                      onCheckedChange={(checked) => handleToggleEnabled(index, checked === true)}
-                                      aria-label={normalized.enabled !== false ? `Disable indexer ${normalized.name || normalized.url || index + 1}` : `Enable indexer ${normalized.name || normalized.url || index + 1}`}
-                                      className="h-6 w-12 data-[state=checked]:bg-green-500 data-[state=unchecked]:bg-muted-foreground/30"
-                                      thumbClassName="flex h-5 w-5 items-center justify-center data-[state=checked]:translate-x-6 data-[state=unchecked]:translate-x-0"
-                                    />
-                                  </div>
-                                </TooltipTrigger>
-                                <TooltipContent>{normalized.enabled !== false ? 'Disable indexer' : 'Enable indexer'}</TooltipContent>
-                              </Tooltip>
-                              <Tooltip>
-                                <TooltipTrigger asChild>
-                                  <Button type="button" variant="outline" size="icon" className="h-9 w-9" aria-label={`Edit indexer ${normalized.name || normalized.url || index + 1}`} onClick={() => {
-                                    setDeleteBlockedName('')
-                                    onClearStatus?.()
-                                    setEditingIndex(index)
-                                  }}>
-                                    <Settings className="h-4 w-4" />
-                                  </Button>
-                                </TooltipTrigger>
-                                <TooltipContent>Edit indexer</TooltipContent>
-                              </Tooltip>
-                              <Tooltip>
-                                <TooltipTrigger asChild>
-                                  <Button type="button" variant="destructive" size="icon" className="h-9 w-9" aria-label={`Delete indexer ${normalized.name || normalized.url || index + 1}`} onClick={() => setDeleteTarget({ index, name: normalized.name || normalized.url })}>
-                                    <Trash2 className="h-4 w-4" />
-                                  </Button>
-                                </TooltipTrigger>
-                                <TooltipContent>Delete indexer</TooltipContent>
-                              </Tooltip>
-                            </div>
-                            <div className="min-w-0 font-semibold sm:order-1">{normalized.name || normalized.url || `Indexer ${index + 1}`}</div>
+                        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                          <div className="flex items-center gap-2 self-end sm:order-2">
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <div className="inline-flex h-9 w-20 items-center justify-center rounded-md border border-border/60 bg-muted/30 px-2">
+                                  <Switch
+                                    checked={normalized.enabled !== false}
+                                    onCheckedChange={(checked) => handleToggleEnabled(index, checked === true)}
+                                    aria-label={normalized.enabled !== false ? `Disable indexer ${normalized.name || normalized.url || index + 1}` : `Enable indexer ${normalized.name || normalized.url || index + 1}`}
+                                    className="h-6 w-12 data-[state=checked]:bg-green-500 data-[state=unchecked]:bg-muted-foreground/30"
+                                    thumbClassName="flex h-5 w-5 items-center justify-center data-[state=checked]:translate-x-6 data-[state=unchecked]:translate-x-0"
+                                  />
+                                </div>
+                              </TooltipTrigger>
+                              <TooltipContent>{normalized.enabled !== false ? 'Disable indexer' : 'Enable indexer'}</TooltipContent>
+                            </Tooltip>
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <Button type="button" variant="outline" size="icon" className="h-9 w-9" aria-label={`Edit indexer ${normalized.name || normalized.url || index + 1}`} onClick={() => {
+                                  setDeleteBlockedName('')
+                                  onClearStatus?.()
+                                  setEditingIndex(index)
+                                }}>
+                                  <Settings className="h-4 w-4" />
+                                </Button>
+                              </TooltipTrigger>
+                              <TooltipContent>Edit indexer</TooltipContent>
+                            </Tooltip>
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <Button type="button" variant="destructive" size="icon" className="h-9 w-9" aria-label={`Delete indexer ${normalized.name || normalized.url || index + 1}`} onClick={() => setDeleteTarget({ index, name: normalized.name || normalized.url })}>
+                                  <Trash2 className="h-4 w-4" />
+                                </Button>
+                              </TooltipTrigger>
+                              <TooltipContent>Delete indexer</TooltipContent>
+                            </Tooltip>
                           </div>
-                          <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3">
-                            <div className="flex flex-wrap gap-2 text-xs text-muted-foreground min-w-0">
-                              <span className="rounded-full border border-border px-2 py-1">
-                                Status:{' '}
-                                <span className={`inline-block h-2 w-2 rounded-full ${isOnline ? 'bg-green-500' : 'bg-red-500'}`} />
-                              </span>
-                              {summary.map((part) => (
-                                <span key={part} className="rounded-full border border-border px-2 py-1">{part}</span>
-                              ))}
-                            </div>
+                          <div className="min-w-0 font-semibold sm:order-1">{normalized.name || normalized.url || `Indexer ${index + 1}`}</div>
+                        </div>
+                        <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3">
+                          <div className="flex flex-wrap gap-2 text-xs text-muted-foreground min-w-0">
+                            <span className="rounded-full border border-border px-2 py-1">
+                              Status:{' '}
+                              <span className={`inline-block h-2 w-2 rounded-full ${isOnline ? 'bg-green-500' : 'bg-red-500'}`} />
+                            </span>
+                            {summary.map((part) => (
+                              <span key={part} className="rounded-full border border-border px-2 py-1">{part}</span>
+                            ))}
                           </div>
+                        </div>
                       </div>
                     </CardContent>
 

--- a/frontend/src/components/IndexerSettings.jsx
+++ b/frontend/src/components/IndexerSettings.jsx
@@ -434,8 +434,8 @@ function IndexerDialog({ open, onOpenChange, initialValue, onSave, onClearStatus
                 <div className="p-3">
                   <div className={rowClass}>
                     <div className={labelClass}>
-                      <Label className="text-sm font-medium">Indexer Query Header</Label>
-                      <p className="mt-1 text-xs text-muted-foreground">User-Agent for search and capability requests. Overrides the global setting for this indexer only.</p>
+                      <Label className="text-sm font-medium">Query Header</Label>
+                      <p className="mt-1 text-xs text-muted-foreground">Optional Query Header override</p>
                     </div>
                     <div className={controlWideClass}>
                       <Input
@@ -453,15 +453,15 @@ function IndexerDialog({ open, onOpenChange, initialValue, onSave, onClearStatus
                 {!isEasynews && <div className="absolute left-3 right-3 top-0 border-t border-border/60" />}
                 <div className={rowClass}>
                   <div className={labelClass}>
-                    <Label className="text-sm font-medium">Indexer Grab Header</Label>
-                    <p className="mt-1 text-xs text-muted-foreground">User-Agent for NZB download requests. Overrides the global setting for this indexer only.</p>
+                    <Label className="text-sm font-medium">Grab Header</Label>
+                    <p className="mt-1 text-xs text-muted-foreground">Optional Grab Header override</p>
                   </div>
                   <div className={controlWideClass}>
                     <Input
                       className="h-9"
                       value={draft.grab_header}
                       onChange={(event) => update('grab_header', event.target.value)}
-                      placeholder="SABnzbd/4.3.0"
+                      placeholder="SABnzbd/4.5.5"
                       autoComplete="off"
                     />
                   </div>
@@ -586,9 +586,9 @@ export function IndexerSettings({ fields = [], append, update, remove, replace, 
   const [deleteBlockedName, setDeleteBlockedName] = useState('')
   const indexerStatusByName = useMemo(() => {
     const map = new Map()
-    ;(stats?.indexers || []).forEach((indexer) => {
-      map.set((indexer.name || '').trim(), true)
-    })
+      ; (stats?.indexers || []).forEach((indexer) => {
+        map.set((indexer.name || '').trim(), true)
+      })
     return map
   }, [stats])
 

--- a/pkg/core/config/config.go
+++ b/pkg/core/config/config.go
@@ -126,6 +126,13 @@ type IndexerConfig struct {
 	// ProxyURL is an optional HTTP or HTTPS proxy for this indexer (http://host:port or https://...).
 	// When empty, HTTP_PROXY / HTTPS_PROXY / NO_PROXY apply via the default proxy resolution.
 	ProxyURL string `json:"proxy_url,omitempty"`
+
+	// QueryHeader overrides the global indexer_query_header for search and capability requests to this indexer.
+	// Some indexers (e.g. SceneNZBs) gate content by User-Agent; leave empty to use the global setting.
+	QueryHeader string `json:"query_header,omitempty"`
+	// GrabHeader overrides the global indexer_grab_header for NZB download requests to this indexer.
+	// Some indexers (e.g. SceneNZBs) return different NZBs depending on the downloader UA; leave empty to use the global setting.
+	GrabHeader string `json:"grab_header,omitempty"`
 }
 
 // ValidateIndexerProxyURL returns nil if raw is empty or a valid http(s) proxy URL.

--- a/pkg/indexer/easynews/client.go
+++ b/pkg/indexer/easynews/client.go
@@ -33,6 +33,7 @@ type Client struct {
 	username        string
 	password        string
 	name            string
+	grabHeader      string
 	client          *http.Client
 	downloadClient  *http.Client
 	downloadBase    string
@@ -54,7 +55,7 @@ type Client struct {
 
 var _ indexer.Indexer = (*Client)(nil)
 
-func NewClient(username, password, name string, downloadBase string, apiLimit, downloadLimit, rateLimitRPS, timeoutSeconds int, proxyURL string, um *indexer.UsageManager) (*Client, error) {
+func NewClient(username, password, name string, downloadBase string, apiLimit, downloadLimit, rateLimitRPS, timeoutSeconds int, proxyURL, grabHeader string, um *indexer.UsageManager) (*Client, error) {
 	if username == "" || password == "" {
 		return nil, fmt.Errorf("easynews username and password are required")
 	}
@@ -84,6 +85,7 @@ func NewClient(username, password, name string, downloadBase string, apiLimit, d
 		username:          username,
 		password:          password,
 		name:              name,
+		grabHeader:        grabHeader,
 		downloadBase:      downloadBase,
 		searchTimeout:     searchTimeout,
 		downloadTimeout:   downloadTimeout,
@@ -122,6 +124,13 @@ func NewClient(username, password, name string, downloadBase string, apiLimit, d
 	}
 
 	return c, nil
+}
+
+func (c *Client) effectiveGrabHeader() string {
+	if h := strings.TrimSpace(c.grabHeader); h != "" {
+		return h
+	}
+	return env.IndexerGrabHeader()
 }
 
 func (c *Client) Name() string {
@@ -509,7 +518,7 @@ func (c *Client) downloadNZBInternal(ctx context.Context, payload map[string]int
 
 	req.SetBasicAuth(c.username, c.password)
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Set("User-Agent", env.IndexerGrabHeader())
+	req.Header.Set("User-Agent", c.effectiveGrabHeader())
 	resp, err := c.downloadClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("easynews NZB download request failed: %w", err)

--- a/pkg/indexer/easynews/client_test.go
+++ b/pkg/indexer/easynews/client_test.go
@@ -57,7 +57,7 @@ func TestGetUsageRefreshesDailyCountersAfterRollover(t *testing.T) {
 	usageData.AllTimeAPIHitsUsed = 30
 	usageData.AllTimeDownloadsUsed = 12
 
-	client, err := NewClient("user", "pass", name, "", 8, 4, 0, 0, "", usageManager)
+	client, err := NewClient("user", "pass", name, "", 8, 4, 0, 0, "", "", usageManager)
 	if err != nil {
 		t.Fatalf("NewClient: %v", err)
 	}
@@ -86,7 +86,7 @@ func TestLimitChecksRefreshDailyUsageAfterRollover(t *testing.T) {
 	usageData.APIHitsUsed = 8
 	usageData.DownloadsUsed = 4
 
-	client, err := NewClient("user", "pass", name, "", 8, 4, 0, 0, "", usageManager)
+	client, err := NewClient("user", "pass", name, "", 8, 4, 0, 0, "", "", usageManager)
 	if err != nil {
 		t.Fatalf("NewClient: %v", err)
 	}

--- a/pkg/indexer/easynews/client_timeout_test.go
+++ b/pkg/indexer/easynews/client_timeout_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestNewClientConfiguresSeparateSearchAndDownloadTimeouts(t *testing.T) {
-	client, err := NewClient("user", "pass", "Easynews", "", 0, 0, 0, 0, "", nil)
+	client, err := NewClient("user", "pass", "Easynews", "", 0, 0, 0, 0, "", "", nil)
 	if err != nil {
 		t.Fatalf("NewClient returned error: %v", err)
 	}
@@ -29,7 +29,7 @@ func TestNewClientConfiguresSeparateSearchAndDownloadTimeouts(t *testing.T) {
 }
 
 func TestNewClientUsesConfiguredTimeoutAndDoublesDownloadTimeout(t *testing.T) {
-	client, err := NewClient("user", "pass", "Easynews", "", 0, 0, 0, 12, "", nil)
+	client, err := NewClient("user", "pass", "Easynews", "", 0, 0, 0, 12, "", "", nil)
 	if err != nil {
 		t.Fatalf("NewClient returned error: %v", err)
 	}
@@ -48,7 +48,7 @@ func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 func TestSearchInternalUsesSearchClient(t *testing.T) {
-	client, err := NewClient("user", "pass", "Easynews", "", 0, 0, 0, 0, "", nil)
+	client, err := NewClient("user", "pass", "Easynews", "", 0, 0, 0, 0, "", "", nil)
 	if err != nil {
 		t.Fatalf("NewClient returned error: %v", err)
 	}
@@ -71,7 +71,7 @@ func TestSearchInternalUsesSearchClient(t *testing.T) {
 }
 
 func TestDownloadNZBInternalUsesDownloadClient(t *testing.T) {
-	client, err := NewClient("user", "pass", "Easynews", "", 0, 0, 0, 0, "", nil)
+	client, err := NewClient("user", "pass", "Easynews", "", 0, 0, 0, 0, "", "EasynewsGrab/1.0", nil)
 	if err != nil {
 		t.Fatalf("NewClient returned error: %v", err)
 	}
@@ -80,6 +80,9 @@ func TestDownloadNZBInternalUsesDownloadClient(t *testing.T) {
 		return nil, nil
 	})
 	client.downloadClient.Transport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if got := req.Header.Get("User-Agent"); got != "EasynewsGrab/1.0" {
+			t.Fatalf("User-Agent = %q, want %q", got, "EasynewsGrab/1.0")
+		}
 		body := `<?xml version="1.0" encoding="UTF-8"?><nzb xmlns="http://www.newzbin.com/DTD/2003/nzb"></nzb>`
 		return &http.Response{
 			StatusCode: http.StatusOK,

--- a/pkg/indexer/newznab/client.go
+++ b/pkg/indexer/newznab/client.go
@@ -247,6 +247,20 @@ func NewClient(cfg config.IndexerConfig, um *indexer.UsageManager) *Client {
 	return c
 }
 
+func (c *Client) effectiveQueryHeader() string {
+	if h := strings.TrimSpace(c.cfg.QueryHeader); h != "" {
+		return h
+	}
+	return env.IndexerQueryHeader()
+}
+
+func (c *Client) effectiveGrabHeader() string {
+	if h := strings.TrimSpace(c.cfg.GrabHeader); h != "" {
+		return h
+	}
+	return env.IndexerGrabHeader()
+}
+
 func (c *Client) checkAPILimit() error {
 	c.refreshUsageFromManager()
 
@@ -339,7 +353,7 @@ func (c *Client) Ping() error {
 	if err != nil {
 		return err
 	}
-	req.Header.Set("User-Agent", env.IndexerQueryHeader())
+	req.Header.Set("User-Agent", c.effectiveQueryHeader())
 	resp, err := c.client.Do(req)
 	if err != nil {
 		return err
@@ -366,7 +380,7 @@ func (c *Client) GetCaps() (*indexer.Caps, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create caps request: %w", err)
 	}
-	req.Header.Set("User-Agent", env.IndexerQueryHeader())
+	req.Header.Set("User-Agent", c.effectiveQueryHeader())
 
 	resp, err := c.client.Do(req)
 	if err != nil {
@@ -658,7 +672,7 @@ func (c *Client) Search(req indexer.SearchRequest) (*indexer.SearchResponse, err
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
-	httpReq.Header.Set("User-Agent", env.IndexerQueryHeader())
+	httpReq.Header.Set("User-Agent", c.effectiveQueryHeader())
 	startedAt := time.Now()
 	resp, err := c.client.Do(httpReq)
 	if err != nil {
@@ -758,7 +772,7 @@ func (c *Client) DownloadNZB(ctx context.Context, nzbURL string) ([]byte, error)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
-	req.Header.Set("User-Agent", env.IndexerGrabHeader())
+	req.Header.Set("User-Agent", c.effectiveGrabHeader())
 	resp, err := c.client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to download NZB from %s: %w", c.Name(), err)

--- a/pkg/indexer/newznab/client_test.go
+++ b/pkg/indexer/newznab/client_test.go
@@ -52,8 +52,10 @@ func testNewznabUsageManager(t *testing.T) *indexer.UsageManager {
 
 func TestNewznabSearch(t *testing.T) {
 	logger.Init("DEBUG")
+	var gotUserAgent string
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUserAgent = r.Header.Get("User-Agent")
 
 		if r.URL.Query().Get("apikey") != "test-api-key" {
 			w.WriteHeader(http.StatusForbidden)
@@ -87,9 +89,10 @@ func TestNewznabSearch(t *testing.T) {
 	defer server.Close()
 
 	client := NewClient(config.IndexerConfig{
-		Name:   "MockIndexer",
-		URL:    server.URL,
-		APIKey: "test-api-key",
+		Name:        "MockIndexer",
+		URL:         server.URL,
+		APIKey:      "test-api-key",
+		QueryHeader: "Prowlarr/2.3.0.5236",
 	}, nil)
 	req := indexer.SearchRequest{
 		Cat:    "2000",
@@ -117,6 +120,9 @@ func TestNewznabSearch(t *testing.T) {
 
 	if item.SourceIndexer == nil {
 		t.Error("SourceIndexer was not populated")
+	}
+	if gotUserAgent != "Prowlarr/2.3.0.5236" {
+		t.Fatalf("User-Agent = %q, want %q", gotUserAgent, "Prowlarr/2.3.0.5236")
 	}
 }
 
@@ -247,7 +253,9 @@ func TestNewznabSearchLimitKeepsExplicitValueEvenAboveCapsMax(t *testing.T) {
 
 func TestNewznabPing(t *testing.T) {
 	logger.Init("DEBUG")
+	var gotUserAgent string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUserAgent = r.Header.Get("User-Agent")
 		if r.URL.Query().Get("t") == "caps" {
 			w.WriteHeader(http.StatusOK)
 		} else {
@@ -257,13 +265,17 @@ func TestNewznabPing(t *testing.T) {
 	defer server.Close()
 
 	client := NewClient(config.IndexerConfig{
-		Name:   "MockIndexer",
-		URL:    server.URL,
-		APIKey: "test-api-key",
+		Name:        "MockIndexer",
+		URL:         server.URL,
+		APIKey:      "test-api-key",
+		QueryHeader: "Prowlarr/2.3.0.5236",
 	}, nil)
 	err := client.Ping()
 	if err != nil {
 		t.Errorf("Ping failed: %v", err)
+	}
+	if gotUserAgent != "Prowlarr/2.3.0.5236" {
+		t.Fatalf("User-Agent = %q, want %q", gotUserAgent, "Prowlarr/2.3.0.5236")
 	}
 }
 
@@ -341,19 +353,22 @@ func TestDownloadNZBUsesNormalizedURL(t *testing.T) {
 	logger.Init("DEBUG")
 	var gotAPIKey string
 	var gotID string
+	var gotUserAgent string
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotAPIKey = r.URL.Query().Get("apikey")
 		gotID = r.URL.Query().Get("id")
+		gotUserAgent = r.Header.Get("User-Agent")
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprint(w, "<nzb></nzb>")
 	}))
 	defer server.Close()
 
 	client := NewClient(config.IndexerConfig{
-		Name:   "MockIndexer",
-		URL:    server.URL,
-		APIKey: "test-api-key",
+		Name:       "MockIndexer",
+		URL:        server.URL,
+		APIKey:     "test-api-key",
+		GrabHeader: "SABnzbd/4.3.0",
 	}, nil)
 
 	data, err := client.DownloadNZB(context.Background(), server.URL+"/api?t=get&guid=guid-123")
@@ -368,6 +383,9 @@ func TestDownloadNZBUsesNormalizedURL(t *testing.T) {
 	}
 	if got := string(data); got != "<nzb></nzb>" {
 		t.Fatalf("DownloadNZB data = %q, want %q", got, "<nzb></nzb>")
+	}
+	if gotUserAgent != "SABnzbd/4.3.0" {
+		t.Fatalf("User-Agent = %q, want %q", gotUserAgent, "SABnzbd/4.3.0")
 	}
 }
 

--- a/pkg/initialization/bootstrap.go
+++ b/pkg/initialization/bootstrap.go
@@ -126,7 +126,7 @@ func BuildComponents(cfg *config.Config) (*InitializedComponents, error) {
 				downloadBase = downloadBase[:len(downloadBase)-1]
 			}
 
-			easynewsClient, err := easynews.NewClient(idxCfg.Username, idxCfg.Password, idxCfg.Name, downloadBase, idxCfg.APIHitsDay, idxCfg.DownloadsDay, idxCfg.RateLimitRPS, idxCfg.EffectiveTimeoutSeconds(), effectiveProxyURL, usageMgr)
+			easynewsClient, err := easynews.NewClient(idxCfg.Username, idxCfg.Password, idxCfg.Name, downloadBase, idxCfg.APIHitsDay, idxCfg.DownloadsDay, idxCfg.RateLimitRPS, idxCfg.EffectiveTimeoutSeconds(), effectiveProxyURL, idxCfg.GrabHeader, usageMgr)
 			if err != nil {
 				logger.Error("Failed to initialize Easynews from indexer list", "name", idxCfg.Name, "err", err)
 			} else {

--- a/pkg/server/api/websocket.go
+++ b/pkg/server/api/websocket.go
@@ -780,6 +780,7 @@ func pingIndexerWithTimeout(indexerCfg config.IndexerConfig) error {
 				indexerCfg.RateLimitRPS,
 				indexerCfg.EffectiveTimeoutSeconds(),
 				indexerCfg.ProxyURL,
+				indexerCfg.GrabHeader,
 				nil,
 			)
 			if err != nil {


### PR DESCRIPTION
## Summary
- Add optional per-indexer query and grab User-Agent headers for Newznab indexers.
- Add optional per-indexer grab User-Agent header support for Easynews downloads.
- Expose header settings in the indexer UI.
- Set the SceneNZBs preset grab header to `SABnzbd/4.3.0`. (picked arbitrary vers. here, can change to any other valid SABnzbd version)

## Notes
For transparency: the frontend part was done by Claude Code because I hate frontend -_-

I ran into an issue where the indexer SceneNZBs needed a specific grab User-Agent, since it returned a bogus _rickroll_ video with default UA settings. The settings only allowed global query/grab headers, which made it hard to match indexer-specific demands, especially for presets like SceneNZBs where the grab request should look like `SABnzbd/4.3.0` without forcing that same header onto every other indexer.

I added UA checks in the tests for the new paths - happy to remove or simplify those if they feel too specific.

For Easynews, I kept the query header hidden in the UI because the original Easynews search path did not appear to use the global query header either (**Is that intended behavior?**)
For now I followed the existing path and only implemented easynews grab headers.

I tried to keep the existing structure.

**Thanks for the awesome work, I love what you are doing!**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-indexer HTTP header overrides for search and download requests (Query Header and Grab Header).
  * Enabled users to configure custom headers for individual indexers in the settings interface.
  * Updated SceneNZBs preset with default grab header configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Gaisberg/streamnzb/pull/144?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->