### PR TITLE
feat(unpack): implement seekable CBC decryption and fix volume offset…

### DIFF
--- a/pkg/media/decode/yenc.go
+++ b/pkg/media/decode/yenc.go
@@ -12,49 +12,67 @@ import (
 
 var sizeMismatchRE = regexp.MustCompile(`expected size (\d+) but got (\d+)`)
 
-type crlfReader struct {
+// yencInputReader prepares a textproto.DotReader article body for rapidyenc.
+//
+// It does two things:
+//  1. Converts bare-LF line endings to CRLF, which rapidyenc requires to detect
+//     line boundaries, the "=y" control, and the "=yend" trailer.
+//  2. Rewrites a '.' that begins a line into the yEnc escape "=n". A literal '.'
+//     and the escape "=n" both decode to byte 0x04, but rapidyenc performs its
+//     own NNTP dot-unstuffing on a line-leading '.' (it expects the raw,
+//     still-stuffed article). Our input has ALREADY been dot-unstuffed by
+//     textproto.DotReader, so a line-leading '.' here is genuine data; without
+//     this rewrite rapidyenc would strip it and silently drop one byte per such
+//     line, corrupting the decoded stream.
+type yencInputReader struct {
 	r    io.Reader
-	buf  []byte
+	in   [8192]byte
+	out  []byte
 	last byte
-	off  int
+	err  error
 }
 
-func (c *crlfReader) Read(p []byte) (int, error) {
-	out := 0
-	for out < len(p) {
-		if c.off < len(c.buf) {
-			b := c.buf[c.off]
-			c.off++
-			if b == '\n' && c.last != '\r' {
-				p[out] = '\r'
-				out++
-				c.last = '\r'
-				if out >= len(p) {
-					c.off--
-					return out, nil
-				}
+func (y *yencInputReader) Read(p []byte) (int, error) {
+	for len(y.out) == 0 {
+		if y.err != nil {
+			return 0, y.err
+		}
+		n, err := y.r.Read(y.in[:])
+		if n > 0 {
+			y.out = y.transform(y.in[:n])
+		}
+		if err != nil {
+			y.err = err
+			if len(y.out) == 0 {
+				return 0, err
 			}
-			p[out] = b
-			out++
-			c.last = b
-			continue
-		}
-		// Reuse the existing backing array instead of allocating a new one each time.
-		buf := c.buf[:cap(c.buf)]
-		if len(buf) == 0 {
-			buf = make([]byte, 4096)
-		}
-		n, err := c.r.Read(buf)
-		c.buf = buf[:n]
-		c.off = 0
-		if n == 0 {
-			return out, err
 		}
 	}
-	return out, nil
+	n := copy(p, y.out)
+	y.out = y.out[n:]
+	return n, nil
 }
 
-func normalizeCRLF(r io.Reader) io.Reader { return &crlfReader{r: r} }
+func (y *yencInputReader) transform(src []byte) []byte {
+	dst := make([]byte, 0, len(src)+len(src)/16+8)
+	for _, b := range src {
+		switch {
+		case b == '\n' && y.last != '\r':
+			dst = append(dst, '\r', '\n')
+			y.last = '\n'
+		case b == '.' && y.last == '\n':
+			// Line-leading data dot -> escaped form so rapidyenc won't unstuff it.
+			dst = append(dst, '=', 'n')
+			y.last = 'n'
+		default:
+			dst = append(dst, b)
+			y.last = b
+		}
+	}
+	return dst
+}
+
+func normalizeCRLF(r io.Reader) io.Reader { return &yencInputReader{r: r} }
 
 type Frame struct {
 	Data     []byte
@@ -79,6 +97,11 @@ func DecodeToBytes(r io.Reader) (*Frame, error) {
 		got, _ := strconv.ParseInt(sub[2], 10, 64)
 		shortfall := expected - got
 		if shortfall > 0 && shortfall <= maxDecodeSizeTolerance && int64(buf.Len()) == got {
+			// Keep the actually-decoded bytes. The =yend "size" is frequently a
+			// nominal/rounded value the poster wrote (e.g. 768000) while the real
+			// payload is a few bytes smaller; the decoded bytes are the true file
+			// content. Padding up to the declared size would splice phantom bytes
+			// at every segment boundary and corrupt the concatenated archive.
 			return &Frame{Data: cloneExact(buf.Bytes()), FileName: dec.Meta.FileName}, nil
 		}
 	}

--- a/pkg/media/decode/yenc_crlf_repro_test.go
+++ b/pkg/media/decode/yenc_crlf_repro_test.go
@@ -1,0 +1,335 @@
+package decode
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"hash/crc32"
+	"math/rand"
+	"net/textproto"
+	"testing"
+
+	"github.com/javi11/rapidyenc"
+)
+
+// manualYencArticle hand-encodes data as a single-part yEnc article with proper
+// line wrapping at `lineLen` columns (the rapidyenc encoder in this version does
+// not wrap, so we cannot use it to produce realistic multi-line bodies with
+// line-leading characters). Output uses CRLF and includes a correct pcrc32.
+func manualYencArticle(data []byte, lineLen int) []byte {
+	crit := func(c byte) bool { return c == 0x00 || c == 0x0A || c == 0x0D || c == 0x3D }
+	var body bytes.Buffer
+	col := 0
+	emit := func(c byte) {
+		if col >= lineLen {
+			body.WriteString("\r\n")
+			col = 0
+		}
+		body.WriteByte(c)
+		col++
+	}
+	for _, b := range data {
+		e := byte((int(b) + 42) & 0xff)
+		if crit(e) {
+			// An escape pair must not be split across a line.
+			if col+2 > lineLen {
+				body.WriteString("\r\n")
+				col = 0
+			}
+			body.WriteByte('=')
+			col++
+			body.WriteByte(byte((int(e) + 64) & 0xff))
+			col++
+		} else {
+			emit(e)
+		}
+	}
+
+	var art bytes.Buffer
+	fmt.Fprintf(&art, "=ybegin part=1 total=1 line=%d size=%d name=test.bin\r\n", lineLen, len(data))
+	fmt.Fprintf(&art, "=ypart begin=1 end=%d\r\n", len(data))
+	art.Write(body.Bytes())
+	fmt.Fprintf(&art, "\r\n=yend size=%d part=1 pcrc32=%08x\r\n", len(data), crc32.ChecksumIEEE(data))
+	return art.Bytes()
+}
+
+// stuffAndTerminate applies NNTP dot-stuffing per CRLF line and appends the
+// dot terminator; optionally rewrites CRLF to bare LF.
+func stuffAndTerminate(article []byte, bareLF bool) []byte {
+	var out bytes.Buffer
+	for _, line := range bytes.SplitAfter(article, []byte("\r\n")) {
+		if len(line) > 0 && line[0] == '.' {
+			out.WriteByte('.')
+		}
+		out.Write(line)
+	}
+	out.WriteString(".\r\n")
+	res := out.Bytes()
+	if bareLF {
+		res = bytes.ReplaceAll(res, []byte("\r\n"), []byte("\n"))
+	}
+	return res
+}
+
+// buildWire encodes data to yEnc, applies NNTP dot-stuffing, appends the dot
+// terminator, and optionally rewrites CRLF to bare LF. This mirrors what a
+// (compliant) Usenet server puts on the wire for an article body.
+func buildWire(t *testing.T, data []byte, bareLF bool) []byte {
+	return buildWireOpt(t, data, bareLF, true)
+}
+
+func buildWireOpt(t *testing.T, data []byte, bareLF, stuff bool) []byte {
+	t.Helper()
+	var crlf bytes.Buffer
+	enc, err := rapidyenc.NewEncoder(&crlf, rapidyenc.Meta{
+		FileName: "test.bin", FileSize: int64(len(data)) * 2,
+		PartNumber: 1, TotalParts: 2, Offset: 0, PartSize: int64(len(data)),
+	})
+	if err != nil {
+		t.Fatalf("NewEncoder: %v", err)
+	}
+	if _, err := enc.Write(data); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	if err := enc.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	// Dot-stuff each CRLF-terminated line, then add the terminator line.
+	var stuffed bytes.Buffer
+	for _, line := range bytes.SplitAfter(crlf.Bytes(), []byte("\r\n")) {
+		if stuff && len(line) > 0 && line[0] == '.' {
+			stuffed.WriteByte('.')
+		}
+		stuffed.Write(line)
+	}
+	stuffed.WriteString(".\r\n")
+
+	out := stuffed.Bytes()
+	if bareLF {
+		out = bytes.ReplaceAll(out, []byte("\r\n"), []byte("\n"))
+	}
+	return out
+}
+
+// fragmentReader returns at most `max` bytes per Read, simulating the small,
+// arbitrarily-sized chunks a network/textproto reader delivers (which exercises
+// the decoder's cross-Read state machine and our crlfReader rewind logic).
+type fragmentReader struct {
+	r   *bytes.Reader
+	max int
+}
+
+func (f *fragmentReader) Read(p []byte) (int, error) {
+	if len(p) > f.max {
+		p = p[:f.max]
+	}
+	return f.r.Read(p)
+}
+
+// decodeWire feeds the wire bytes through textproto.DotReader (the production
+// NNTP body reader) and then through DecodeToBytes, exactly as the fetch path does.
+func decodeWire(t *testing.T, wire []byte) (*Frame, error) {
+	t.Helper()
+	r := textproto.NewReader(bufio.NewReader(bytes.NewReader(wire)))
+	return DecodeToBytes(r.DotReader())
+}
+
+// encodeBareLFArticle yEnc-encodes data (with CRLF, as rapidyenc emits) and then
+// rewrites every CRLF to a bare LF, simulating a poster/provider that delivers
+// articles with bare-LF line endings (which is what the failing release uses).
+func encodeBareLFArticle(t *testing.T, data []byte, part, total int64, offset int64) []byte {
+	t.Helper()
+	var crlf bytes.Buffer
+	enc, err := rapidyenc.NewEncoder(&crlf, rapidyenc.Meta{
+		FileName:   "test.bin",
+		FileSize:   int64(len(data)) * total,
+		PartNumber: part,
+		TotalParts: total,
+		Offset:     offset,
+		PartSize:   int64(len(data)),
+	})
+	if err != nil {
+		t.Fatalf("NewEncoder: %v", err)
+	}
+	if _, err := enc.Write(data); err != nil {
+		t.Fatalf("encode write: %v", err)
+	}
+	if err := enc.Close(); err != nil {
+		t.Fatalf("encode close: %v", err)
+	}
+	// Articles are terminated by a "\r\n.\r\n" line in NNTP; rapidyenc stops at
+	// "=yend". Convert to bare LF to reproduce the wire format under test.
+	return bytes.ReplaceAll(crlf.Bytes(), []byte("\r\n"), []byte("\n"))
+}
+
+func TestDecodeBareLFArticleNoByteLoss(t *testing.T) {
+	sizes := []int{768000, 100000, 50000}
+	for _, n := range sizes {
+		rng := rand.New(rand.NewSource(int64(n)))
+		data := make([]byte, n)
+		rng.Read(data)
+
+		body := encodeBareLFArticle(t, data, 1, 2, 0)
+
+		frame, err := DecodeToBytes(bytes.NewReader(body))
+		if err != nil {
+			t.Fatalf("size=%d decode error: %v", n, err)
+		}
+		if len(frame.Data) != n {
+			t.Errorf("size=%d: decoded %d bytes, want %d (delta %d)", n, len(frame.Data), n, len(frame.Data)-n)
+		}
+		if !bytes.Equal(frame.Data, data) {
+			// Find first divergence for diagnostics.
+			first := -1
+			for i := 0; i < len(data) && i < len(frame.Data); i++ {
+				if data[i] != frame.Data[i] {
+					first = i
+					break
+				}
+			}
+			t.Errorf("size=%d: decoded data differs from original (first diff at %d)", n, first)
+		}
+	}
+}
+
+// TestDecodeBareLFManyCriticalBytes stresses the path with data that yEnc must
+// escape frequently (NUL, LF, CR, '='), increasing the chance of an escape
+// landing next to a line boundary where CRLF normalization could corrupt it.
+func TestDecodeBareLFManyCriticalBytes(t *testing.T) {
+	n := 768000
+	data := make([]byte, n)
+	// yEnc escapes a byte b when (b+42)&0xff is one of 0x00,0x0A,0x0D,0x3D.
+	// Pick source bytes that hit those so escapes are dense.
+	crit := []byte{byte((0x00 - 42) & 0xff), byte((0x0A - 42) & 0xff), byte((0x0D - 42) & 0xff), byte((0x3D - 42) & 0xff), 0xD6, 0xE0, 0xE3, 0x13}
+	for i := range data {
+		data[i] = crit[i%len(crit)]
+	}
+
+	body := encodeBareLFArticle(t, data, 1, 2, 0)
+	frame, err := DecodeToBytes(bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if len(frame.Data) != n {
+		t.Errorf("decoded %d bytes, want %d (delta %d)", len(frame.Data), n, len(frame.Data)-n)
+	}
+	if !bytes.Equal(frame.Data, data) {
+		t.Errorf("decoded data differs from original")
+	}
+}
+
+// TestDecodeWireDotReaderBareLF reproduces the full production fetch+decode path:
+// server wire bytes -> textproto.DotReader -> DecodeToBytes. It compares CRLF vs
+// bare-LF wire to isolate whether bare-LF line endings cause byte loss via the
+// dot-unstuffing layer.
+func TestDecodeWireDotReaderBareLF(t *testing.T) {
+	for _, bareLF := range []bool{false, true} {
+		// Force many lines to start with '.' (data byte 0x04 -> encoded '.').
+		n := 200000
+		rng := rand.New(rand.NewSource(99))
+		data := make([]byte, n)
+		rng.Read(data)
+		for i := 0; i < n; i += 100 {
+			data[i] = 0x04
+		}
+
+		wire := buildWire(t, data, bareLF)
+		frame, err := decodeWire(t, wire)
+		if err != nil {
+			t.Fatalf("bareLF=%v decode error: %v", bareLF, err)
+		}
+		if len(frame.Data) != n {
+			t.Errorf("bareLF=%v: decoded %d bytes, want %d (delta %d)", bareLF, len(frame.Data), n, len(frame.Data)-n)
+		} else if !bytes.Equal(frame.Data, data) {
+			t.Errorf("bareLF=%v: decoded data differs from original", bareLF)
+		}
+	}
+}
+
+// TestDecodeWireMissingDotStuffing reproduces a non-compliant server that does
+// NOT dot-stuff: yEnc lines that genuinely begin with '.' (data byte 0x04) are
+// delivered with a single dot, and textproto.DotReader strips it as if it were
+// stuffing, silently dropping one real byte per such line. This both loses bytes
+// (matching the observed shortfall direction) and is content-dependent.
+func TestDecodeWireMissingDotStuffing(t *testing.T) {
+	n := 200000
+	rng := rand.New(rand.NewSource(123))
+	data := make([]byte, n)
+	rng.Read(data)
+	for i := 0; i < n; i += 137 {
+		data[i] = 0x04 // encodes to '.'
+	}
+
+	wire := buildWireOpt(t, data, true /*bareLF*/, false /*stuff*/)
+	frame, err := decodeWire(t, wire)
+	if err != nil {
+		t.Logf("decode error (informative): %v", err)
+	}
+	t.Logf("missing-stuffing: decoded %d bytes, want %d (delta %d)", len(frame.Data), n, len(frame.Data)-n)
+	if len(frame.Data) == n {
+		t.Logf("no loss observed for this fixture")
+	}
+}
+
+// TestDecodeLineLeadingDotByteExact is the regression test for the double
+// dot-unstuffing bug: a yEnc data byte 0x04 encodes to '.', and when it lands at
+// the start of a line, rapidyenc (which expects raw, still-stuffed NNTP input)
+// would unstuff it after textproto.DotReader already did, dropping a real byte.
+// Using all-0x00 data (no escapes, exactly 128 cols/line) we deterministically
+// place a 0x04 at column 0 of line 2.
+func TestDecodeLineLeadingDotByteExact(t *testing.T) {
+	const lineLen = 128
+	// 0x04 encodes to '.'. Place it at the start of several wrapped lines so the
+	// double dot-unstuffing bug would drop those bytes.
+	data := make([]byte, 5*lineLen)
+	for i := lineLen; i < len(data); i += lineLen {
+		data[i] = 0x04
+	}
+	// Also exercise a line that starts with two data dots (0x04 0x04).
+	data[lineLen] = 0x04
+	data[lineLen+1] = 0x04
+
+	for _, bareLF := range []bool{false, true} {
+		wire := stuffAndTerminate(manualYencArticle(data, lineLen), bareLF)
+		frame, err := decodeWire(t, wire)
+		if err != nil {
+			t.Fatalf("bareLF=%v decode error: %v", bareLF, err)
+		}
+		if len(frame.Data) != len(data) {
+			t.Fatalf("bareLF=%v: decoded %d bytes, want %d", bareLF, len(frame.Data), len(data))
+		}
+		if !bytes.Equal(frame.Data, data) {
+			t.Fatalf("bareLF=%v: decoded bytes differ from original (line-leading dot dropped?)", bareLF)
+		}
+	}
+}
+
+// TestDecodeWireFragmentedReads reproduces network-style fragmented delivery:
+// the wire bytes are read in small chunks of varying size through the full
+// DotReader -> normalizeCRLF -> rapidyenc path.
+func TestDecodeWireFragmentedReads(t *testing.T) {
+	n := 200000
+	rng := rand.New(rand.NewSource(7))
+	data := make([]byte, n)
+	rng.Read(data)
+	for i := 0; i < n; i += 97 {
+		data[i] = 0x04 // encodes to '.' -> may land at line start
+	}
+
+	for _, bareLF := range []bool{false, true} {
+		wire := buildWire(t, data, bareLF)
+		for _, chunk := range []int{1, 2, 3, 7, 13, 64, 127, 128, 129, 1000} {
+			r := textproto.NewReader(bufio.NewReader(&fragmentReader{r: bytes.NewReader(wire), max: chunk}))
+			frame, err := DecodeToBytes(r.DotReader())
+			if err != nil {
+				t.Fatalf("bareLF=%v chunk=%d decode error: %v", bareLF, chunk, err)
+			}
+			if len(frame.Data) != n {
+				t.Errorf("bareLF=%v chunk=%d: decoded %d bytes, want %d (delta %d)", bareLF, chunk, len(frame.Data), n, len(frame.Data)-n)
+			} else if !bytes.Equal(frame.Data, data) {
+				t.Errorf("bareLF=%v chunk=%d: decoded data differs", bareLF, chunk)
+			}
+		}
+	}
+}

--- a/pkg/media/loader/file.go
+++ b/pkg/media/loader/file.go
@@ -84,6 +84,8 @@ type File struct {
 
 	zeroFillMu    sync.Mutex
 	zeroFillCount int
+
+	segmentDetectMu sync.Mutex
 }
 
 type inflightSegmentDownload struct {
@@ -180,23 +182,20 @@ func (f *File) EnsureSegmentMap() error {
 }
 
 func (f *File) EnsureSegmentMapCtx(ctx context.Context) error {
+	f.segmentDetectMu.Lock()
+	defer f.segmentDetectMu.Unlock()
+
 	f.mu.Lock()
 	if f.detected {
 		f.mu.Unlock()
 		return nil
 	}
 	f.mu.Unlock()
-	return f.detectSegmentSize(ctx)
+
+	return f.detectSegmentSizeLocked(ctx)
 }
 
-func (f *File) detectSegmentSize(ctx context.Context) error {
-	f.mu.Lock()
-	if f.detected {
-		f.mu.Unlock()
-		return nil
-	}
-	f.mu.Unlock()
-
+func (f *File) detectSegmentSizeLocked(ctx context.Context) error {
 	if ctx == nil {
 		ctx = f.ctx
 	}
@@ -207,6 +206,13 @@ func (f *File) detectSegmentSize(ctx context.Context) error {
 		return err
 	}
 
+	f.mu.Lock()
+	if f.detected {
+		f.mu.Unlock()
+		return nil
+	}
+	f.mu.Unlock()
+
 	if len(f.segments) == 0 {
 		f.mu.Lock()
 		f.totalSize = 0
@@ -215,41 +221,59 @@ func (f *File) detectSegmentSize(ctx context.Context) error {
 		return nil
 	}
 
-	firstEncoded := f.segments[0].Bytes
-	segSize := int64(0)
-	usedEstimator := false
+	knownByNZBBytes := make(map[int64]int64)
 	if f.estimator != nil {
-		if decoded, ok := f.estimator.Get(firstEncoded); ok {
-			segSize = decoded
-			usedEstimator = true
+		if decoded, ok := f.estimator.Get(f.segments[0].Bytes); ok {
+			knownByNZBBytes[f.segments[0].Bytes] = decoded
+			logger.Trace("Using estimated segment size", "name", f.Name(), "size", decoded)
 		}
 	}
 
-	if !usedEstimator {
-		data, err := f.DownloadSegment(ctx, 0)
-		if err != nil {
-			return err
-		}
-		if len(data) == 0 {
-			return errors.New("empty first segment")
-		}
-		segSize = int64(len(data))
+	includeMiddle := shouldProbeMiddleSegment(ctx, f.segments)
+	indices := segmentProbeIndices(f.segments, knownByNZBBytes, includeMiddle, unpack.IsSkipGapProbingEnabled(ctx))
+	logSegmentProbePlan(ctx, f.Name(), f.segments, indices, knownByNZBBytes, includeMiddle)
+
+	probedByIndex, err := f.probeSegmentIndicesParallel(ctx, indices)
+	if err != nil {
+		return err
 	}
 
-	lastSegSize := segSize
-	lastIdx := len(f.segments) - 1
-	if lastIdx > 0 {
-		if err := ctx.Err(); err != nil {
-			return err
+	if !unpack.IsSkipGapProbingEnabled(ctx) {
+		if missing := segmentUnprobedIndices(len(f.segments), indices); len(missing) > 0 {
+			logger.Debug("Segment map gap probe",
+				"name", f.Name(),
+				"indices", missing,
+				"count", len(missing))
+			gapProbed, gapErr := f.probeSegmentIndicesParallel(ctx, missing)
+			if gapErr != nil {
+				return gapErr
+			}
+			for idx, decoded := range gapProbed {
+				probedByIndex[idx] = decoded
+			}
 		}
-		data, err := f.DownloadSegment(ctx, lastIdx)
-		if err != nil {
-			return err
+	}
+
+	for idx, decoded := range probedByIndex {
+		if idx < 0 || idx >= len(f.segments) {
+			continue
 		}
-		if len(data) == 0 {
-			return errors.New("empty last segment")
+		logger.Debug("Detected segment size",
+			"name", f.Name(),
+			"index", idx,
+			"size", decoded,
+			"nzb_size", f.segments[idx].Bytes)
+		if idx == 0 && f.estimator != nil {
+			f.estimator.Set(f.segments[0].Bytes, decoded)
 		}
-		lastSegSize = int64(len(data))
+	}
+
+	sizes := buildSegmentDecodedSizesFromProbes(f.segments, probedByIndex, unpack.IsSkipGapProbingEnabled(ctx))
+	if includeMiddle {
+		mid := middleProbeIndex(len(f.segments))
+		if midDecoded, ok := probedByIndex[mid]; ok {
+			applyUniformMiddleCalibration(f.segments, sizes, mid, midDecoded)
+		}
 	}
 
 	f.mu.Lock()
@@ -257,38 +281,63 @@ func (f *File) detectSegmentSize(ctx context.Context) error {
 	if f.detected {
 		return nil
 	}
-	if usedEstimator {
-		logger.Trace("Using estimated segment size", "name", f.Name(), "size", segSize)
-	} else {
-		logger.Debug("Detected segment size", "name", f.Name(), "size", segSize, "nzb_size", f.segments[0].Bytes)
-		if f.estimator != nil {
-			f.estimator.Set(f.segments[0].Bytes, segSize)
-		}
-	}
-	if lastIdx > 0 {
-		logger.Debug("Detected last segment size", "name", f.Name(), "size", lastSegSize, "nzb_size", f.segments[lastIdx].Bytes)
-	}
-	f.applySegmentSize(segSize, lastSegSize)
+	f.totalSize = applySegmentDecodedSizes(f.segments, sizes)
+	f.detected = true
+	nzbSum := sumNZBSegmentBytes(f.segments)
+	logSegmentMapSizeCheck(f.Name(), f.segments, nzbSum, f.totalSize, probedByIndex)
+	logger.Debug("Recalculated total decoded size",
+		"name", f.Name(),
+		"size", f.totalSize,
+		"segments", len(f.segments),
+		"probed", len(probedByIndex))
 	return nil
 }
 
-func (f *File) applySegmentSize(segSize, lastSegSize int64) {
-	if lastSegSize <= 0 {
-		lastSegSize = segSize
+func logSegmentMapSizeCheck(name string, segments []*Segment, nzbSum, decodedSum int64, probedByIndex map[int]int64) {
+	attrs := []any{
+		"name", name,
+		"nzb_bytes_sum", nzbSum,
+		"decoded_sum", decodedSum,
+		"delta_decoded_minus_nzb", decodedSum - nzbSum,
+		"segments", len(segments),
 	}
-	var offset int64
-	for i := range f.segments {
-		f.segments[i].StartOffset = offset
-		currentSize := segSize
-		if i == len(f.segments)-1 {
-			currentSize = lastSegSize
+	if len(segments) > 0 && segments[0].Bytes > 0 {
+		if dec, ok := probedByIndex[0]; ok && dec > 0 {
+			attrs = append(attrs, "seg0_decode_ratio", float64(dec)/float64(segments[0].Bytes))
 		}
-		f.segments[i].EndOffset = offset + currentSize
-		offset += currentSize
 	}
-	f.totalSize = offset
-	f.detected = true
-	logger.Trace("Recalculated total decoded size", "size", f.totalSize)
+	if n := len(segments); n > 0 {
+		attrs = append(attrs, "last_nzb_bytes", segments[n-1].Bytes)
+		if dec, ok := probedByIndex[n-1]; ok {
+			attrs = append(attrs, "last_decoded", dec)
+		}
+	}
+	logger.Debug("Segment map size check", attrs...)
+}
+
+// SegmentOffsetRange returns decoded byte offsets for a segment index after map detection.
+func (f *File) SegmentOffsetRange(index int) (start, end int64, ok bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if index < 0 || index >= len(f.segments) {
+		return 0, 0, false
+	}
+	s := f.segments[index]
+	return s.StartOffset, s.EndOffset, true
+}
+
+// segmentDecodedLen returns the virtual decoded byte length for a segment index.
+func (f *File) segmentDecodedLen(idx int) int64 {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if idx < 0 || idx >= len(f.segments) {
+		return 0
+	}
+	s := f.segments[idx]
+	if f.detected {
+		return s.EndOffset - s.StartOffset
+	}
+	return s.Bytes
 }
 
 func (f *File) FindSegmentIndex(offset int64) int {
@@ -605,17 +654,35 @@ func (f *File) ReadAt(p []byte, off int64) (n int, err error) {
 	totalRead := 0
 	for i := startIdx; i < len(f.segments) && totalRead < len(p); i++ {
 		seg := f.segments[i]
+		segLen := f.segmentDecodedLen(i)
 		segOff := currentOffset - seg.StartOffset
+		if segOff >= segLen {
+			continue
+		}
 
 		data, err := f.DownloadSegment(f.ctx, i)
 		if err != nil {
 			return totalRead, err
 		}
-		if segOff >= int64(len(data)) {
+
+		remain := segLen - segOff
+		avail := int64(len(data)) - segOff
+		if avail < 0 {
+			avail = 0
+		}
+		toCopy := remain
+		if avail < toCopy {
+			toCopy = avail
+		}
+		bufRoom := int64(len(p) - totalRead)
+		if bufRoom < toCopy {
+			toCopy = bufRoom
+		}
+		if toCopy <= 0 {
 			continue
 		}
 
-		copied := copy(p[totalRead:], data[segOff:])
+		copied := copy(p[totalRead:], data[segOff:segOff+toCopy])
 		totalRead += copied
 		currentOffset += int64(copied)
 	}

--- a/pkg/media/loader/file.go
+++ b/pkg/media/loader/file.go
@@ -195,6 +195,44 @@ func (f *File) EnsureSegmentMapCtx(ctx context.Context) error {
 	return f.detectSegmentSizeLocked(ctx)
 }
 
+// PrimeUniformSegmentMapFromEstimator builds a segment map without NNTP probes when
+// every segment (including the last) shares the same NZB bytes and the estimator
+// already knows the decoded size from an earlier volume in the same release.
+func (f *File) PrimeUniformSegmentMapFromEstimator() bool {
+	if f == nil || len(f.segments) == 0 || f.estimator == nil {
+		return false
+	}
+	if !hasUniformNZBSegmentBytes(f.segments) {
+		return false
+	}
+	last := f.segments[len(f.segments)-1]
+	first := f.segments[0]
+	if last.Bytes != first.Bytes {
+		return false
+	}
+	decoded, ok := f.estimator.Get(first.Bytes)
+	if !ok || decoded <= 0 {
+		return false
+	}
+
+	knownByNZBBytes := map[int64]int64{first.Bytes: decoded}
+	sizes := buildSegmentDecodedSizesFromProbes(f.segments, nil, knownByNZBBytes, true)
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.detected {
+		return true
+	}
+	f.totalSize = applySegmentDecodedSizes(f.segments, sizes)
+	f.detected = true
+	logger.Trace("Primed uniform segment map from estimator",
+		"name", f.Name(),
+		"size", f.totalSize,
+		"segments", len(f.segments),
+		"decoded", decoded)
+	return true
+}
+
 func (f *File) detectSegmentSizeLocked(ctx context.Context) error {
 	if ctx == nil {
 		ctx = f.ctx
@@ -212,6 +250,10 @@ func (f *File) detectSegmentSizeLocked(ctx context.Context) error {
 		return nil
 	}
 	f.mu.Unlock()
+
+	if unpack.IsArchiveFastFailoverModeEnabled(ctx) && f.PrimeUniformSegmentMapFromEstimator() {
+		return nil
+	}
 
 	if len(f.segments) == 0 {
 		f.mu.Lock()
@@ -268,7 +310,7 @@ func (f *File) detectSegmentSizeLocked(ctx context.Context) error {
 		}
 	}
 
-	sizes := buildSegmentDecodedSizesFromProbes(f.segments, probedByIndex, unpack.IsSkipGapProbingEnabled(ctx))
+	sizes := buildSegmentDecodedSizesFromProbes(f.segments, probedByIndex, knownByNZBBytes, unpack.IsSkipGapProbingEnabled(ctx))
 	if includeMiddle {
 		mid := middleProbeIndex(len(f.segments))
 		if midDecoded, ok := probedByIndex[mid]; ok {
@@ -709,6 +751,34 @@ func (f *File) OpenReaderAt(ctx context.Context, offset int64) (io.ReadCloser, e
 		return nil, err
 	}
 	return NewSegmentReader(ctx, f, offset), nil
+}
+
+// OpenPlaybackReaderAt opens a reader with a larger read-ahead window for archive
+// playback seeks that cross RAR volume boundaries.
+func (f *File) OpenPlaybackReaderAt(ctx context.Context, offset int64) (io.ReadCloser, error) {
+	if err := f.EnsureSegmentMapCtx(ctx); err != nil {
+		return nil, err
+	}
+	return NewSegmentReaderWithReadAhead(ctx, f, offset, unpack.PlaybackReadAheadSegments), nil
+}
+
+// PrefetchPlaybackOffset warms the segment cache ahead of an upcoming volume switch.
+func (f *File) PrefetchPlaybackOffset(ctx context.Context, offset int64) {
+	if err := f.EnsureSegmentMapCtx(ctx); err != nil {
+		return
+	}
+	idx := f.FindSegmentIndex(offset)
+	if idx < 0 {
+		return
+	}
+	end := idx + unpack.PlaybackReadAheadSegments
+	if end > len(f.segments) {
+		end = len(f.segments)
+	}
+	bgCtx := context.WithoutCancel(ctx)
+	for i := idx; i < end; i++ {
+		f.ReadAheadSegment(bgCtx, i)
+	}
 }
 
 // MaxSegmentSizeEstimatorEntries caps the number of size entries to prevent unbounded growth.

--- a/pkg/media/loader/file_test.go
+++ b/pkg/media/loader/file_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"sort"
 	"sync"
 	"testing"
 	"time"
@@ -14,6 +15,7 @@ import (
 	"streamnzb/pkg/core/logger"
 	"streamnzb/pkg/media/decode"
 	"streamnzb/pkg/media/nzb"
+	"streamnzb/pkg/media/unpack"
 	"streamnzb/pkg/usenet/pool"
 )
 
@@ -430,8 +432,8 @@ func TestEnsureSegmentMapUsesActualLastSegmentSize(t *testing.T) {
 		t.Fatalf("expected last segment end offset %d, got %d", 21, got)
 	}
 	calls := fetcher.Calls()
-	if len(calls) != 2 || calls[0] != 1 || calls[1] != 3 {
-		t.Fatalf("expected first and last segment detection fetches, got %v", calls)
+	if !segmentProbeCallsMatch(calls, []int{1, 2, 3}) {
+		t.Fatalf("expected first, middle, and last segment probes, got %v", calls)
 	}
 	reader, err := f.OpenReaderAt(context.Background(), 16)
 	if err != nil {
@@ -445,6 +447,96 @@ func TestEnsureSegmentMapUsesActualLastSegmentSize(t *testing.T) {
 	if got := string(data); got != "ccccc" {
 		t.Fatalf("expected tail data %q, got %q", "ccccc", got)
 	}
+}
+
+func TestEnsureSegmentMapUsesPerSegmentNZBBytes(t *testing.T) {
+	oldLogger := logger.Log
+	logger.Log = slog.New(slog.NewTextHandler(io.Discard, nil))
+	defer func() {
+		logger.Log = oldLogger
+	}()
+
+	fetcher := &varyingSizeSegmentFetcher{sizes: []int64{8, 12, 5}}
+	f := NewFile(context.Background(), testNZBFileWithSegments(10, 15, 10), nil, nil, fetcher)
+
+	if err := f.EnsureSegmentMap(); err != nil {
+		t.Fatalf("EnsureSegmentMap returned error: %v", err)
+	}
+	if got := f.Size(); got != 25 {
+		t.Fatalf("expected decoded size %d, got %d", 25, got)
+	}
+	segs := f.Segments()
+	if got := segs[1].StartOffset; got != 8 {
+		t.Fatalf("expected second segment start offset %d, got %d", 8, got)
+	}
+	if got := segs[1].EndOffset; got != 20 {
+		t.Fatalf("expected second segment end offset %d, got %d", 20, got)
+	}
+	calls := fetcher.Calls()
+	if len(calls) != 3 {
+		t.Fatalf("expected three parallel probe fetches (distinct NZB bytes + last), got %v", calls)
+	}
+}
+
+func TestEnsureSegmentMapSlowModeCalibratesUniformNZB(t *testing.T) {
+	oldLogger := logger.Log
+	logger.Log = slog.New(slog.NewTextHandler(io.Discard, nil))
+	defer func() {
+		logger.Log = oldLogger
+	}()
+
+	fetcher := &varyingSizeSegmentFetcher{sizes: []int64{8, 10, 5}}
+	f := NewFile(context.Background(), testNZBFileWithSegments(10, 10, 10), nil, nil, fetcher)
+
+	if err := f.EnsureSegmentMap(); err != nil {
+		t.Fatalf("EnsureSegmentMap returned error: %v", err)
+	}
+	if got := f.Size(); got != 23 {
+		t.Fatalf("expected decoded size %d, got %d", 23, got)
+	}
+	calls := fetcher.Calls()
+	if !segmentProbeCallsMatch(calls, []int{1, 2, 3}) {
+		t.Fatalf("expected first, middle, and last segment probes, got %v", calls)
+	}
+}
+
+func TestEnsureSegmentMapFastModeGapProbesSkippedMiddle(t *testing.T) {
+	oldLogger := logger.Log
+	logger.Log = slog.New(slog.NewTextHandler(io.Discard, nil))
+	defer func() {
+		logger.Log = oldLogger
+	}()
+
+	fetcher := &varyingSizeSegmentFetcher{sizes: []int64{8, 10, 5}}
+	ctx := unpack.WithArchiveFastFailoverMode(context.Background(), true)
+	f := NewFile(ctx, testNZBFileWithSegments(10, 10, 10), nil, nil, fetcher)
+
+	if err := f.EnsureSegmentMapCtx(ctx); err != nil {
+		t.Fatalf("EnsureSegmentMapCtx returned error: %v", err)
+	}
+	if got := f.Size(); got != 23 {
+		t.Fatalf("expected decoded size %d after gap probe, got %d", 23, got)
+	}
+	calls := fetcher.Calls()
+	if !segmentProbeCallsMatch(calls, []int{1, 2, 3}) {
+		t.Fatalf("expected first, gap middle, and last probes in fast mode, got %v", calls)
+	}
+}
+
+func segmentProbeCallsMatch(calls []int, want []int) bool {
+	if len(calls) != len(want) {
+		return false
+	}
+	got := append([]int(nil), calls...)
+	sort.Ints(got)
+	expected := append([]int(nil), want...)
+	sort.Ints(expected)
+	for i := range expected {
+		if got[i] != expected[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func TestEnsureSegmentMapEstimatorStillUsesActualLastSegmentSize(t *testing.T) {
@@ -466,7 +558,31 @@ func TestEnsureSegmentMapEstimatorStillUsesActualLastSegmentSize(t *testing.T) {
 		t.Fatalf("expected decoded size %d, got %d", 21, got)
 	}
 	calls := fetcher.Calls()
-	if len(calls) != 1 || calls[0] != 3 {
-		t.Fatalf("expected estimator hit plus last-segment fetch, got %v", calls)
+	if !segmentProbeCallsMatch(calls, []int{1, 2, 3}) {
+		t.Fatalf("expected gap first, middle, and last segment probes with estimator, got %v", calls)
+	}
+}
+
+func TestEnsureSegmentMapWithSkipGapProbing(t *testing.T) {
+	oldLogger := logger.Log
+	logger.Log = slog.New(slog.NewTextHandler(io.Discard, nil))
+	defer func() {
+		logger.Log = oldLogger
+	}()
+
+	fetcher := &varyingSizeSegmentFetcher{sizes: []int64{8, 10, 5}}
+	ctx := unpack.WithArchiveFastFailoverMode(context.Background(), true)
+	ctx = unpack.WithSkipGapProbing(ctx, true)
+	f := NewFile(ctx, testNZBFileWithSegments(10, 10, 6), nil, nil, fetcher)
+
+	if err := f.EnsureSegmentMapCtx(ctx); err != nil {
+		t.Fatalf("EnsureSegmentMapCtx returned error: %v", err)
+	}
+	if got := f.Size(); got != 21 {
+		t.Fatalf("expected decoded size %d, got %d", 21, got)
+	}
+	calls := fetcher.Calls()
+	if !segmentProbeCallsMatch(calls, []int{1, 3}) {
+		t.Fatalf("expected only first and last segment probes, got %v", calls)
 	}
 }

--- a/pkg/media/loader/file_test.go
+++ b/pkg/media/loader/file_test.go
@@ -586,3 +586,27 @@ func TestEnsureSegmentMapWithSkipGapProbing(t *testing.T) {
 		t.Fatalf("expected only first and last segment probes, got %v", calls)
 	}
 }
+
+func TestPrimeUniformSegmentMapFromEstimatorSkipsNNTPProbes(t *testing.T) {
+	oldLogger := logger.Log
+	logger.Log = slog.New(slog.NewTextHandler(io.Discard, nil))
+	defer func() {
+		logger.Log = oldLogger
+	}()
+
+	estimator := NewSegmentSizeEstimator()
+	estimator.Set(768000, 768000)
+	fetcher := &varyingSizeSegmentFetcher{sizes: []int64{768000, 768000, 768000}}
+	ctx := unpack.WithArchiveFastFailoverMode(context.Background(), true)
+	f := NewFile(ctx, testNZBFileWithSegments(768000, 768000, 768000), nil, estimator, fetcher)
+
+	if err := f.EnsureSegmentMapCtx(ctx); err != nil {
+		t.Fatalf("EnsureSegmentMapCtx returned error: %v", err)
+	}
+	if got := f.Size(); got != 3*768000 {
+		t.Fatalf("expected decoded size %d, got %d", 3*768000, got)
+	}
+	if calls := fetcher.Calls(); len(calls) != 0 {
+		t.Fatalf("expected no NNTP probes for uniform primed volume, got %v", calls)
+	}
+}

--- a/pkg/media/loader/segment_reader.go
+++ b/pkg/media/loader/segment_reader.go
@@ -57,7 +57,19 @@ func LiveSegmentReaderDetails() []string {
 	return details
 }
 
+func NewSegmentReaderWithReadAhead(parent context.Context, f *File, startOffset int64, readAhead int) *SegmentReader {
+	sr := newSegmentReader(parent, f, startOffset)
+	if readAhead > 0 {
+		sr.readAheadSize = readAhead
+	}
+	return sr
+}
+
 func NewSegmentReader(parent context.Context, f *File, startOffset int64) *SegmentReader {
+	return newSegmentReader(parent, f, startOffset)
+}
+
+func newSegmentReader(parent context.Context, f *File, startOffset int64) *SegmentReader {
 	if parent == nil {
 		parent = context.Background()
 	}

--- a/pkg/media/loader/segment_reader.go
+++ b/pkg/media/loader/segment_reader.go
@@ -116,12 +116,35 @@ func (r *SegmentReader) traceDetail() string {
 }
 
 func (r *SegmentReader) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+
+	total := 0
+	for total < len(p) {
+		n, err := r.readInto(p[total:])
+		total += n
+		if err != nil {
+			if err == io.EOF && total > 0 {
+				return total, nil
+			}
+			if total > 0 && err != io.EOF {
+				return total, err
+			}
+			return total, err
+		}
+	}
+	return total, nil
+}
+
+func (r *SegmentReader) readInto(p []byte) (int, error) {
 	r.mu.Lock()
 	if r.closed {
 		r.mu.Unlock()
 		return 0, io.ErrClosedPipe
 	}
-	if r.segIdx >= len(r.file.segments) {
+	if r.segIdx >= len(r.file.segments) || r.offset >= r.file.Size() {
+		r.logEOFBeforeVirtualSize()
 		r.mu.Unlock()
 		return 0, io.EOF
 	}
@@ -129,29 +152,50 @@ func (r *SegmentReader) Read(p []byte) (int, error) {
 	segOff := r.segOff
 	r.mu.Unlock()
 
+	decodedLen := r.file.segmentDecodedLen(segIdx)
+	if segOff >= decodedLen {
+		r.mu.Lock()
+		r.segIdx++
+		r.segOff = 0
+		r.mu.Unlock()
+		return r.readInto(p)
+	}
+
 	data, err := r.file.DownloadSegment(r.ctx, segIdx)
 	if err != nil {
 		return 0, err
 	}
 
-	if segOff >= int64(len(data)) {
+	remain := decodedLen - segOff
+	avail := int64(len(data)) - segOff
+	if avail < 0 {
+		avail = 0
+	}
+	toCopy := int64(len(p))
+	if remain < toCopy {
+		toCopy = remain
+	}
+	if avail < toCopy {
+		toCopy = avail
+	}
+	if toCopy <= 0 {
+		if remain > 0 && avail == 0 {
+			return 0, fmt.Errorf("segment %d data shorter than mapped size (have %d decoded %d at off %d)",
+				segIdx, len(data), decodedLen, segOff)
+		}
 		r.mu.Lock()
 		r.segIdx++
 		r.segOff = 0
-		nextSegIdx := r.segIdx
 		r.mu.Unlock()
-		if nextSegIdx >= len(r.file.segments) {
-			return 0, io.EOF
-		}
-		return r.Read(p)
+		return r.readInto(p)
 	}
 
-	n := copy(p, data[segOff:])
+	n := copy(p, data[segOff:segOff+toCopy])
 
 	r.mu.Lock()
 	r.segOff += int64(n)
 	r.offset += int64(n)
-	if r.segOff >= int64(len(data)) {
+	if r.segOff >= decodedLen {
 		r.segIdx++
 		r.segOff = 0
 	}
@@ -161,6 +205,18 @@ func (r *SegmentReader) Read(p []byte) (int, error) {
 	r.triggerReadAhead(currentSeg)
 
 	return n, nil
+}
+
+func (r *SegmentReader) logEOFBeforeVirtualSize() {
+	if r.file == nil || r.offset >= r.file.Size() {
+		return
+	}
+	logger.Debug("SegmentReader EOF before virtual size",
+		"file", r.file.Name(),
+		"offset", r.offset,
+		"virtual_size", r.file.Size(),
+		"seg_idx", r.segIdx,
+		"seg_off", r.segOff)
 }
 
 // triggerReadAhead fires off background downloads for the next readAheadSize

--- a/pkg/media/loader/segment_reader_test.go
+++ b/pkg/media/loader/segment_reader_test.go
@@ -96,6 +96,37 @@ func TestSegmentReaderSeekIsNonBlocking(t *testing.T) {
 	}
 }
 
+func TestSegmentReaderDoesNotAdvanceBeforeMappedEnd(t *testing.T) {
+	oldLogger := logger.Log
+	logger.Log = slog.New(slog.NewTextHandler(io.Discard, nil))
+	defer func() {
+		logger.Log = oldLogger
+	}()
+
+	fetcher := &fixedLenSegmentFetcher{length: 8}
+	f := NewFile(context.Background(), testNZBFileWithSegments(10, 10), nil, nil, fetcher)
+	f.mu.Lock()
+	f.detected = true
+	f.segments[0].StartOffset = 0
+	f.segments[0].EndOffset = 10
+	f.segments[1].StartOffset = 10
+	f.segments[1].EndOffset = 16
+	f.totalSize = 16
+	f.mu.Unlock()
+
+	r := NewSegmentReader(context.Background(), f, 0)
+	defer func() { _ = r.Close() }()
+
+	buf := make([]byte, 16)
+	n, err := r.Read(buf)
+	if n != 8 {
+		t.Fatalf("expected first read of 8 bytes, got %d", n)
+	}
+	if err == nil {
+		t.Fatal("expected short-segment error on second segment, got nil")
+	}
+}
+
 func TestSegmentReaderSeekDoesNotCancelInFlightForegroundRead(t *testing.T) {
 	oldLogger := logger.Log
 	logger.Log = slog.New(slog.NewTextHandler(io.Discard, nil))
@@ -201,6 +232,14 @@ func waitForInflightWaiters(t *testing.T, f *File, index, want int) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatalf("timed out waiting for inflight segment %d to reach %d waiters", index, want)
+}
+
+type fixedLenSegmentFetcher struct {
+	length int64
+}
+
+func (f *fixedLenSegmentFetcher) FetchSegment(ctx context.Context, segment *nzb.Segment, groups []string) (pool.SegmentData, error) {
+	return pool.SegmentData{Body: bytesForSegment(segment.Number, f.length), Size: f.length}, nil
 }
 
 type staticSegmentFetcher struct{}

--- a/pkg/media/loader/segment_size.go
+++ b/pkg/media/loader/segment_size.go
@@ -178,7 +178,7 @@ func segmentUnprobedIndices(segmentCount int, probedIndices []int) []int {
 	return missing
 }
 
-func buildSegmentDecodedSizesFromProbes(segments []*Segment, probedByIndex map[int]int64, skipGapProbing bool) []int64 {
+func buildSegmentDecodedSizesFromProbes(segments []*Segment, probedByIndex map[int]int64, knownByNZBBytes map[int64]int64, skipGapProbing bool) []int64 {
 	n := len(segments)
 	sizes := make([]int64, n)
 	if n == 0 {
@@ -189,7 +189,22 @@ func buildSegmentDecodedSizesFromProbes(segments []*Segment, probedByIndex map[i
 	if firstEncoded <= 0 {
 		firstEncoded = 1
 	}
+
+	decodedByBytes := make(map[int64]int64)
+	for sz, dec := range knownByNZBBytes {
+		decodedByBytes[sz] = dec
+	}
+	for idx, dec := range probedByIndex {
+		if idx < 0 || idx >= n || dec <= 0 {
+			continue
+		}
+		decodedByBytes[segments[idx].Bytes] = dec
+	}
+
 	firstDecoded := probedByIndex[0]
+	if firstDecoded <= 0 {
+		firstDecoded = decodedByBytes[firstEncoded]
+	}
 	if firstDecoded <= 0 {
 		for _, dec := range probedByIndex {
 			if dec > 0 {
@@ -197,14 +212,6 @@ func buildSegmentDecodedSizesFromProbes(segments []*Segment, probedByIndex map[i
 				break
 			}
 		}
-	}
-
-	decodedByBytes := make(map[int64]int64)
-	for idx, dec := range probedByIndex {
-		if idx < 0 || idx >= n || dec <= 0 {
-			continue
-		}
-		decodedByBytes[segments[idx].Bytes] = dec
 	}
 
 	findNearbyProbedDecoded := func(nzbBytes int64) (int64, bool) {

--- a/pkg/media/loader/segment_size.go
+++ b/pkg/media/loader/segment_size.go
@@ -1,0 +1,373 @@
+package loader
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"sync"
+
+	"streamnzb/pkg/core/logger"
+	"streamnzb/pkg/media/unpack"
+)
+
+const (
+	segmentSizeSlop              = 256
+	maxSegmentProbeConcurrency     = 16
+)
+
+func sumNZBSegmentBytes(segments []*Segment) int64 {
+	var sum int64
+	for _, seg := range segments {
+		sum += seg.Bytes
+	}
+	return sum
+}
+
+func scaleDecodedSize(nzbBytes, firstEncoded, firstDecoded int64) int64 {
+	if nzbBytes <= 0 {
+		return firstDecoded
+	}
+	if firstEncoded <= 0 || firstDecoded <= 0 {
+		return nzbBytes
+	}
+	return (nzbBytes * firstDecoded) / firstEncoded
+}
+
+func hasUniformNZBSegmentBytes(segments []*Segment) bool {
+	if len(segments) <= 1 {
+		return true
+	}
+	first := segments[0].Bytes
+	for i := 1; i < len(segments)-1; i++ {
+		if segments[i].Bytes != first {
+			return false
+		}
+	}
+	return true
+}
+
+func middleProbeIndex(segmentCount int) int {
+	if segmentCount <= 2 {
+		return 0
+	}
+	return segmentCount / 2
+}
+
+func shouldProbeMiddleSegment(ctx context.Context, segments []*Segment) bool {
+	if len(segments) <= 2 {
+		return false
+	}
+	if unpack.IsArchiveFastFailoverModeEnabled(ctx) {
+		return false
+	}
+	return hasUniformNZBSegmentBytes(segments)
+}
+
+// segmentProbeIndices returns segment indices to BODY-probe in parallel.
+// We probe the first occurrence of each distinct NZB bytes value (unless already
+// known from the estimator), always probe the physical last segment (tail size
+// often differs while NZB bytes match an earlier article), and optionally probe
+// the middle segment when uniform NZB bytes need slow-mode calibration.
+func segmentProbeIndices(segments []*Segment, knownByNZBBytes map[int64]int64, includeMiddle bool, skipGapProbing bool) []int {
+	if len(segments) == 0 {
+		return nil
+	}
+
+	lastIdx := len(segments) - 1
+	seen := make(map[int]bool)
+	var indices []int
+
+	add := func(i int) {
+		if i < 0 || i >= len(segments) || seen[i] {
+			return
+		}
+		seen[i] = true
+		indices = append(indices, i)
+	}
+
+	firstIndexByBytes := make(map[int64]int)
+	for i, seg := range segments {
+		if _, ok := firstIndexByBytes[seg.Bytes]; !ok {
+			firstIndexByBytes[seg.Bytes] = i
+		}
+	}
+
+	if skipGapProbing {
+		var uniqueSizes []int64
+		for sz := range firstIndexByBytes {
+			uniqueSizes = append(uniqueSizes, sz)
+		}
+		sort.Slice(uniqueSizes, func(i, j int) bool { return uniqueSizes[i] < uniqueSizes[j] })
+
+		var representatives []int64
+		for _, sz := range uniqueSizes {
+			matched := false
+			for _, rep := range representatives {
+				diff := sz - rep
+				if diff < 0 {
+					diff = -diff
+				}
+				if diff*10 < rep {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				representatives = append(representatives, sz)
+			}
+		}
+
+		for _, repSz := range representatives {
+			idx := firstIndexByBytes[repSz]
+			if _, known := knownByNZBBytes[repSz]; known {
+				continue
+			}
+			knownNearby := false
+			for knownSz := range knownByNZBBytes {
+				diff := repSz - knownSz
+				if diff < 0 {
+					diff = -diff
+				}
+				if diff*10 < knownSz {
+					knownNearby = true
+					break
+				}
+			}
+			if knownNearby {
+				continue
+			}
+			add(idx)
+		}
+	} else {
+		for nbytes, idx := range firstIndexByBytes {
+			if _, known := knownByNZBBytes[nbytes]; known {
+				continue
+			}
+			add(idx)
+		}
+	}
+
+	if lastIdx > 0 {
+		add(lastIdx)
+	}
+
+	if includeMiddle {
+		add(middleProbeIndex(len(segments)))
+	}
+
+	sort.Ints(indices)
+	return indices
+}
+
+// segmentUnprobedIndices returns segment indices not covered by the initial probe plan.
+// Same NZB bytes can decode to different lengths; a second pass probes these gaps only.
+func segmentUnprobedIndices(segmentCount int, probedIndices []int) []int {
+	if segmentCount <= 0 {
+		return nil
+	}
+	seen := make(map[int]bool, len(probedIndices))
+	for _, i := range probedIndices {
+		seen[i] = true
+	}
+	var missing []int
+	for i := 0; i < segmentCount; i++ {
+		if !seen[i] {
+			missing = append(missing, i)
+		}
+	}
+	return missing
+}
+
+func buildSegmentDecodedSizesFromProbes(segments []*Segment, probedByIndex map[int]int64, skipGapProbing bool) []int64 {
+	n := len(segments)
+	sizes := make([]int64, n)
+	if n == 0 {
+		return sizes
+	}
+
+	firstEncoded := segments[0].Bytes
+	if firstEncoded <= 0 {
+		firstEncoded = 1
+	}
+	firstDecoded := probedByIndex[0]
+	if firstDecoded <= 0 {
+		for _, dec := range probedByIndex {
+			if dec > 0 {
+				firstDecoded = dec
+				break
+			}
+		}
+	}
+
+	decodedByBytes := make(map[int64]int64)
+	for idx, dec := range probedByIndex {
+		if idx < 0 || idx >= n || dec <= 0 {
+			continue
+		}
+		decodedByBytes[segments[idx].Bytes] = dec
+	}
+
+	findNearbyProbedDecoded := func(nzbBytes int64) (int64, bool) {
+		for probedNzb, dec := range decodedByBytes {
+			diff := nzbBytes - probedNzb
+			if diff < 0 {
+				diff = -diff
+			}
+			if diff*10 < probedNzb {
+				return dec, true
+			}
+		}
+		return 0, false
+	}
+
+	for i := 0; i < n; i++ {
+		if dec, ok := probedByIndex[i]; ok && dec > 0 {
+			sizes[i] = dec
+			continue
+		}
+		if dec, ok := decodedByBytes[segments[i].Bytes]; ok {
+			sizes[i] = dec
+			continue
+		}
+		if skipGapProbing {
+			if dec, ok := findNearbyProbedDecoded(segments[i].Bytes); ok {
+				sizes[i] = dec
+				continue
+			}
+		}
+		sizes[i] = scaleDecodedSize(segments[i].Bytes, firstEncoded, firstDecoded)
+	}
+	return sizes
+}
+
+func applyUniformMiddleCalibration(segments []*Segment, sizes []int64, middleIdx int, middleDecoded int64) {
+	n := len(segments)
+	if n <= 2 || middleIdx <= 0 || middleIdx >= n-1 {
+		return
+	}
+	if !hasUniformNZBSegmentBytes(segments) {
+		return
+	}
+
+	firstEncoded := segments[0].Bytes
+	if firstEncoded <= 0 {
+		return
+	}
+	firstDecoded := sizes[0]
+	scaledMid := scaleDecodedSize(segments[middleIdx].Bytes, firstEncoded, firstDecoded)
+	diff := middleDecoded - scaledMid
+	if diff < 0 {
+		diff = -diff
+	}
+	if diff <= segmentSizeSlop {
+		sizes[middleIdx] = middleDecoded
+		return
+	}
+
+	ratio1 := float64(firstDecoded) / float64(firstEncoded)
+	ratio2 := float64(middleDecoded) / float64(segments[middleIdx].Bytes)
+	if segments[middleIdx].Bytes <= 0 {
+		ratio2 = ratio1
+	}
+	for i := 0; i < middleIdx; i++ {
+		sizes[i] = int64(float64(segments[i].Bytes) * ratio1)
+	}
+	sizes[middleIdx] = middleDecoded
+	for i := middleIdx + 1; i < n-1; i++ {
+		sizes[i] = int64(float64(segments[i].Bytes) * ratio2)
+	}
+}
+
+func applySegmentDecodedSizes(segments []*Segment, sizes []int64) int64 {
+	var offset int64
+	for i := range segments {
+		size := sizes[i]
+		if size < 0 {
+			size = 0
+		}
+		segments[i].StartOffset = offset
+		segments[i].EndOffset = offset + size
+		offset += size
+	}
+	return offset
+}
+
+func (f *File) probeSegmentIndicesParallel(ctx context.Context, indices []int) (map[int]int64, error) {
+	probed := make(map[int]int64, len(indices))
+	if len(indices) == 0 {
+		return probed, nil
+	}
+
+	var (
+		mu       sync.Mutex
+		wg       sync.WaitGroup
+		firstErr error
+		sem      = make(chan struct{}, maxSegmentProbeConcurrency)
+	)
+
+	for _, idx := range indices {
+		idx := idx
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			if err := ctx.Err(); err != nil {
+				mu.Lock()
+				if firstErr == nil {
+					firstErr = err
+				}
+				mu.Unlock()
+				return
+			}
+
+			data, err := f.DownloadSegment(ctx, idx)
+			if err != nil {
+				mu.Lock()
+				if firstErr == nil {
+					firstErr = err
+				}
+				mu.Unlock()
+				return
+			}
+			if len(data) == 0 {
+				mu.Lock()
+				if firstErr == nil {
+					firstErr = errors.New("empty probe segment")
+				}
+				mu.Unlock()
+				return
+			}
+
+			mu.Lock()
+			probed[idx] = int64(len(data))
+			mu.Unlock()
+		}()
+	}
+	wg.Wait()
+	return probed, firstErr
+}
+
+func logSegmentProbePlan(ctx context.Context, name string, segments []*Segment, indices []int, knownByNZBBytes map[int64]int64, includeMiddle bool) {
+	unique := len(firstIndexByBytesMap(segments))
+	logger.Debug("Segment map probe plan",
+		"name", name,
+		"segments", len(segments),
+		"unique_nzb_bytes", unique,
+		"probe_indices", indices,
+		"known_from_estimator", len(knownByNZBBytes),
+		"uniform_nzb_bytes", hasUniformNZBSegmentBytes(segments),
+		"middle_calibration", includeMiddle,
+		"failover_fast_mode", unpack.IsArchiveFastFailoverModeEnabled(ctx))
+}
+
+func firstIndexByBytesMap(segments []*Segment) map[int64]int {
+	m := make(map[int64]int)
+	for i, seg := range segments {
+		if _, ok := m[seg.Bytes]; !ok {
+			m[seg.Bytes] = i
+		}
+	}
+	return m
+}

--- a/pkg/media/loader/segment_size_test.go
+++ b/pkg/media/loader/segment_size_test.go
@@ -1,0 +1,166 @@
+package loader
+
+import (
+	"context"
+	"testing"
+
+	"streamnzb/pkg/media/nzb"
+	"streamnzb/pkg/media/unpack"
+)
+
+func TestScaleDecodedSizeUsesPerSegmentNZBBytes(t *testing.T) {
+	got := scaleDecodedSize(15, 10, 8)
+	if got != 12 {
+		t.Fatalf("scaleDecodedSize(15,10,8) = %d, want 12", got)
+	}
+}
+
+func TestSegmentProbeIndicesDistinctNZBBytesAndLast(t *testing.T) {
+	segments := []*Segment{
+		{Segment: nzbSegment(10)},
+		{Segment: nzbSegment(15)},
+		{Segment: nzbSegment(10)},
+	}
+	got := segmentProbeIndices(segments, nil, false, false)
+	want := []int{0, 1, 2}
+	if len(got) != len(want) {
+		t.Fatalf("probe indices = %v, want %v", got, want)
+	}
+	for i, idx := range want {
+		if got[i] != idx {
+			t.Fatalf("probe indices = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestSegmentUnprobedIndices(t *testing.T) {
+	got := segmentUnprobedIndices(5, []int{0, 2, 4})
+	want := []int{1, 3}
+	if len(got) != len(want) {
+		t.Fatalf("unprobed = %v, want %v", got, want)
+	}
+	for i, idx := range want {
+		if got[i] != idx {
+			t.Fatalf("unprobed = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestSegmentProbeIndicesSkipsKnownEstimatorBytes(t *testing.T) {
+	segments := []*Segment{
+		{Segment: nzbSegment(10)},
+		{Segment: nzbSegment(10)},
+		{Segment: nzbSegment(10)},
+	}
+	known := map[int64]int64{10: 8}
+	got := segmentProbeIndices(segments, known, true, false)
+	want := []int{1, 2}
+	if len(got) != len(want) {
+		t.Fatalf("probe indices = %v, want %v", got, want)
+	}
+	for i, idx := range want {
+		if got[i] != idx {
+			t.Fatalf("probe indices = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestBuildSegmentDecodedSizesFromProbesVariableNZBBytes(t *testing.T) {
+	segments := []*Segment{
+		{Segment: nzbSegment(10)},
+		{Segment: nzbSegment(15)},
+		{Segment: nzbSegment(10)},
+	}
+	probed := map[int]int64{0: 8, 1: 12, 2: 5}
+	sizes := buildSegmentDecodedSizesFromProbes(segments, probed, false)
+	want := []int64{8, 12, 5}
+	for i, w := range want {
+		if sizes[i] != w {
+			t.Fatalf("sizes[%d] = %d, want %d (full=%v)", i, sizes[i], w, sizes)
+		}
+	}
+}
+
+func TestApplyUniformMiddleCalibration(t *testing.T) {
+	segments := []*Segment{
+		{Segment: nzbSegment(10)},
+		{Segment: nzbSegment(10)},
+		{Segment: nzbSegment(10)},
+	}
+	sizes := []int64{8, 8, 5}
+	applyUniformMiddleCalibration(segments, sizes, 1, 10)
+	want := []int64{8, 10, 5}
+	for i, w := range want {
+		if sizes[i] != w {
+			t.Fatalf("sizes[%d] = %d, want %d (full=%v)", i, sizes[i], w, sizes)
+		}
+	}
+}
+
+func TestShouldProbeMiddleSegmentRespectsFastMode(t *testing.T) {
+	segments := []*Segment{
+		{Segment: nzbSegment(10)},
+		{Segment: nzbSegment(10)},
+		{Segment: nzbSegment(10)},
+	}
+	if !shouldProbeMiddleSegment(context.Background(), segments) {
+		t.Fatal("expected middle probe when fast mode disabled")
+	}
+	fast := unpack.WithArchiveFastFailoverMode(context.Background(), true)
+	if shouldProbeMiddleSegment(fast, segments) {
+		t.Fatal("expected no middle probe in fast failover mode")
+	}
+}
+
+func TestShouldProbeMiddleSegmentSkipsVariableNZBBytes(t *testing.T) {
+	segments := []*Segment{
+		{Segment: nzbSegment(10)},
+		{Segment: nzbSegment(15)},
+		{Segment: nzbSegment(10)},
+	}
+	if shouldProbeMiddleSegment(context.Background(), segments) {
+		t.Fatal("expected no middle probe when NZB bytes already vary per segment")
+	}
+}
+
+func nzbSegment(bytes int64) nzb.Segment {
+	return nzb.Segment{Bytes: bytes, Number: 1}
+}
+
+func TestSegmentProbeIndicesGroupsSimilarSizesInSkipGapProbing(t *testing.T) {
+	segments := []*Segment{
+		{Segment: nzbSegment(792710)},
+		{Segment: nzbSegment(792818)},
+		{Segment: nzbSegment(792682)},
+		{Segment: nzbSegment(792562)},
+		{Segment: nzbSegment(792707)},
+		{Segment: nzbSegment(82924)},
+	}
+	got := segmentProbeIndices(segments, nil, false, true)
+	want := []int{3, 5}
+	if len(got) != len(want) {
+		t.Fatalf("probe indices = %v, want %v", got, want)
+	}
+	for i, idx := range want {
+		if got[i] != idx {
+			t.Fatalf("probe indices = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestBuildSegmentDecodedSizesFromProbesGroupsSimilarSizesInSkipGapProbing(t *testing.T) {
+	segments := []*Segment{
+		{Segment: nzbSegment(792710)},
+		{Segment: nzbSegment(792818)},
+		{Segment: nzbSegment(792682)},
+		{Segment: nzbSegment(82924)},
+	}
+	probed := map[int]int64{0: 768000, 3: 80000}
+	sizes := buildSegmentDecodedSizesFromProbes(segments, probed, true)
+	want := []int64{768000, 768000, 768000, 80000}
+	for i, w := range want {
+		if sizes[i] != w {
+			t.Fatalf("sizes[%d] = %d, want %d (full=%v)", i, sizes[i], w, sizes)
+		}
+	}
+}

--- a/pkg/media/loader/segment_size_test.go
+++ b/pkg/media/loader/segment_size_test.go
@@ -72,7 +72,7 @@ func TestBuildSegmentDecodedSizesFromProbesVariableNZBBytes(t *testing.T) {
 		{Segment: nzbSegment(10)},
 	}
 	probed := map[int]int64{0: 8, 1: 12, 2: 5}
-	sizes := buildSegmentDecodedSizesFromProbes(segments, probed, false)
+	sizes := buildSegmentDecodedSizesFromProbes(segments, probed, nil, false)
 	want := []int64{8, 12, 5}
 	for i, w := range want {
 		if sizes[i] != w {
@@ -156,7 +156,7 @@ func TestBuildSegmentDecodedSizesFromProbesGroupsSimilarSizesInSkipGapProbing(t 
 		{Segment: nzbSegment(82924)},
 	}
 	probed := map[int]int64{0: 768000, 3: 80000}
-	sizes := buildSegmentDecodedSizesFromProbes(segments, probed, true)
+	sizes := buildSegmentDecodedSizesFromProbes(segments, probed, nil, true)
 	want := []int64{768000, 768000, 768000, 80000}
 	for i, w := range want {
 		if sizes[i] != w {
@@ -164,3 +164,21 @@ func TestBuildSegmentDecodedSizesFromProbesGroupsSimilarSizesInSkipGapProbing(t 
 		}
 	}
 }
+
+func TestBuildSegmentDecodedSizesFromProbesPreservesEstimator(t *testing.T) {
+	segments := []*Segment{
+		{Segment: nzbSegment(768000)},
+		{Segment: nzbSegment(768000)},
+		{Segment: nzbSegment(366792)},
+	}
+	probed := map[int]int64{2: 350762}
+	known := map[int64]int64{768000: 768000}
+	sizes := buildSegmentDecodedSizesFromProbes(segments, probed, known, true)
+	want := []int64{768000, 768000, 350762}
+	for i, w := range want {
+		if sizes[i] != w {
+			t.Fatalf("sizes[%d] = %d, want %d (full=%v)", i, sizes[i], w, sizes)
+		}
+	}
+}
+

--- a/pkg/media/seek/seek.go
+++ b/pkg/media/seek/seek.go
@@ -1,143 +1,96 @@
-package seek
-
-import (
-	"bytes"
-	"fmt"
-	"io"
-	"strconv"
-	"strings"
-)
-
-const (
-	MaxBytesToRead = 2 * 1024 * 1024
-)
-
-type StreamStartInfo struct {
-	HeaderValid   bool
-	DurationSec   float64
-	DurationKnown bool
-}
-
-func InspectStreamStart(stream io.ReadSeeker, size int64, filename string, maxBytes int) (StreamStartInfo, error) {
-	var info StreamStartInfo
-	if size <= 0 {
-		return info, fmt.Errorf("invalid size %d", size)
-	}
-	if maxBytes <= 0 {
-		maxBytes = MaxBytesToRead
-	}
-
-	readSize := maxBytes
-	if size < int64(readSize) {
-		readSize = int(size)
-	}
-	buf := make([]byte, readSize)
-	n, err := io.ReadFull(stream, buf)
-	if err != nil && err != io.ErrUnexpectedEOF {
-		return info, err
-	}
-	buf = buf[:n]
-
-	if _, err := stream.Seek(0, io.SeekStart); err != nil {
-		return info, err
-	}
-
-	info.HeaderValid = ValidateContainerHeader(buf, filename)
-	switch formatFromFilename(filename) {
-	case "mp4":
-		info.DurationSec, info.DurationKnown = durationFromMP4(buf)
-	case "mkv":
-		info.DurationSec, info.DurationKnown = durationFromMKV(buf)
-	}
-
-	return info, nil
-}
-
-func TimeToByteOffset(stream io.ReadSeeker, size int64, filename string, tSeconds float64) (offset int64, ok bool) {
-	if size <= 0 || tSeconds < 0 {
-		return 0, false
-	}
-	info, err := InspectStreamStart(stream, size, filename, MaxBytesToRead)
-	if err != nil || !info.DurationKnown {
-		return 0, false
-	}
-	return TimeToByteOffsetFromDuration(size, info.DurationSec, tSeconds)
-	}
-
-func TimeToByteOffsetFromDuration(size int64, durationSec, tSeconds float64) (offset int64, ok bool) {
-	if size <= 0 || durationSec <= 0 || tSeconds < 0 {
-		return 0, false
-	}
-	if tSeconds >= durationSec {
-
-		if size > 1 {
-			return size - 1, true
-		}
-		return 0, true
-	}
-
-	offset = int64((tSeconds / durationSec) * float64(size))
-	if offset < 0 {
-		offset = 0
-	}
-	if offset >= size {
-		offset = size - 1
-	}
-	return offset, true
-}
-
-func formatFromFilename(filename string) string {
-	lower := strings.ToLower(filename)
-	switch {
-	case strings.HasSuffix(lower, ".mp4"), strings.HasSuffix(lower, ".m4v"), strings.HasSuffix(lower, ".mov"):
-		return "mp4"
-	case strings.HasSuffix(lower, ".mkv"), strings.HasSuffix(lower, ".webm"):
-		return "mkv"
-	default:
-		return ""
-	}
-}
-
-func ParseTSeconds(t string) (float64, bool) {
-	if t == "" {
-		return 0, false
-	}
-	f, err := strconv.ParseFloat(strings.TrimSpace(t), 64)
-	if err != nil {
-		return 0, false
-	}
-	if f < 0 {
-		return 0, false
-	}
-	return f, true
-}
-
-// EBML header ID (MKV/WebM) - first element in file.
-var ebmlHeaderID = []byte{0x1A, 0x45, 0xDF, 0xA3}
-
-// ftyp box type (MP4/MOV).
-var ftypBox = []byte{'f', 't', 'y', 'p'}
-
-// ValidateContainerHeader checks that data starts with valid container headers for the given filename.
-// Used by the play probe to ensure RAR/7z/direct streams have readable, valid headers before serving.
-func ValidateContainerHeader(data []byte, filename string) bool {
-	if len(data) < 8 {
-		return false
-	}
-	switch formatFromFilename(filename) {
-	case "mkv":
-		return len(data) >= 4 && bytes.HasPrefix(data, ebmlHeaderID)
-	case "mp4":
-		// MP4: optional 4-byte size (big-endian) then "ftyp", or "ftyp" at 0
-		if bytes.HasPrefix(data, ftypBox) {
-			return true
-		}
-		if len(data) >= 8 && bytes.Equal(data[4:8], ftypBox) {
-			return true
-		}
-		return false
-	default:
-		// AVI, etc.: no strict check; caller may use probe size only to trigger segment read
-		return true
-	}
-}
+package seek
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+)
+
+const (
+	MaxBytesToRead = 2 * 1024 * 1024
+)
+
+type StreamStartInfo struct {
+	HeaderValid   bool
+	DurationSec   float64
+	DurationKnown bool
+}
+
+func InspectStreamStart(stream io.ReadSeeker, size int64, filename string, maxBytes int) (StreamStartInfo, error) {
+	var info StreamStartInfo
+	if size <= 0 {
+		return info, fmt.Errorf("invalid size %d", size)
+	}
+	if maxBytes <= 0 {
+		maxBytes = MaxBytesToRead
+	}
+
+	readSize := maxBytes
+	if size < int64(readSize) {
+		readSize = int(size)
+	}
+	buf := make([]byte, readSize)
+	n, err := io.ReadFull(stream, buf)
+	if err != nil && err != io.ErrUnexpectedEOF {
+		return info, err
+	}
+	buf = buf[:n]
+
+	if _, err := stream.Seek(0, io.SeekStart); err != nil {
+		return info, err
+	}
+
+	info.HeaderValid = ValidateContainerHeader(buf, filename)
+	switch formatFromFilename(filename) {
+	case "mp4":
+		info.DurationSec, info.DurationKnown = durationFromMP4(buf)
+	case "mkv":
+		info.DurationSec, info.DurationKnown = durationFromMKV(buf)
+	}
+
+	return info, nil
+}
+
+func formatFromFilename(filename string) string {
+	lower := strings.ToLower(filename)
+	switch {
+	case strings.HasSuffix(lower, ".mp4"), strings.HasSuffix(lower, ".m4v"), strings.HasSuffix(lower, ".mov"):
+		return "mp4"
+	case strings.HasSuffix(lower, ".mkv"), strings.HasSuffix(lower, ".webm"):
+		return "mkv"
+	default:
+		return ""
+	}
+}
+
+// EBML header ID (MKV/WebM) - first element in file.
+var ebmlHeaderID = []byte{0x1A, 0x45, 0xDF, 0xA3}
+
+// ftyp box type (MP4/MOV).
+var ftypBox = []byte{'f', 't', 'y', 'p'}
+
+// ValidateContainerHeader checks that data starts with valid container headers for the given filename.
+// Used by the play probe to ensure RAR/7z/direct streams have readable, valid headers before serving.
+func ValidateContainerHeader(data []byte, filename string) bool {
+	if len(data) < 8 {
+		return false
+	}
+	switch formatFromFilename(filename) {
+	case "mkv":
+		return len(data) >= 4 && bytes.HasPrefix(data, ebmlHeaderID)
+	case "mp4":
+		// MP4: optional 4-byte size (big-endian) then "ftyp", or "ftyp" at 0
+		if bytes.HasPrefix(data, ftypBox) {
+			return true
+		}
+		if len(data) >= 8 && bytes.Equal(data[4:8], ftypBox) {
+			return true
+		}
+		return false
+	default:
+		// AVI, etc.: no strict check; caller may use probe size only to trigger segment read
+		return true
+	}
+}
+

--- a/pkg/media/seek/seek_test.go
+++ b/pkg/media/seek/seek_test.go
@@ -31,18 +31,6 @@ func TestInspectStreamStartParsesMP4AndResetsOffset(t *testing.T) {
 	}
 }
 
-func TestTimeToByteOffsetFromDuration(t *testing.T) {
-	if offset, ok := TimeToByteOffsetFromDuration(100, 20, 5); !ok || offset != 25 {
-		t.Fatalf("expected offset 25 with ok=true, got offset=%d ok=%t", offset, ok)
-	}
-	if offset, ok := TimeToByteOffsetFromDuration(100, 20, 25); !ok || offset != 99 {
-		t.Fatalf("expected end clamp to 99 with ok=true, got offset=%d ok=%t", offset, ok)
-	}
-	if _, ok := TimeToByteOffsetFromDuration(100, 0, 5); ok {
-		t.Fatal("expected zero duration to fail")
-	}
-}
-
 func makeTestMP4(timescale, duration uint32) []byte {
 	ftyp := make([]byte, 16)
 	binary.BigEndian.PutUint32(ftyp[0:4], uint32(len(ftyp)))

--- a/pkg/media/unpack/archive.go
+++ b/pkg/media/unpack/archive.go
@@ -104,6 +104,7 @@ func GetMediaStreamForEpisodeWithHints(ctx context.Context, files []UnpackableFi
 		"files", len(files),
 		"cached_type", fmt.Sprintf("%T", cachedBP))
 	rarScanCtx := WithArchiveFastFailoverMode(ctx, hints.FailoverFastMode)
+	rarScanCtx = WithSkipGapProbing(rarScanCtx, true)
 	if cachedBP != nil {
 		switch bp := cachedBP.(type) {
 		case *ArchiveBlueprint:
@@ -112,7 +113,7 @@ func GetMediaStreamForEpisodeWithHints(ctx context.Context, files []UnpackableFi
 				break
 			}
 			logger.Debug("Using cached RAR blueprint", "cached", bp.Target, "requested", target, "file", bp.MainFileName)
-			s, name, size, err := StreamFromBlueprint(ctx, bp, password)
+			s, name, size, err := StreamFromBlueprint(rarScanCtx, bp, password)
 			return s, name, size, bp, err
 		case *SevenZipBlueprint:
 			if !blueprintTargetMatches(bp.Target, target) {
@@ -135,7 +136,7 @@ func GetMediaStreamForEpisodeWithHints(ctx context.Context, files []UnpackableFi
 			}
 			if bp.FileIndex >= 0 && bp.FileIndex < len(files) {
 				f := files[bp.FileIndex]
-				stream, err := f.OpenStreamCtx(ctx)
+				stream, err := f.OpenStreamCtx(rarScanCtx)
 				if err != nil {
 					return nil, "", 0, nil, err
 				}
@@ -168,7 +169,7 @@ func GetMediaStreamForEpisodeWithHints(ctx context.Context, files []UnpackableFi
 			rarScanErr = err
 			logger.Warn("ScanArchive failed, falling back to other methods", "err", err)
 		} else {
-			s, name, size, err := StreamFromBlueprint(ctx, bp, password)
+			s, name, size, err := StreamFromBlueprint(rarScanCtx, bp, password)
 			if err != nil {
 				return nil, "", 0, nil, err
 			}
@@ -215,7 +216,7 @@ func GetMediaStreamForEpisodeWithHints(ctx context.Context, files []UnpackableFi
 	} else if directIdx >= 0 {
 		f := files[directIdx]
 		name := directFileDisplayName(files, directIdx, nameOverrides)
-		stream, err := f.OpenStreamCtx(ctx)
+		stream, err := f.OpenStreamCtx(rarScanCtx)
 		if err != nil {
 			return nil, "", 0, nil, err
 		}
@@ -223,7 +224,7 @@ func GetMediaStreamForEpisodeWithHints(ctx context.Context, files []UnpackableFi
 		return stream, name, f.Size(), &DirectBlueprint{FileName: name, FileIndex: directIdx, Target: target}, nil
 	}
 
-	if probedStream, probedName, probedSize, probedIdx, ok := probeDirectPlayableCandidates(ctx, files, nameOverrides); ok {
+	if probedStream, probedName, probedSize, probedIdx, ok := probeDirectPlayableCandidates(rarScanCtx, files, nameOverrides); ok {
 		logger.Debug("Selected direct playback file via content probe",
 			"target", target,
 			"name", probedName,
@@ -256,7 +257,7 @@ func GetMediaStreamForEpisodeWithHints(ctx context.Context, files []UnpackableFi
 			logger.Info("Attempting heuristic RAR scan on unknown files")
 			bp, err := ScanArchive(rarScanCtx, unpackables, password, target)
 			if err == nil {
-				s, name, size, err := StreamFromBlueprint(ctx, bp, password)
+				s, name, size, err := StreamFromBlueprint(rarScanCtx, bp, password)
 				if err == nil {
 					logger.Info("Heuristic scan found RAR archive")
 					return s, name, size, bp, nil
@@ -295,7 +296,7 @@ func GetMediaStreamForEpisodeWithHints(ctx context.Context, files []UnpackableFi
 				"size", largestFile.Size())
 			return nil, "", 0, &FailedBlueprint{Err: err, Target: target}, err
 		}
-		stream, err := largestFile.OpenStreamCtx(ctx)
+		stream, err := largestFile.OpenStreamCtx(rarScanCtx)
 		if err != nil {
 			return nil, "", 0, nil, err
 		}

--- a/pkg/media/unpack/archive.go
+++ b/pkg/media/unpack/archive.go
@@ -166,7 +166,7 @@ func GetMediaStreamForEpisodeWithHints(ctx context.Context, files []UnpackableFi
 				return nil, "", 0, &FailedBlueprint{Err: err, Target: target}, err
 			}
 			rarScanFailed = true
-			rarScanErr = err
+			rarScanErr = maybeMarkArchiveFastProbe(rarScanCtx, err)
 			logger.Warn("ScanArchive failed, falling back to other methods", "err", err)
 		} else {
 			s, name, size, err := StreamFromBlueprint(rarScanCtx, bp, password)

--- a/pkg/media/unpack/context.go
+++ b/pkg/media/unpack/context.go
@@ -7,12 +7,41 @@ import (
 )
 
 type archiveFastFailoverContextKey struct{}
+type archiveScanIOTraceContextKey struct{}
+type skipGapProbingContextKey struct{}
+
+func WithSkipGapProbing(ctx context.Context, enabled bool) context.Context {
+	if !enabled {
+		return ctx
+	}
+	return context.WithValue(ctx, skipGapProbingContextKey{}, true)
+}
+
+func IsSkipGapProbingEnabled(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	enabled, _ := ctx.Value(skipGapProbingContextKey{}).(bool)
+	return enabled
+}
 
 func WithArchiveFastFailoverMode(ctx context.Context, enabled bool) context.Context {
 	if !enabled {
 		return ctx
 	}
 	return context.WithValue(ctx, archiveFastFailoverContextKey{}, true)
+}
+
+func WithArchiveScanIOTrace(ctx context.Context) context.Context {
+	return context.WithValue(ctx, archiveScanIOTraceContextKey{}, true)
+}
+
+func IsArchiveScanIOTraceEnabled(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	enabled, _ := ctx.Value(archiveScanIOTraceContextKey{}).(bool)
+	return enabled
 }
 
 func IsArchiveFastFailoverModeEnabled(ctx context.Context) bool {

--- a/pkg/media/unpack/context.go
+++ b/pkg/media/unpack/context.go
@@ -52,6 +52,16 @@ func IsArchiveFastFailoverModeEnabled(ctx context.Context) bool {
 	return enabled
 }
 
+// playbackSegmentMapCtx returns a context for on-demand segment-map detection during
+// playback reads/seeks. It skips expensive gap probing and middle calibration that
+// are only needed for one-time archive sizing.
+func playbackSegmentMapCtx(ctx context.Context) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return WithArchiveFastFailoverMode(WithSkipGapProbing(ctx, true), true)
+}
+
 var ErrArchiveFastProbe = errors.New("archive fast probe incomplete")
 
 func markArchiveFastProbe(err error) error {

--- a/pkg/media/unpack/fs.go
+++ b/pkg/media/unpack/fs.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"io/fs"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 )
@@ -30,6 +31,27 @@ func (n *NZBFS) Open(name string) (fs.File, error) {
 	f, ok := n.files[name]
 	if !ok {
 		f, ok = n.files[filepath.Base(name)]
+	}
+	if !ok {
+		// Try volume-number matching for multi-volume archives to handle padded digits mismatches (e.g. part10 vs part010)
+		reqPrefix := archivePrefix(name)
+		if volNum := GetRARVolumeNumber(name); volNum >= 0 {
+			for k, file := range n.files {
+				if GetRARVolumeNumber(k) == volNum && archivePrefix(k) == reqPrefix {
+					f = file
+					ok = true
+					break
+				}
+			}
+		} else if volNum7z := Get7zVolumeNumber(name); volNum7z >= 0 {
+			for k, file := range n.files {
+				if Get7zVolumeNumber(k) == volNum7z && archivePrefix(k) == reqPrefix {
+					f = file
+					ok = true
+					break
+				}
+			}
+		}
 	}
 	if !ok {
 		return nil, fs.ErrNotExist
@@ -142,3 +164,26 @@ func (fi *fileInfo) Mode() fs.FileMode  { return 0444 }
 func (fi *fileInfo) ModTime() time.Time { return time.Time{} }
 func (fi *fileInfo) IsDir() bool        { return false }
 func (fi *fileInfo) Sys() interface{}   { return nil }
+
+func archivePrefix(filename string) string {
+	lower := strings.ToLower(ExtractFilename(filename))
+	if idx := strings.Index(lower, ".part"); idx >= 0 && strings.HasSuffix(lower, ".rar") {
+		return lower[:idx]
+	}
+	if len(lower) >= 4 && lower[len(lower)-4:len(lower)-2] == ".r" {
+		suffix := lower[len(lower)-2:]
+		if suffix[0] >= '0' && suffix[0] <= '9' && suffix[1] >= '0' && suffix[1] <= '9' {
+			return lower[:len(lower)-4]
+		}
+	}
+	if strings.HasSuffix(lower, ".rar") {
+		return lower[:len(lower)-4]
+	}
+	if idx := strings.LastIndex(lower, ".7z."); idx >= 0 {
+		return lower[:idx]
+	}
+	if strings.HasSuffix(lower, ".7z") {
+		return lower[:len(lower)-3]
+	}
+	return lower
+}

--- a/pkg/media/unpack/fs.go
+++ b/pkg/media/unpack/fs.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"io/fs"
 	"path/filepath"
+	"sync"
 	"time"
 )
 
@@ -39,13 +40,17 @@ func (n *NZBFS) Open(name string) (fs.File, error) {
 		return nil, fmt.Errorf("failed to open stream: %w", err)
 	}
 
-	return &fileWrapper{
+	fw := &fileWrapper{
 		ctx:    n.ctx,
 		stream: stream,
 		file:   f,
 		name:   ExtractFilename(f.Name()),
 		size:   f.Size(),
-	}, nil
+	}
+	if IsArchiveScanIOTraceEnabled(n.ctx) {
+		return wrapFileForScanTrace(fw), nil
+	}
+	return fw, nil
 }
 
 type fileWrapper struct {
@@ -54,14 +59,63 @@ type fileWrapper struct {
 	file   UnpackableFile
 	name   string
 	size   int64
+
+	readMu  sync.Mutex
+	readPos int64
 }
 
 func (fw *fileWrapper) Stat() (fs.FileInfo, error) {
 	return &fileInfo{name: fw.name, size: fw.size}, nil
 }
 
-func (fw *fileWrapper) Read(p []byte) (int, error)                { return fw.stream.Read(p) }
-func (fw *fileWrapper) Seek(off int64, whence int) (int64, error) { return fw.stream.Seek(off, whence) }
+// Read serves sequential archive parsers via ReadAt so virtual file offsets stay
+// aligned with the detected segment map (SegmentReader sequential reads can stop early).
+func (fw *fileWrapper) Read(p []byte) (int, error) {
+	fw.readMu.Lock()
+	off := fw.readPos
+	fw.readMu.Unlock()
+
+	n, err := fw.file.ReadAt(p, off)
+	if n > 0 {
+		fw.readMu.Lock()
+		fw.readPos += int64(n)
+		fw.readMu.Unlock()
+	}
+	return n, err
+}
+
+// Seek tracks readPos arithmetically to stay consistent with the ReadAt-based
+// Read path. It must NOT delegate to fw.stream: Read serves bytes via
+// fw.file.ReadAt(readPos) and never advances the stream, so the stream's own
+// position is stale. A relative (SeekCurrent) delegate — which is how archive
+// parsers discard data blocks — would then compute from the wrong base and
+// corrupt readPos, making the next read land at the wrong offset.
+//
+// We also must not clamp the target: callers such as rardecode set their own
+// internal offset to the requested value regardless of the returned position,
+// so clamping here would desync the next relative seek. Reads past EOF are
+// handled by ReadAt returning io.EOF.
+func (fw *fileWrapper) Seek(off int64, whence int) (int64, error) {
+	fw.readMu.Lock()
+	defer fw.readMu.Unlock()
+
+	var target int64
+	switch whence {
+	case io.SeekStart:
+		target = off
+	case io.SeekCurrent:
+		target = fw.readPos + off
+	case io.SeekEnd:
+		target = fw.size + off
+	default:
+		return fw.readPos, fmt.Errorf("invalid whence %d", whence)
+	}
+	if target < 0 {
+		return fw.readPos, fmt.Errorf("negative seek position %d", target)
+	}
+	fw.readPos = target
+	return target, nil
+}
 func (fw *fileWrapper) Close() error                              { return fw.stream.Close() }
 func (fw *fileWrapper) ReadAt(p []byte, off int64) (int, error) {
 	reader, err := fw.file.OpenReaderAt(fw.ctx, off)

--- a/pkg/media/unpack/fs_scan_trace.go
+++ b/pkg/media/unpack/fs_scan_trace.go
@@ -29,8 +29,8 @@ func wrapFileForScanTrace(fw *fileWrapper) fs.File {
 	return &scanTraceFileWrapper{inner: fw}
 }
 
-func (w *scanTraceFileWrapper) Stat() (fs.FileInfo, error)  { return w.inner.Stat() }
-func (w *scanTraceFileWrapper) Close() error                  { return w.inner.Close() }
+func (w *scanTraceFileWrapper) Stat() (fs.FileInfo, error) { return w.inner.Stat() }
+func (w *scanTraceFileWrapper) Close() error               { return w.inner.Close() }
 func (w *scanTraceFileWrapper) Seek(off int64, whence int) (int64, error) {
 	newPos, err := w.inner.Seek(off, whence)
 	if err == nil {

--- a/pkg/media/unpack/fs_scan_trace.go
+++ b/pkg/media/unpack/fs_scan_trace.go
@@ -1,0 +1,97 @@
+package unpack
+
+import (
+	"errors"
+	"io"
+	"io/fs"
+	"sync/atomic"
+
+	"streamnzb/pkg/core/logger"
+)
+
+var scanTraceReadPos atomic.Int64
+
+func ScanTraceLastReadPos() int64 {
+	return scanTraceReadPos.Load()
+}
+
+type segmentMapDebugInfo interface {
+	FindSegmentIndex(offset int64) int
+	SegmentOffsetRange(index int) (start, end int64, ok bool)
+}
+
+type scanTraceFileWrapper struct {
+	inner *fileWrapper
+	pos   int64
+}
+
+func wrapFileForScanTrace(fw *fileWrapper) fs.File {
+	return &scanTraceFileWrapper{inner: fw}
+}
+
+func (w *scanTraceFileWrapper) Stat() (fs.FileInfo, error)  { return w.inner.Stat() }
+func (w *scanTraceFileWrapper) Close() error                  { return w.inner.Close() }
+func (w *scanTraceFileWrapper) Seek(off int64, whence int) (int64, error) {
+	newPos, err := w.inner.Seek(off, whence)
+	if err == nil {
+		w.pos = newPos
+	}
+	return newPos, err
+}
+
+func (w *scanTraceFileWrapper) Read(p []byte) (int, error) {
+	n, err := w.inner.Read(p)
+	if n > 0 {
+		w.pos += int64(n)
+		scanTraceReadPos.Store(w.pos)
+	}
+	if shouldLogScanIOErr(err, w.pos-int64(n), w.inner.size, n, len(p)) {
+		w.logIOFail("read", w.pos-int64(n), len(p), n, err)
+	}
+	return n, err
+}
+
+func (w *scanTraceFileWrapper) ReadAt(p []byte, off int64) (int, error) {
+	n, err := w.inner.ReadAt(p, off)
+	if shouldLogScanIOErr(err, off, w.inner.size, n, len(p)) {
+		w.logIOFail("read_at", off, len(p), n, err)
+	}
+	return n, err
+}
+
+func shouldLogScanIOErr(err error, off, virtualSize int64, n, want int) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, io.EOF) && n == 0 && off >= virtualSize {
+		return false
+	}
+	if errors.Is(err, io.EOF) && n == 0 && off < virtualSize {
+		return true
+	}
+	return errors.Is(err, io.ErrUnexpectedEOF) ||
+		(errors.Is(err, io.EOF) && n > 0 && n < want) ||
+		(err != nil && n < want)
+}
+
+func (w *scanTraceFileWrapper) logIOFail(op string, off int64, want, got int, err error) {
+	attrs := []any{
+		"file", w.inner.name,
+		"op", op,
+		"offset", off,
+		"want", want,
+		"got", got,
+		"virtual_size", w.inner.size,
+		"err", err,
+	}
+	if dbg, ok := w.inner.file.(segmentMapDebugInfo); ok {
+		idx := dbg.FindSegmentIndex(off)
+		attrs = append(attrs, "segment_index", idx)
+		if idx >= 0 {
+			if start, end, ok := dbg.SegmentOffsetRange(idx); ok {
+				attrs = append(attrs, "segment_start", start, "segment_end", end)
+			}
+		}
+	}
+	logger.Debug("RAR scan IO short read", attrs...)
+}

--- a/pkg/media/unpack/playback_io.go
+++ b/pkg/media/unpack/playback_io.go
@@ -1,0 +1,25 @@
+package unpack
+
+import (
+	"context"
+	"io"
+)
+
+// PlaybackReadAheadSegments is how many segments ahead of a playback seek/read
+// position we prefetch when crossing multi-volume archive boundaries.
+const PlaybackReadAheadSegments = 24
+
+type playbackReaderAt interface {
+	OpenPlaybackReaderAt(ctx context.Context, offset int64) (io.ReadCloser, error)
+}
+
+type playbackPrefetcher interface {
+	PrefetchPlaybackOffset(ctx context.Context, offset int64)
+}
+
+func openPlaybackReaderAt(f UnpackableFile, ctx context.Context, offset int64) (io.ReadCloser, error) {
+	if o, ok := f.(playbackReaderAt); ok {
+		return o.OpenPlaybackReaderAt(ctx, offset)
+	}
+	return f.OpenReaderAt(ctx, offset)
+}

--- a/pkg/media/unpack/rar.go
+++ b/pkg/media/unpack/rar.go
@@ -15,7 +15,7 @@ import (
 	"github.com/javi11/rardecode/v2"
 )
 
-const likelyPAR2RepairRequiredMsg = "likely PAR2 repair required"
+var ErrPAR2RepairRequired = errors.New("likely PAR2 repair required")
 
 type ArchiveBlueprint struct {
 	MainFileName string
@@ -50,16 +50,33 @@ func StreamFromBlueprint(ctx context.Context, bp *ArchiveBlueprint, password str
 		return streamEncryptedRAR(ctx, bp, password)
 	}
 
+	// Blueprint virtual stream jumps straight to the target volume/offset
+	// (OpenReaderAt). rardecode seek walks packed blocks across every volume
+	// sequentially, which makes HTTP range seeks stall for minutes on huge sets.
+	stream, name, size := newVirtualStreamFromBlueprint(ctx, bp)
+	if len(bp.Parts) > 1 {
+		logger.Debug("Serving multi-volume RAR via virtual blueprint", "file", name, "parts", len(bp.Parts))
+	}
+	return stream, name, size, nil
+}
+
+func newVirtualStreamFromBlueprint(ctx context.Context, bp *ArchiveBlueprint) (io.ReadSeekCloser, string, int64) {
 	parts := make([]virtualPart, len(bp.Parts))
 	for i, p := range bp.Parts {
 		parts[i] = virtualPart(p)
 	}
-	return NewVirtualStream(ctx, parts, bp.TotalSize, 0), bp.MainFileName, bp.TotalSize, nil
+	return NewVirtualStream(ctx, parts, bp.TotalSize, 0), bp.MainFileName, bp.TotalSize
 }
 
 func streamEncryptedRAR(ctx context.Context, bp *ArchiveBlueprint, password string) (io.ReadSeekCloser, string, int64, error) {
 	if err := contextErr(ctx); err != nil {
 		return nil, "", 0, err
+	}
+
+	if !bp.AnyEncrypted {
+		logger.Debug("Archive has no encrypted parts in blueprint, serving via plaintext virtual stream", "file", bp.MainFileName)
+		stream, name, size := newVirtualStreamFromBlueprint(ctx, bp)
+		return stream, name, size, nil
 	}
 
 	var aesKey, aesIV []byte
@@ -81,17 +98,27 @@ func streamEncryptedRAR(ctx context.Context, bp *ArchiveBlueprint, password stri
 		}
 	}
 
-	if len(aesKey) == 0 {
-		// Fall back to standard unencrypted stream. The archive is either not
-		// encrypted, or we don't have the correct password/keys to decrypt it.
-		logger.Debug("Encrypted virtual stream fallback to plaintext", "file", bp.MainFileName)
-		return NewVirtualStream(ctx, parts, bp.TotalSize, 0), bp.MainFileName, bp.TotalSize, nil
+	if len(aesKey) > 0 {
+		logger.Debug("Serving multi-volume encrypted RAR via encrypted virtual stream", "file", bp.MainFileName, "parts", len(bp.Parts))
+		stream := NewEncryptedVirtualStream(ctx, parts, bp.TotalSize, packedSize, aesKey, aesIV, 0)
+		return stream, bp.MainFileName, bp.TotalSize, nil
 	}
 
-	stream := NewEncryptedVirtualStream(ctx, parts, bp.TotalSize, packedSize, aesKey, aesIV, 0)
-	return stream, bp.MainFileName, bp.TotalSize, nil
-}
+	if len(bp.Parts) > 1 {
+		stream, name, size, decErr := streamRARFromDecoder(ctx, bp, password)
+		if decErr == nil {
+			logger.Debug("Serving multi-volume encrypted RAR via rardecode fallback", "file", name, "parts", len(bp.Parts))
+			return stream, name, size, nil
+		}
+		logger.Debug("Multi-volume rardecode stream fallback failed for encrypted archive, trying standard virtual path", "file", bp.MainFileName, "err", decErr)
+	}
 
+	// Fall back to standard unencrypted stream. The archive is either not
+	// encrypted, or we don't have the correct password/keys to decrypt it.
+	logger.Debug("Encrypted virtual stream fallback to plaintext", "file", bp.MainFileName)
+	stream, name, size := newVirtualStreamFromBlueprint(ctx, bp)
+	return stream, name, size, nil
+}
 
 // maxFirstVolumesToScan caps how many "first" volumes we try when many files are
 // treated as first volumes (e.g. non-standard names like .100, .101). Prevents
@@ -216,7 +243,7 @@ func shouldRetryExhaustiveRARScan(err error) bool {
 	if errors.Is(err, ErrTooManyZeroFills) {
 		return false
 	}
-	return !strings.Contains(strings.ToLower(err.Error()), strings.ToLower(likelyPAR2RepairRequiredMsg))
+	return !errors.Is(err, ErrPAR2RepairRequired)
 }
 
 func ScanArchive(ctx context.Context, files []UnpackableFile, password string, target EpisodeTarget) (*ArchiveBlueprint, error) {
@@ -396,13 +423,13 @@ func (d scanDiagnostics) classifyArchiveError() error {
 		return nil
 	}
 	return fmt.Errorf(
-		"archive data appears corrupted or incomplete (%d/%d corrupt scans; invalid_blocks=%d unexpected_eof=%d decode_corruption=%d): %s",
+		"archive data appears corrupted or incomplete (%d/%d corrupt scans; invalid_blocks=%d unexpected_eof=%d decode_corruption=%d): %w",
 		evidence,
 		d.failedScans,
 		d.invalidBlocks,
 		d.unexpectedEOF,
 		d.decodeCorruption,
-		likelyPAR2RepairRequiredMsg,
+		ErrPAR2RepairRequired,
 	)
 }
 
@@ -587,15 +614,30 @@ func buildBlueprint(ctx context.Context, parts []filePart, allRarFiles []Unpacka
 	headerSize := mainParts[0].unpackedSize
 	scannedSize := totalPackedSize(mainParts)
 
-	if scannedSize < headerSize && len(allRarFiles) > len(mainParts) {
-		mainParts, err = aggregateRemainingVolumes(ctx, mainParts, allRarFiles, bestName, headerSize, password)
+	anyEncrypted := false
+	for _, p := range mainParts {
+		if p.isEncrypted {
+			anyEncrypted = true
+			break
+		}
+	}
+
+	targetSize := headerSize
+	if anyEncrypted {
+		targetSize = roundUpTo16(headerSize)
+	}
+
+	if scannedSize < targetSize && len(allRarFiles) > len(mainParts) {
+		mainParts, err = aggregateRemainingVolumes(ctx, mainParts, allRarFiles, bestName, targetSize, password)
 		if err != nil {
 			return nil, err
 		}
 	}
 
+	mainParts = reconcileMainPartsPackedSpan(mainParts, targetSize)
+
 	compressed := false
-	anyEncrypted := false
+	anyEncrypted = false
 	for _, p := range mainParts {
 		if p.isCompressed {
 			compressed = true
@@ -603,9 +645,6 @@ func buildBlueprint(ctx context.Context, parts []filePart, allRarFiles []Unpacka
 		if p.isEncrypted {
 			anyEncrypted = true
 		}
-	}
-	if password != "" {
-		anyEncrypted = true
 	}
 
 	bp := &ArchiveBlueprint{
@@ -634,6 +673,11 @@ func buildBlueprint(ctx context.Context, parts []filePart, allRarFiles []Unpacka
 
 	logger.Trace("Blueprint total", "vOffset", vOffset, "headerSize", headerSize, "parts", len(mainParts))
 
+	if vOffset != headerSize {
+		logger.Debug("Blueprint packed span differs from unpacked header",
+			"header", headerSize, "packed", vOffset, "parts", len(mainParts))
+	}
+
 	// Packed volume totals can be smaller than unpacked media size; only clamp
 	// for direct VirtualStream reads. Decrypting streams must keep unpacked size.
 	if vOffset < headerSize && !anyEncrypted && password == "" {
@@ -641,7 +685,25 @@ func buildBlueprint(ctx context.Context, parts []filePart, allRarFiles []Unpacka
 		bp.TotalSize = vOffset
 	}
 
+	primeUniformSegmentMapsForPlayback(allRarFiles)
+
 	return bp, nil
+}
+
+type uniformSegmentMapPrimer interface {
+	PrimeUniformSegmentMapFromEstimator() bool
+}
+
+func primeUniformSegmentMapsForPlayback(files []UnpackableFile) {
+	var primed int
+	for _, f := range files {
+		if p, ok := f.(uniformSegmentMapPrimer); ok && p.PrimeUniformSegmentMapFromEstimator() {
+			primed++
+		}
+	}
+	if primed > 0 {
+		logger.Debug("Primed uniform segment maps for playback", "files", primed, "total", len(files))
+	}
 }
 
 func selectMainFile(parts []filePart, target EpisodeTarget) (string, error) {
@@ -706,6 +768,40 @@ func totalPackedSize(parts []filePart) int64 {
 	return total
 }
 
+// reconcileMainPartsPackedSpan trims the final part when summed packed spans exceed
+// the MKV header size. Continuation aggregation can overshoot by trailing RAR bytes
+// on the last volume (decoded file size minus dataOffset > MKV contribution).
+func reconcileMainPartsPackedSpan(parts []filePart, headerSize int64) []filePart {
+	if len(parts) == 0 || headerSize <= 0 {
+		return parts
+	}
+	packed := totalPackedSize(parts)
+	delta := packed - headerSize
+	if delta <= 0 {
+		return parts
+	}
+	out := append([]filePart(nil), parts...)
+	last := len(out) - 1
+	newPacked := out[last].packedSize - delta
+	if newPacked <= 0 {
+		return parts
+	}
+	out[last].packedSize = newPacked
+	logger.Debug("Reconciled last blueprint part packed span to header",
+		"header", headerSize,
+		"was_packed", packed,
+		"delta", delta,
+		"last_packed", newPacked)
+	return out
+}
+
+func roundUpTo16(val int64) int64 {
+	if val%16 == 0 {
+		return val
+	}
+	return (val/16 + 1) * 16
+}
+
 func aggregateRemainingVolumes(ctx context.Context, mainParts []filePart, allRarFiles []UnpackableFile, name string, headerSize int64, password string) ([]filePart, error) {
 	if err := contextErr(ctx); err != nil {
 		return nil, err
@@ -734,15 +830,79 @@ func aggregateRemainingVolumes(ctx context.Context, mainParts []filePart, allRar
 		logger.Trace("Probed continuation volume", "dataOffset", probe.dataOffset, "packedSize", probe.packedSize)
 	}
 
+	mainParts = applyContinuationProbeToMainParts(mainParts, probe)
+
 	return aggregateRemainingVolumesFromStart(ctx, mainParts, allRarFiles, startIdx, name, headerSize, probe)
+}
+
+// applyContinuationProbeToMainParts aligns the first-volume block with metadata from
+// the two-volume ListTolerant probe. Single-volume scans can report a different
+// dataOffset than continuation volumes; that skew breaks every seek past ~100MB.
+func applyContinuationProbeToMainParts(parts []filePart, probe continuationProbe) []filePart {
+	if len(parts) == 0 || (probe.firstDataOffset <= 0 && probe.firstPackedSize <= 0) {
+		return parts
+	}
+	out := make([]filePart, len(parts))
+	copy(out, parts)
+	firstVol := out[0].volName
+	for i := range out {
+		if out[i].volName != firstVol || i != 0 {
+			continue
+		}
+		beforeOff, beforePacked := out[i].dataOffset, out[i].packedSize
+		if probe.firstDataOffset > 0 {
+			out[i].dataOffset = probe.firstDataOffset
+		}
+		packed := probe.firstPackedSize
+		if probe.packedSize > 0 && packed > 0 {
+			switch {
+			case packed == probe.packedSize:
+				// already aligned with continuation span
+			case packed == probe.packedSize+1:
+				// Keep the first-volume STORE span. Shrinking by one byte shifts the
+				// ~100MB part boundary and breaks MKV seek/resume past the first RAR.
+			case packed == probe.packedSize-1:
+				packed = probe.packedSize
+			}
+		}
+		if packed > 0 {
+			out[i].packedSize = packed
+		}
+		if out[i].dataOffset != beforeOff || out[i].packedSize != beforePacked {
+			logger.Debug("Aligned first-volume part with continuation probe",
+				"vol", firstVol,
+				"data_offset", out[i].dataOffset,
+				"packed_size", out[i].packedSize,
+				"was_data_offset", beforeOff,
+				"was_packed_size", beforePacked)
+		}
+	}
+	return out
+}
+
+func uvarintSize(v uint64) int64 {
+	if v == 0 {
+		return 1
+	}
+	var size int64
+	for v > 0 {
+		size++
+		v >>= 7
+	}
+	return size
 }
 
 func aggregateRemainingVolumesFromStart(ctx context.Context, mainParts []filePart, allRarFiles []UnpackableFile, startIdx int, name string, headerSize int64, probe continuationProbe) ([]filePart, error) {
 	if err := contextErr(ctx); err != nil {
 		return nil, err
 	}
+	if len(mainParts) == 0 {
+		return nil, fmt.Errorf("aggregate remaining volumes: no main parts")
+	}
 	first := mainParts[0]
-	result := []filePart{first}
+	// Keep every split block discovered on the first volume. Using only mainParts[0]
+	// shifts all later virtual offsets and breaks seeks past the first ~100MB.
+	result := append([]filePart(nil), mainParts...)
 
 	numContVolumes := len(allRarFiles) - startIdx - 1
 	if numContVolumes <= 0 {
@@ -760,13 +920,30 @@ func aggregateRemainingVolumesFromStart(ctx context.Context, mainParts []filePar
 		if err := primeContinuationSegmentMaps(ctx, allRarFiles[startIdx+1:]); err != nil {
 			return nil, err
 		}
+	} else if len(allRarFiles) > 1 {
+		// Prime the last volume's segment map in the background so player seeks to the end (Matroska cues) do not stall.
+		lastVol := allRarFiles[len(allRarFiles)-1]
+		bgCtx := playbackSegmentMapCtx(context.Background())
+		go func() {
+			_ = ensureSegmentMap(bgCtx, lastVol)
+		}()
 	}
 
+	firstVolumePacked := totalPackedSize(mainParts)
+	firstVolNum := GetRARVolumeNumber(allRarFiles[startIdx].Name())
+
 	var lastPartData int64
-	if contPackedSize > 0 && numContVolumes > 1 {
-		lastPartData = headerSize - first.packedSize - int64(numContVolumes-1)*contPackedSize
-	} else if contPackedSize > 0 && numContVolumes == 1 {
-		lastPartData = headerSize - first.packedSize
+	if contPackedSize > 0 {
+		var sumNonLastContPacked int64
+		for i := startIdx + 1; i < len(allRarFiles)-1; i++ {
+			volIdx := int64(GetRARVolumeNumber(allRarFiles[i].Name()) - firstVolNum)
+			if volIdx < 0 {
+				volIdx = int64(i - startIdx)
+			}
+			volDataOffset := contDataOffset + uvarintSize(uint64(volIdx)) - 1
+			sumNonLastContPacked += contPackedSize - (volDataOffset - contDataOffset)
+		}
+		lastPartData = headerSize - firstVolumePacked - sumNonLastContPacked
 	}
 
 	added := 0
@@ -786,26 +963,38 @@ func aggregateRemainingVolumesFromStart(ctx context.Context, mainParts []filePar
 			}
 		}
 
+		volIdx := int64(GetRARVolumeNumber(f.Name()) - firstVolNum)
+		if volIdx < 0 {
+			volIdx = int64(i - startIdx)
+		}
+		volDataOffset := contDataOffset + uvarintSize(uint64(volIdx)) - 1
+
 		isLastVolume := i == len(allRarFiles)-1
 		var dataSize int64
 		if contPackedSize > 0 {
-			if isLastVolume && lastPartData > 0 {
-				dataSize = lastPartData
-			} else if !isLastVolume {
-				dataSize = contPackedSize
+			if isLastVolume {
+				// Prefer the header-reconciled tail size. Measured fileSize-dataOffset
+				// includes trailing non-MKV bytes after the STORE block and overshoots
+				// TotalUnpackedSize (e.g. +744 on 761-volume sets).
+				if lastPartData > 0 {
+					dataSize = lastPartData
+				} else if err := ensureSegmentMap(ctx, f); err == nil {
+					if fileSize = f.Size(); fileSize > volDataOffset {
+						if measured := fileSize - volDataOffset; measured > 0 {
+							dataSize = measured
+						}
+					}
+				}
 			} else {
-
-				dataSize = contPackedSize
+				dataSize = contPackedSize - (volDataOffset - contDataOffset)
 			}
 		} else {
-
-			dataSize = fileSize - contDataOffset
+			dataSize = fileSize - volDataOffset
 		}
 
 		if dataSize <= 0 {
 			continue
 		}
-		volDataOffset := contDataOffset
 
 		result = append(result, filePart{
 			name:         name,
@@ -889,8 +1078,10 @@ func primeContinuationSegmentMaps(ctx context.Context, files []UnpackableFile) e
 }
 
 type continuationProbe struct {
-	dataOffset int64
-	packedSize int64
+	dataOffset      int64 // per-continuation-volume payload offset (parts[1+])
+	packedSize      int64 // per-continuation-volume packed span (parts[1+])
+	firstDataOffset int64 // opening block on the first volume (parts[0])
+	firstPackedSize int64 // opening block packed span on the first volume (parts[0])
 }
 
 func probeContinuation(ctx context.Context, allRarFiles []UnpackableFile, startIdx int, targetName string, password string) (continuationProbe, error) {
@@ -953,11 +1144,14 @@ func probeContinuation(ctx context.Context, allRarFiles []UnpackableFile, startI
 
 	if len(targetParts) >= 2 {
 		probe := normalizeContinuationProbe(targetParts)
+		probe.firstDataOffset = targetParts[0].DataOffset
+		probe.firstPackedSize = targetParts[0].PackedSize
 		logger.Debug("Continuation probe metadata",
 			"target", targetName,
 			"dataOffset", probe.dataOffset,
 			"packedSize", probe.packedSize,
-			"first_part_packed", targetParts[0].PackedSize,
+			"first_data_offset", probe.firstDataOffset,
+			"first_part_packed", probe.firstPackedSize,
 			"second_part_packed", targetParts[1].PackedSize)
 		return probe, nil
 	}

--- a/pkg/media/unpack/rar.go
+++ b/pkg/media/unpack/rar.go
@@ -5,8 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -33,6 +31,8 @@ type VirtualPartDef struct {
 	VirtualEnd   int64
 	VolFile      UnpackableFile
 	VolOffset    int64
+	AesKey       []byte
+	AesIV        []byte
 }
 
 func StreamFromBlueprint(ctx context.Context, bp *ArchiveBlueprint, password string) (io.ReadSeekCloser, string, int64, error) {
@@ -40,7 +40,10 @@ func StreamFromBlueprint(ctx context.Context, bp *ArchiveBlueprint, password str
 		return nil, "", 0, fmt.Errorf("compressed RAR archive (file: %s) -- STORE mode required for streaming", bp.MainFileName)
 	}
 
-	if bp.AnyEncrypted {
+	// Password-protected RAR5 releases sometimes list the first volume without
+	// AnyEncrypted/file Encrypted flags (ListTolerant on part01 only). Route any
+	// passworded release through rardecode so playback sees decrypted bytes.
+	if bp.AnyEncrypted || password != "" {
 		if password == "" {
 			return nil, "", 0, fmt.Errorf("password-protected RAR (file: %s) -- password required from NZB head", bp.MainFileName)
 		}
@@ -58,243 +61,37 @@ func streamEncryptedRAR(ctx context.Context, bp *ArchiveBlueprint, password stri
 	if err := contextErr(ctx); err != nil {
 		return nil, "", 0, err
 	}
-	fileMap := make(map[string]UnpackableFile, len(bp.Parts))
-	for _, p := range bp.Parts {
-		name := ExtractFilename(p.VolFile.Name())
-		fileMap[name] = p.VolFile
-	}
-	firstName := ExtractFilename(bp.Parts[0].VolFile.Name())
-	fsys := NewNZBFSFromMapCtx(ctx, fileMap)
 
-	opts := []rardecode.Option{rardecode.FileSystem(fsys), rardecode.Password(password)}
-	rc, err := rardecode.OpenReader(firstName, opts...)
-	if err != nil {
-		return nil, "", 0, fmt.Errorf("open encrypted RAR: %w", err)
+	var aesKey, aesIV []byte
+	var packedSize int64
+	parts := make([]virtualPart, len(bp.Parts))
+	for i, p := range bp.Parts {
+		parts[i] = virtualPart{
+			VirtualStart: p.VirtualStart,
+			VirtualEnd:   p.VirtualEnd,
+			VolFile:      p.VolFile,
+			VolOffset:    p.VolOffset,
+			AesKey:       p.AesKey,
+			AesIV:        p.AesIV,
+		}
+		packedSize += (p.VirtualEnd - p.VirtualStart)
+		if len(p.AesKey) > 0 && len(aesKey) == 0 {
+			aesKey = p.AesKey
+			aesIV = p.AesIV
+		}
 	}
 
-	mainBase := filepath.Base(bp.MainFileName)
-	for {
-		if err := contextErr(ctx); err != nil {
-			rc.Close()
-			return nil, "", 0, err
-		}
-		h, err := rc.Next()
-		if err != nil {
-			rc.Close()
-			if err == io.EOF {
-				return nil, "", 0, fmt.Errorf("encrypted RAR: file %q not found", bp.MainFileName)
-			}
-			return nil, "", 0, fmt.Errorf("encrypted RAR next: %w", err)
-		}
-		if h.Name == bp.MainFileName || filepath.Base(h.Name) == mainBase {
-			stream, err := newEncryptedRARStream(
-				ctx,
-				rc,
-				bp.TotalSize,
-				firstName,
-				fileMap,
-				password,
-				bp.MainFileName,
-				mainBase,
-			)
-			if err != nil {
-				rc.Close()
-				return nil, "", 0, err
-			}
-			return stream, bp.MainFileName, bp.TotalSize, nil
-		}
-
-		_, _ = io.Copy(io.Discard, io.LimitReader(rc, h.UnPackedSize))
+	if len(aesKey) == 0 {
+		// Fall back to standard unencrypted stream. The archive is either not
+		// encrypted, or we don't have the correct password/keys to decrypt it.
+		logger.Debug("Encrypted virtual stream fallback to plaintext", "file", bp.MainFileName)
+		return NewVirtualStream(ctx, parts, bp.TotalSize, 0), bp.MainFileName, bp.TotalSize, nil
 	}
+
+	stream := NewEncryptedVirtualStream(ctx, parts, bp.TotalSize, packedSize, aesKey, aesIV, 0)
+	return stream, bp.MainFileName, bp.TotalSize, nil
 }
 
-func newEncryptedRARStream(
-	ctx context.Context,
-	rc *rardecode.ReadCloser,
-	limit int64,
-	firstVolName string,
-	fileMap map[string]UnpackableFile,
-	password string,
-	mainFileName string,
-	mainBase string,
-) (*encryptedRARStream, error) {
-	tmp, err := os.CreateTemp("", "streamnzb-encrypted-rar-*")
-	if err != nil {
-		return nil, fmt.Errorf("create encrypted RAR cache file: %w", err)
-	}
-	return &encryptedRARStream{
-		ctx:          ctx,
-		rc:           rc,
-		limit:        limit,
-		firstVolName: firstVolName,
-		fileMap:      fileMap,
-		password:     password,
-		mainFileName: mainFileName,
-		mainBase:     mainBase,
-		cacheFile:    tmp,
-		cachePath:    tmp.Name(),
-		copyBuf:      make([]byte, 256*1024),
-	}, nil
-}
-
-type encryptedRARStream struct {
-	ctx          context.Context
-	rc           *rardecode.ReadCloser
-	limit        int64
-	read         int64
-	firstVolName string
-	fileMap      map[string]UnpackableFile
-	password     string
-	mainFileName string
-	mainBase     string
-	cacheFile    *os.File
-	cachePath    string
-	cachedBytes  int64
-	sourceEOF    bool
-	copyBuf      []byte
-	mu           sync.Mutex
-}
-
-func (e *encryptedRARStream) Read(p []byte) (n int, err error) {
-	e.mu.Lock()
-	defer e.mu.Unlock()
-	if err := contextErr(e.ctx); err != nil {
-		return 0, err
-	}
-	if e.read >= e.limit {
-		return 0, io.EOF
-	}
-	max := int64(len(p))
-	if max > e.limit-e.read {
-		max = e.limit - e.read
-	}
-	if max <= 0 {
-		return 0, io.EOF
-	}
-
-	target := e.read + max
-	if err := e.ensureCachedUntilLocked(target); err != nil && !errors.Is(err, io.EOF) {
-		return 0, err
-	}
-
-	available := e.cachedBytes - e.read
-	if available <= 0 {
-		return 0, io.EOF
-	}
-	if available > max {
-		available = max
-	}
-
-	n, readErr := e.cacheFile.ReadAt(p[:available], e.read)
-	if n > 0 {
-		e.read += int64(n)
-	}
-	if readErr != nil && !errors.Is(readErr, io.EOF) {
-		return n, readErr
-	}
-	if int64(n) < max {
-		return n, io.EOF
-	}
-	return n, nil
-}
-
-func (e *encryptedRARStream) ensureCachedUntilLocked(target int64) error {
-	if target > e.limit {
-		target = e.limit
-	}
-	for e.cachedBytes < target {
-		if err := contextErr(e.ctx); err != nil {
-			return err
-		}
-		if e.sourceEOF {
-			break
-		}
-		remaining := target - e.cachedBytes
-		chunk := int64(len(e.copyBuf))
-		if remaining < chunk {
-			chunk = remaining
-		}
-		n, err := e.rc.Read(e.copyBuf[:chunk])
-		if n > 0 {
-			if err := writeAllAt(e.cacheFile, e.copyBuf[:n], e.cachedBytes); err != nil {
-				return err
-			}
-			e.cachedBytes += int64(n)
-		}
-		if err != nil {
-			if errors.Is(err, io.EOF) {
-				e.sourceEOF = true
-				break
-			}
-			return err
-		}
-		if n == 0 {
-			break
-		}
-	}
-	if e.cachedBytes < target {
-		return io.EOF
-	}
-	return nil
-}
-
-func writeAllAt(file *os.File, data []byte, off int64) error {
-	for len(data) > 0 {
-		n, err := file.WriteAt(data, off)
-		if err != nil {
-			return err
-		}
-		data = data[n:]
-		off += int64(n)
-	}
-	return nil
-}
-
-func (e *encryptedRARStream) Seek(offset int64, whence int) (int64, error) {
-	e.mu.Lock()
-	defer e.mu.Unlock()
-	var abs int64
-	switch whence {
-	case io.SeekStart:
-		abs = offset
-	case io.SeekCurrent:
-		abs = e.read + offset
-	case io.SeekEnd:
-		abs = e.limit + offset
-	default:
-		return e.read, fmt.Errorf("invalid whence %d", whence)
-	}
-	if abs < 0 {
-		return e.read, fmt.Errorf("negative position")
-	}
-	e.read = abs
-	return e.read, nil
-}
-
-func (e *encryptedRARStream) Close() error {
-	e.mu.Lock()
-	defer e.mu.Unlock()
-	var closeErr error
-	if e.rc != nil {
-		if err := e.rc.Close(); err != nil {
-			closeErr = err
-		}
-		e.rc = nil
-	}
-	if e.cacheFile != nil {
-		if err := e.cacheFile.Close(); err != nil && closeErr == nil {
-			closeErr = err
-		}
-		e.cacheFile = nil
-	}
-	if e.cachePath != "" {
-		if err := os.Remove(e.cachePath); err != nil && !errors.Is(err, os.ErrNotExist) && closeErr == nil {
-			closeErr = err
-		}
-		e.cachePath = ""
-	}
-	return closeErr
-}
 
 // maxFirstVolumesToScan caps how many "first" volumes we try when many files are
 // treated as first volumes (e.g. non-standard names like .100, .101). Prevents
@@ -426,6 +223,8 @@ func ScanArchive(ctx context.Context, files []UnpackableFile, password string, t
 	if err := contextErr(ctx); err != nil {
 		return nil, err
 	}
+	ctx = WithArchiveScanIOTrace(ctx)
+	scanTraceReadPos.Store(0)
 	rarFiles := filterRarFiles(files)
 	if len(rarFiles) == 0 {
 		return nil, errors.New("no RAR files found")
@@ -566,6 +365,8 @@ type filePart struct {
 	isMedia      bool
 	isCompressed bool
 	isEncrypted  bool
+	aesKey       []byte
+	aesIV        []byte
 }
 
 type scanDiagnostics struct {
@@ -647,7 +448,10 @@ func scanVolumesParallel(ctx context.Context, files []UnpackableFile, password s
 
 			cleanName := ExtractFilename(f.Name())
 			fsys := NewNZBFSFromMapCtx(ctx, map[string]UnpackableFile{cleanName: f})
-			listOpts := []rardecode.Option{rardecode.FileSystem(fsys), rardecode.ParallelRead(true), rardecode.SkipVolumeCheck}
+			// ListTolerant: this maps only the single first volume; a split file that
+			// continues into sibling volumes must still be discoverable here. The full
+			// per-volume layout is stitched later by aggregateRemainingVolumes.
+			listOpts := []rardecode.Option{rardecode.FileSystem(fsys), rardecode.ParallelRead(false), rardecode.SkipVolumeCheck, rardecode.ListTolerant}
 			if password != "" {
 				listOpts = append(listOpts, rardecode.Password(password))
 			}
@@ -657,7 +461,8 @@ func scanVolumesParallel(ctx context.Context, files []UnpackableFile, password s
 					setFirstErr(ctxErr)
 					return
 				}
-				logger.Debug("Scan failure", "name", cleanName, "err", err)
+				logger.Debug("Scan failure", "name", cleanName, "err", err, "virtual_size", f.Size())
+				logRARScanDebug(f, err)
 				mu.Lock()
 				diag.failedScans++
 				msg := strings.ToLower(err.Error())
@@ -700,6 +505,16 @@ func scanVolumesParallel(ctx context.Context, files []UnpackableFile, password s
 					}
 				}
 
+				fileEncrypted := info.AnyEncrypted
+				if !fileEncrypted {
+					for _, p := range info.Parts {
+						if p.Encrypted || len(p.AesKey) > 0 {
+							fileEncrypted = true
+							break
+						}
+					}
+				}
+
 				for _, p := range info.Parts {
 					mu.Lock()
 					result = append(result, filePart{
@@ -711,7 +526,9 @@ func scanVolumesParallel(ctx context.Context, files []UnpackableFile, password s
 						volName:      f.Name(),
 						isMedia:      isMediaFile(info),
 						isCompressed: compressed,
-						isEncrypted:  info.AnyEncrypted,
+						isEncrypted:  fileEncrypted,
+						aesKey:       p.AesKey,
+						aesIV:        p.AesIV,
 					})
 					mu.Unlock()
 				}
@@ -787,6 +604,9 @@ func buildBlueprint(ctx context.Context, parts []filePart, allRarFiles []Unpacka
 			anyEncrypted = true
 		}
 	}
+	if password != "" {
+		anyEncrypted = true
+	}
 
 	bp := &ArchiveBlueprint{
 		MainFileName: bestName,
@@ -803,6 +623,8 @@ func buildBlueprint(ctx context.Context, parts []filePart, allRarFiles []Unpacka
 			VirtualEnd:   vOffset + p.packedSize,
 			VolFile:      p.volFile,
 			VolOffset:    p.dataOffset,
+			AesKey:       p.aesKey,
+			AesIV:        p.aesIV,
 		})
 		if i < 3 || i >= len(mainParts)-2 {
 			logger.Trace("Blueprint part", "idx", i, "vStart", vOffset, "vEnd", vOffset+p.packedSize, "volOff", p.dataOffset, "packed", p.packedSize)
@@ -812,7 +634,9 @@ func buildBlueprint(ctx context.Context, parts []filePart, allRarFiles []Unpacka
 
 	logger.Trace("Blueprint total", "vOffset", vOffset, "headerSize", headerSize, "parts", len(mainParts))
 
-	if vOffset < headerSize {
+	// Packed volume totals can be smaller than unpacked media size; only clamp
+	// for direct VirtualStream reads. Decrypting streams must keep unpacked size.
+	if vOffset < headerSize && !anyEncrypted && password == "" {
 		logger.Debug("Adjusting stream size", "header", headerSize, "actual", vOffset)
 		bp.TotalSize = vOffset
 	}
@@ -928,6 +752,16 @@ func aggregateRemainingVolumesFromStart(ctx context.Context, mainParts []filePar
 	contPackedSize := probe.packedSize
 	contDataOffset := probe.dataOffset
 
+	// When the fast continuation probe is unavailable we must learn each remaining
+	// volume's decoded size. Probing volumes one-by-one is the dominant startup
+	// cost (each probe is a round of segment downloads), so prime them concurrently
+	// up front; the sequential loop below then hits already-cached segment maps.
+	if contPackedSize <= 0 {
+		if err := primeContinuationSegmentMaps(ctx, allRarFiles[startIdx+1:]); err != nil {
+			return nil, err
+		}
+	}
+
 	var lastPartData int64
 	if contPackedSize > 0 && numContVolumes > 1 {
 		lastPartData = headerSize - first.packedSize - int64(numContVolumes-1)*contPackedSize
@@ -971,19 +805,87 @@ func aggregateRemainingVolumesFromStart(ctx context.Context, mainParts []filePar
 		if dataSize <= 0 {
 			continue
 		}
+		volDataOffset := contDataOffset
+
 		result = append(result, filePart{
 			name:         name,
 			unpackedSize: headerSize,
-			dataOffset:   contDataOffset,
+			dataOffset:   volDataOffset,
 			packedSize:   dataSize,
 			volFile:      f,
 			volName:      f.Name(),
 			isMedia:      true,
+			isCompressed: first.isCompressed,
+			isEncrypted:  first.isEncrypted,
+			aesKey:       first.aesKey,
+			aesIV:        first.aesIV,
 		})
 		added++
 	}
 	logger.Trace("Manual volume aggregation", "added", added, "total", len(result))
 	return result, nil
+}
+
+// maxContinuationProbeConcurrency bounds how many continuation volumes we probe
+// at once so we speed up startup without flooding the NNTP connection pool.
+// Each volume probe fans out into ~60 segment fetches, so keep this small to
+// avoid saturating the pool (which shows up as "NNTP pool wait exceeded
+// threshold" and stalls real playback reads).
+const maxContinuationProbeConcurrency = 3
+
+// primeContinuationSegmentMaps probes the segment maps of the given volumes
+// concurrently so the subsequent sequential aggregation hits cached maps. It
+// returns the first error encountered (other than per-volume sizing issues,
+// which the aggregation loop already tolerates by skipping empty volumes).
+func primeContinuationSegmentMaps(ctx context.Context, files []UnpackableFile) error {
+	if len(files) == 0 {
+		return nil
+	}
+	if err := contextErr(ctx); err != nil {
+		return err
+	}
+
+	var (
+		wg       sync.WaitGroup
+		mu       sync.Mutex
+		firstErr error
+		sem      = make(chan struct{}, maxContinuationProbeConcurrency)
+	)
+
+	for _, f := range files {
+		f := f
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			select {
+			case sem <- struct{}{}:
+			case <-ctx.Done():
+				mu.Lock()
+				if firstErr == nil {
+					firstErr = ctx.Err()
+				}
+				mu.Unlock()
+				return
+			}
+			defer func() { <-sem }()
+
+			if err := ensureSegmentMap(ctx, f); err != nil {
+				mu.Lock()
+				if firstErr == nil {
+					firstErr = err
+				}
+				mu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+
+	// Only surface context cancellation as fatal; individual volume probe errors
+	// are handled (and may be retried) by the aggregation loop.
+	if firstErr != nil && isContextErr(firstErr) {
+		return firstErr
+	}
+	return nil
 }
 
 type continuationProbe struct {
@@ -1008,7 +910,10 @@ func probeContinuation(ctx context.Context, allRarFiles []UnpackableFile, startI
 		firstName:  firstFile,
 		secondName: secondFile,
 	})
-	listOpts := []rardecode.Option{rardecode.FileSystem(fsys), rardecode.ParallelRead(true)}
+	// ListTolerant lets the split file resolve across the two mounted volumes and
+	// return both parts even though the archive continues into volumes not mounted
+	// here; we only need Parts[1] (the per-continuation-volume packed size).
+	listOpts := []rardecode.Option{rardecode.FileSystem(fsys), rardecode.ParallelRead(false), rardecode.SkipVolumeCheck, rardecode.ListTolerant}
 	if password != "" {
 		listOpts = append(listOpts, rardecode.Password(password))
 	}
@@ -1021,7 +926,14 @@ func probeContinuation(ctx context.Context, allRarFiles []UnpackableFile, startI
 		return continuationProbe{}, nil
 	}
 
+	// Gather every part of the target file across all returned entries, in the
+	// order rardecode discovered them (volume order). Depending on how the split
+	// continuation block in the second volume is flagged, rardecode may either
+	// merge both volumes into a single entry with 2 parts, or emit two separate
+	// single-part entries for the same name. Both layouts mean the same thing:
+	// the second part overall is the per-continuation-volume data block we want.
 	lowerTarget := strings.ToLower(targetName)
+	var targetParts []rardecode.FilePartInfo
 	for _, info := range infos {
 		if err := contextErr(ctx); err != nil {
 			return continuationProbe{}, err
@@ -1029,14 +941,43 @@ func probeContinuation(ctx context.Context, allRarFiles []UnpackableFile, startI
 		if strings.ToLower(info.Name) != lowerTarget {
 			continue
 		}
-		if len(info.Parts) >= 2 {
-			return continuationProbe{
-				dataOffset: info.Parts[1].DataOffset,
-				packedSize: info.Parts[1].PackedSize,
-			}, nil
-		}
+		targetParts = append(targetParts, info.Parts...)
+	}
+
+	logger.Debug("Continuation probe result",
+		"target", targetName,
+		"infos", len(infos),
+		"target_parts", len(targetParts),
+		"first_volume", firstName,
+		"second_volume", secondName)
+
+	if len(targetParts) >= 2 {
+		probe := normalizeContinuationProbe(targetParts)
+		logger.Debug("Continuation probe metadata",
+			"target", targetName,
+			"dataOffset", probe.dataOffset,
+			"packedSize", probe.packedSize,
+			"first_part_packed", targetParts[0].PackedSize,
+			"second_part_packed", targetParts[1].PackedSize)
+		return probe, nil
 	}
 	return continuationProbe{}, nil
+}
+
+func normalizeContinuationProbe(parts []rardecode.FilePartInfo) continuationProbe {
+	if len(parts) < 2 {
+		return continuationProbe{}
+	}
+	probe := continuationProbe{
+		dataOffset: parts[1].DataOffset,
+		packedSize: parts[1].PackedSize,
+	}
+	// RAR5 split continuations can expose a valid dataOffset while PackedSize is
+	// left zero on the second list entry; reuse the first part's packed span.
+	if probe.packedSize <= 0 && parts[0].PackedSize > 0 {
+		probe.packedSize = parts[0].PackedSize
+	}
+	return probe
 }
 
 func tryNestedArchive(ctx context.Context, parts []filePart, password string, target EpisodeTarget) (*ArchiveBlueprint, error) {

--- a/pkg/media/unpack/rar_decoder_stream.go
+++ b/pkg/media/unpack/rar_decoder_stream.go
@@ -1,0 +1,152 @@
+package unpack
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"streamnzb/pkg/core/logger"
+
+	"github.com/javi11/rardecode/v2"
+)
+
+type decoderReadSeekCloser struct {
+	rc     io.ReadCloser
+	seeker io.Seeker
+	size   int64
+	pos    int64
+}
+
+func (d *decoderReadSeekCloser) Read(p []byte) (int, error) {
+	n, err := d.rc.Read(p)
+	if n > 0 {
+		d.pos += int64(n)
+	}
+	return n, err
+}
+
+func (d *decoderReadSeekCloser) Seek(offset int64, whence int) (int64, error) {
+	if d.seeker == nil {
+		return 0, fmt.Errorf("rardecode stream: seeker unavailable")
+	}
+
+	var target int64
+	switch whence {
+	case io.SeekStart:
+		target = offset
+	case io.SeekCurrent:
+		target = d.pos + offset
+	case io.SeekEnd:
+		if d.size <= 0 {
+			abs, err := d.seeker.Seek(offset, whence)
+			if err != nil {
+				return 0, err
+			}
+			d.pos = abs
+			return abs, nil
+		}
+		target = d.size + offset
+	default:
+		return 0, fmt.Errorf("invalid whence %d", whence)
+	}
+
+	if target < 0 {
+		return 0, fmt.Errorf("seek before start")
+	}
+	if d.size > 0 && target > d.size {
+		return 0, fmt.Errorf("seek past end")
+	}
+
+	// http.ServeContent probes size via Seek(0, SeekEnd) then rewinds with
+	// Seek(0, SeekStart). rardecode cannot SeekStart to multi-volume EOF without
+	// walking every packed block; answer EOF from blueprint size instead.
+	if whence == io.SeekEnd && d.size > 0 {
+		d.pos = target
+		return target, nil
+	}
+
+	abs, err := d.seeker.Seek(target, io.SeekStart)
+	if err != nil {
+		return 0, err
+	}
+	d.pos = abs
+	return abs, nil
+}
+
+func (d *decoderReadSeekCloser) Close() error {
+	if d.rc == nil {
+		return nil
+	}
+	return d.rc.Close()
+}
+
+func volumeFilesFromBlueprint(bp *ArchiveBlueprint) (map[string]UnpackableFile, string) {
+	files := make(map[string]UnpackableFile, len(bp.Parts))
+	var firstVol string
+	for i, p := range bp.Parts {
+		name := ExtractFilename(p.VolFile.Name())
+		files[name] = p.VolFile
+		if i == 0 {
+			firstVol = name
+		}
+	}
+	return files, firstVol
+}
+
+func streamRARFromDecoder(ctx context.Context, bp *ArchiveBlueprint, password string) (io.ReadSeekCloser, string, int64, error) {
+	if err := contextErr(ctx); err != nil {
+		return nil, "", 0, err
+	}
+	if bp == nil || len(bp.Parts) < 2 {
+		return nil, "", 0, fmt.Errorf("rardecode stream: need multi-volume blueprint")
+	}
+
+	volFiles, firstVol := volumeFilesFromBlueprint(bp)
+	if firstVol == "" {
+		return nil, "", 0, fmt.Errorf("rardecode stream: empty first volume")
+	}
+
+	playCtx := playbackSegmentMapCtx(ctx)
+	fsys := NewNZBFSFromMapCtx(playCtx, volFiles)
+	opts := []rardecode.Option{
+		rardecode.FileSystem(fsys),
+		rardecode.ParallelRead(false),
+		rardecode.SkipVolumeCheck,
+		rardecode.ListTolerant,
+		// Hashed STORE blocks are wrapped in checksumReader when skipCheck is off;
+		// that wrapper is read-only and openArchiveFile then returns a non-seeker.
+		rardecode.SkipCheck,
+	}
+	if password != "" {
+		opts = append(opts, rardecode.Password(password))
+	}
+
+	files, err := rardecode.List(firstVol, opts...)
+	if err != nil {
+		return nil, "", 0, fmt.Errorf("rardecode list: %w", err)
+	}
+
+	lowerTarget := strings.ToLower(bp.MainFileName)
+	for _, f := range files {
+		if strings.ToLower(f.Name) != lowerTarget {
+			continue
+		}
+		rc, err := f.Open()
+		if err != nil {
+			return nil, "", 0, fmt.Errorf("rardecode open %q: %w", f.Name, err)
+		}
+		seeker, ok := rc.(io.Seeker)
+		if !ok {
+			_ = rc.Close()
+			return nil, "", 0, fmt.Errorf("rardecode open %q: stream is not seekable (volume reader or post-open checksum wrapper)", f.Name)
+		}
+		size := bp.TotalSize
+		if f.UnPackedSize > 0 {
+			size = f.UnPackedSize
+		}
+		logger.Trace("Opened rardecode media stream", "file", f.Name, "size", size, "volumes", len(volFiles))
+		return &decoderReadSeekCloser{rc: rc, seeker: seeker, size: size}, f.Name, size, nil
+	}
+	return nil, "", 0, fmt.Errorf("rardecode stream: file %q not in archive", bp.MainFileName)
+}

--- a/pkg/media/unpack/rar_decoder_stream_test.go
+++ b/pkg/media/unpack/rar_decoder_stream_test.go
@@ -1,0 +1,71 @@
+package unpack
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+)
+
+type seekEndFailingSeeker struct {
+	*bytes.Reader
+	seekCalls int
+}
+
+func (s *seekEndFailingSeeker) Seek(offset int64, whence int) (int64, error) {
+	s.seekCalls++
+	if whence == io.SeekEnd {
+		return 0, errors.New("packedSize scan failed")
+	}
+	return s.Reader.Seek(offset, whence)
+}
+
+func TestDecoderReadSeekCloserSeekEndUsesKnownSize(t *testing.T) {
+	data := []byte("0123456789")
+	underlying := &seekEndFailingSeeker{Reader: bytes.NewReader(data)}
+	stream := &decoderReadSeekCloser{
+		rc:     io.NopCloser(underlying),
+		seeker: underlying,
+		size:   int64(len(data)),
+	}
+
+	pos, err := stream.Seek(0, io.SeekEnd)
+	if err != nil {
+		t.Fatalf("Seek(0, SeekEnd) returned error: %v", err)
+	}
+	if pos != int64(len(data)) {
+		t.Fatalf("SeekEnd position = %d, want %d", pos, len(data))
+	}
+	if underlying.seekCalls != 0 {
+		t.Fatalf("SeekEnd should not call underlying seeker, calls = %d", underlying.seekCalls)
+	}
+
+	pos, err = stream.Seek(0, io.SeekStart)
+	if err != nil {
+		t.Fatalf("Seek(0, SeekStart) returned error: %v", err)
+	}
+	if pos != 0 {
+		t.Fatalf("SeekStart position = %d, want 0", pos)
+	}
+}
+
+func TestDecoderReadSeekCloserMatchesServeContentSizeProbe(t *testing.T) {
+	data := []byte("0123456789abcdef")
+	underlying := &seekEndFailingSeeker{Reader: bytes.NewReader(data)}
+	stream := &decoderReadSeekCloser{
+		rc:     io.NopCloser(underlying),
+		seeker: underlying,
+		size:   int64(len(data)),
+	}
+
+	size, err := stream.Seek(0, io.SeekEnd)
+	if err != nil {
+		t.Fatalf("size probe SeekEnd returned error: %v", err)
+	}
+	if _, err := stream.Seek(0, io.SeekStart); err != nil {
+		t.Fatalf("rewind SeekStart returned error: %v", err)
+	}
+	if size != int64(len(data)) {
+		t.Fatalf("size probe = %d, want %d", size, len(data))
+	}
+}

--- a/pkg/media/unpack/rar_scan_debug.go
+++ b/pkg/media/unpack/rar_scan_debug.go
@@ -1,0 +1,37 @@
+package unpack
+
+import (
+	"context"
+	"encoding/hex"
+	"io"
+
+	"streamnzb/pkg/core/logger"
+)
+
+func logRARScanDebug(f UnpackableFile, err error) {
+	attrs := []any{
+		"err", err,
+		"virtual_size", f.Size(),
+		"stream_read_pos", ScanTraceLastReadPos(),
+	}
+	if preview, ok := readVolumeHeaderPreview(f); ok {
+		attrs = append(attrs, "header_hex", preview)
+	}
+	logger.Debug("RAR scan debug", attrs...)
+}
+
+func readVolumeHeaderPreview(f UnpackableFile) (string, bool) {
+	const previewLen = 32
+	buf := make([]byte, previewLen)
+	n, err := f.ReadAt(buf, 0)
+	if err != nil && n == 0 {
+		if reader, openErr := f.OpenReaderAt(context.Background(), 0); openErr == nil {
+			defer reader.Close()
+			n, err = io.ReadFull(reader, buf)
+		}
+	}
+	if n <= 0 {
+		return "", false
+	}
+	return hex.EncodeToString(buf[:n]), true
+}

--- a/pkg/media/unpack/rar_test.go
+++ b/pkg/media/unpack/rar_test.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"strings"
 	"testing"
+	"time"
 
 	"streamnzb/pkg/core/logger"
 
@@ -89,8 +90,124 @@ func TestAggregateRemainingVolumesFromStartSkipsSegmentDetectionWhenProbeProvide
 	if got := parts[2].dataOffset; got != 24 {
 		t.Fatalf("expected later continuation dataOffset 24, got %d", got)
 	}
-	if secondFile.ensureCalls != 0 || thirdFile.ensureCalls != 0 {
-		t.Fatalf("expected no EnsureSegmentMap calls with probe metadata, got second=%d third=%d", secondFile.ensureCalls, thirdFile.ensureCalls)
+	if secondFile.ensureCalls != 0 {
+		t.Fatalf("expected no EnsureSegmentMap on middle volumes with probe metadata, got second=%d", secondFile.ensureCalls)
+	}
+	// Continuation volumes are primed in the background for playback seeks.
+	time.Sleep(50 * time.Millisecond)
+	if thirdFile.ensureCalls > 1 {
+		t.Fatalf("expected at most one background EnsureSegmentMap on last volume, got third=%d", thirdFile.ensureCalls)
+	}
+}
+
+func TestReconcileMainPartsPackedSpanTrimsOvershootFromLastPart(t *testing.T) {
+	parts := []filePart{
+		{packedSize: 200},
+		{packedSize: 300},
+		{packedSize: 510},
+	}
+	header := int64(1000)
+	reconciled := reconcileMainPartsPackedSpan(parts, header)
+	if got := totalPackedSize(reconciled); got != header {
+		t.Fatalf("packed total = %d, want %d", got, header)
+	}
+	if got := reconciled[2].packedSize; got != 500 {
+		t.Fatalf("last packed = %d, want 500", got)
+	}
+}
+
+func TestApplyContinuationProbeToMainPartsAlignsFirstVolume(t *testing.T) {
+	discardTestLogger(t)
+
+	firstFile := &memoryUnpackableFile{name: "release.part001.rar", data: []byte("first")}
+	parts := []filePart{{
+		name: "movie.mkv", unpackedSize: 1000, dataOffset: 200, packedSize: 199,
+		volFile: firstFile, volName: firstFile.Name(), isMedia: true,
+	}}
+
+	aligned := applyContinuationProbeToMainParts(parts, continuationProbe{
+		firstDataOffset: 103,
+		firstPackedSize: 105215780,
+		dataOffset:      103,
+		packedSize:      105215779,
+	})
+
+	if got := aligned[0].dataOffset; got != 103 {
+		t.Fatalf("dataOffset = %d, want 103", got)
+	}
+	if got := aligned[0].packedSize; got != 105215780 {
+		t.Fatalf("packedSize = %d, want 105215780 (keep first-volume STORE span)", got)
+	}
+
+	// Large first/continuation deltas should not be overwritten.
+	parts[0].packedSize = 400
+	aligned = applyContinuationProbeToMainParts(parts, continuationProbe{
+		firstDataOffset: 103,
+		firstPackedSize: 400,
+		dataOffset:      103,
+		packedSize:      300,
+	})
+	if got := aligned[0].packedSize; got != 400 {
+		t.Fatalf("packedSize = %d, want 400", got)
+	}
+}
+
+func TestAggregateRemainingVolumesIncludesAllFirstVolumeParts(t *testing.T) {
+	discardTestLogger(t)
+
+	firstFile := &trackingUnpackableFile{memoryUnpackableFile: &memoryUnpackableFile{name: "release.part001.rar", data: []byte("first")}}
+	secondFile := &trackingUnpackableFile{memoryUnpackableFile: &memoryUnpackableFile{name: "release.part002.rar", data: []byte("second")}}
+	thirdFile := &trackingUnpackableFile{memoryUnpackableFile: &memoryUnpackableFile{name: "release.part003.rar", data: []byte("third")}}
+
+	mainParts := []filePart{
+		{name: "movie.mkv", unpackedSize: 1000, dataOffset: 10, packedSize: 40, volFile: firstFile, volName: firstFile.Name(), isMedia: true},
+		{name: "movie.mkv", unpackedSize: 1000, dataOffset: 50, packedSize: 60, volFile: firstFile, volName: firstFile.Name(), isMedia: true},
+	}
+
+	parts, err := aggregateRemainingVolumesFromStart(
+		context.Background(),
+		mainParts,
+		[]UnpackableFile{firstFile, secondFile, thirdFile},
+		0,
+		"movie.mkv",
+		1000,
+		continuationProbe{dataOffset: 24, packedSize: 300},
+	)
+	if err != nil {
+		t.Fatalf("aggregateRemainingVolumesFromStart returned error: %v", err)
+	}
+
+	if len(parts) != 4 {
+		t.Fatalf("expected 4 parts (2 first-volume blocks + 2 continuation volumes), got %d", len(parts))
+	}
+	if got := parts[0].packedSize; got != 40 {
+		t.Fatalf("expected first block packed size 40, got %d", got)
+	}
+	if got := parts[1].packedSize; got != 60 {
+		t.Fatalf("expected second first-volume block packed size 60, got %d", got)
+	}
+	if got := parts[2].packedSize; got != 300 {
+		t.Fatalf("expected first continuation packed size 300, got %d", got)
+	}
+	if got := parts[3].packedSize; got != 600 {
+		t.Fatalf("expected final continuation packed size 600, got %d", got)
+	}
+
+	var vOffset int64
+	for i, p := range parts {
+		start := vOffset
+		end := vOffset + p.packedSize
+		// Offset 85 should land in the second first-volume block, not the first continuation volume.
+		if i == 1 && (85 < start || 85 >= end) {
+			t.Fatalf("offset 85 expected in part %d [%d,%d)", i, start, end)
+		}
+		if i == 2 && 85 >= start {
+			t.Fatalf("offset 85 incorrectly mapped to continuation part %d at %d", i, start)
+		}
+		vOffset += p.packedSize
+	}
+	if vOffset != 1000 {
+		t.Fatalf("expected virtual span 1000, got %d", vOffset)
 	}
 }
 
@@ -186,7 +303,7 @@ func TestScanDiagnosticsClassifiesLikelyCorruption(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected corruption classification error")
 	}
-	if !strings.Contains(err.Error(), likelyPAR2RepairRequiredMsg) {
+	if !errors.Is(err, ErrPAR2RepairRequired) {
 		t.Fatalf("expected PAR2 guidance in error, got %v", err)
 	}
 }
@@ -219,7 +336,7 @@ func TestShouldRetryExhaustiveRARScan(t *testing.T) {
 		t.Fatal("expected nil error to skip exhaustive retry")
 	}
 
-	if shouldRetryExhaustiveRARScan(errors.New("archive data appears corrupted or incomplete: likely PAR2 repair required")) {
+	if shouldRetryExhaustiveRARScan(fmt.Errorf("archive data appears corrupted or incomplete: %w", ErrPAR2RepairRequired)) {
 		t.Fatal("expected PAR2-classified corruption to skip exhaustive retry")
 	}
 
@@ -278,3 +395,91 @@ func TestParseSubjectPartCounter(t *testing.T) {
 		t.Fatal("expected missing counter to fail parsing")
 	}
 }
+
+func TestStreamFromBlueprintUnencryptedWithDummyPassword(t *testing.T) {
+	bp := &ArchiveBlueprint{
+		MainFileName: "movie.mkv",
+		TotalSize:    1000,
+		IsCompressed: false,
+		AnyEncrypted: false,
+		Parts: []VirtualPartDef{
+			{
+				VirtualStart: 0,
+				VirtualEnd:   1000,
+				VolFile:      &memoryUnpackableFile{name: "release.part1.rar", data: make([]byte, 1000)},
+				VolOffset:    0,
+			},
+		},
+	}
+	stream, name, size, err := StreamFromBlueprint(context.Background(), bp, "some_dummy_password")
+	if err != nil {
+		t.Fatalf("StreamFromBlueprint returned error: %v", err)
+	}
+	defer stream.Close()
+
+	if name != "movie.mkv" {
+		t.Fatalf("expected movie.mkv, got %q", name)
+	}
+	if size != 1000 {
+		t.Fatalf("expected size 1000, got %d", size)
+	}
+	typeName := fmt.Sprintf("%T", stream)
+	if !strings.Contains(typeName, "VirtualStream") {
+		t.Fatalf("expected VirtualStream type, got %s", typeName)
+	}
+}
+
+func TestBuildBlueprintCiphertextBlockAlignmentForEncryptedRAR(t *testing.T) {
+	parts := []filePart{
+		{
+			name:         "movie.mkv",
+			unpackedSize: 1000,
+			dataOffset:   100,
+			packedSize:   200,
+			volName:      "release.part01.rar",
+			isMedia:      true,
+			isEncrypted:  true,
+		},
+		{
+			name:         "movie.mkv",
+			unpackedSize: 1000,
+			dataOffset:   100,
+			packedSize:   300,
+			volName:      "release.part02.rar",
+			isMedia:      true,
+			isEncrypted:  true,
+		},
+		{
+			name:         "movie.mkv",
+			unpackedSize: 1000,
+			dataOffset:   100,
+			packedSize:   510,
+			volName:      "release.part03.rar",
+			isMedia:      true,
+			isEncrypted:  true,
+		},
+	}
+	allFiles := []UnpackableFile{
+		&memoryUnpackableFile{name: "release.part01.rar"},
+		&memoryUnpackableFile{name: "release.part02.rar"},
+		&memoryUnpackableFile{name: "release.part03.rar"},
+	}
+
+	bp, err := buildBlueprint(context.Background(), parts, allFiles, "password", EpisodeTarget{})
+	if err != nil {
+		t.Fatalf("buildBlueprint returned error: %v", err)
+	}
+
+	var totalPartsPacked int64
+	for _, p := range bp.Parts {
+		totalPartsPacked += (p.VirtualEnd - p.VirtualStart)
+	}
+
+	if totalPartsPacked != 1008 {
+		t.Fatalf("expected total packed parts size to be 1008, got %d", totalPartsPacked)
+	}
+	if bp.TotalSize != 1000 {
+		t.Fatalf("expected blueprint TotalSize (unpacked) to remain 1000, got %d", bp.TotalSize)
+	}
+}
+

--- a/pkg/media/unpack/rar_test.go
+++ b/pkg/media/unpack/rar_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"streamnzb/pkg/core/logger"
+
+	"github.com/javi11/rardecode/v2"
 )
 
 func discardTestLogger(t *testing.T) {
@@ -24,11 +26,32 @@ func discardTestLogger(t *testing.T) {
 type trackingUnpackableFile struct {
 	*memoryUnpackableFile
 	ensureCalls int
+	detected    bool
 }
 
+// EnsureSegmentMap mirrors the real *File: detection runs once and subsequent
+// calls are cheap cache hits. ensureCalls therefore counts actual detection
+// work, not the number of (possibly redundant) invocations.
 func (f *trackingUnpackableFile) EnsureSegmentMap() error {
+	if f.detected {
+		return nil
+	}
+	f.detected = true
 	f.ensureCalls++
 	return nil
+}
+
+func TestNormalizeContinuationProbeFallsBackToFirstPartPackedSize(t *testing.T) {
+	probe := normalizeContinuationProbe([]rardecode.FilePartInfo{
+		{DataOffset: 100, PackedSize: 49_999_328},
+		{DataOffset: 24, PackedSize: 0},
+	})
+	if probe.dataOffset != 24 {
+		t.Fatalf("dataOffset = %d, want 24", probe.dataOffset)
+	}
+	if probe.packedSize != 49_999_328 {
+		t.Fatalf("packedSize = %d, want 49999328", probe.packedSize)
+	}
 }
 
 func TestAggregateRemainingVolumesFromStartSkipsSegmentDetectionWhenProbeProvidesPackedSize(t *testing.T) {
@@ -59,6 +82,12 @@ func TestAggregateRemainingVolumesFromStartSkipsSegmentDetectionWhenProbeProvide
 	}
 	if got := parts[2].packedSize; got != 500 {
 		t.Fatalf("expected final continuation packed size 500, got %d", got)
+	}
+	if got := parts[1].dataOffset; got != 24 {
+		t.Fatalf("expected first continuation dataOffset 24, got %d", got)
+	}
+	if got := parts[2].dataOffset; got != 24 {
+		t.Fatalf("expected later continuation dataOffset 24, got %d", got)
 	}
 	if secondFile.ensureCalls != 0 || thirdFile.ensureCalls != 0 {
 		t.Fatalf("expected no EnsureSegmentMap calls with probe metadata, got second=%d third=%d", secondFile.ensureCalls, thirdFile.ensureCalls)

--- a/pkg/media/unpack/virtual_stream.go
+++ b/pkg/media/unpack/virtual_stream.go
@@ -50,61 +50,97 @@ func NewVirtualStream(ctx context.Context, parts []virtualPart, totalSize int64,
 }
 
 func (s *VirtualStream) Read(p []byte) (int, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	return s.readLocked(p)
-}
-
-func (s *VirtualStream) readLocked(p []byte) (int, error) {
-	if s.closed {
-		return 0, io.ErrClosedPipe
+	if len(p) == 0 {
+		return 0, nil
 	}
 
-	if s.offset >= s.totalSize {
-		return 0, io.EOF
-	}
-
-	select {
-	case <-s.ctx.Done():
-		return 0, s.ctx.Err()
-	default:
-	}
-
-	part, partIdx := s.findPart(s.offset)
-	if part == nil {
-		return 0, fmt.Errorf("offset %d not mapped in %d parts", s.offset, len(s.parts))
-	}
-
-	if err := s.ensureReader(part, partIdx); err != nil {
-		return 0, err
-	}
-
-	remaining := part.VirtualEnd - s.offset
-	buf := p
-	if int64(len(buf)) > remaining {
-		buf = buf[:remaining]
-	}
-
-	n, err := s.currentReader.Read(buf)
-	s.offset += int64(n)
-
-	if err == io.EOF {
-		s.closeReader()
-
-		if s.offset < part.VirtualEnd {
-			s.offset = part.VirtualEnd
+	for {
+		s.mu.Lock()
+		if s.closed {
+			s.mu.Unlock()
+			return 0, io.ErrClosedPipe
 		}
-		if n > 0 {
-			return n, nil
-		}
-		if s.offset < s.totalSize {
-			return s.readLocked(p)
-		}
-		return 0, io.EOF
-	}
 
-	return n, err
+		if s.offset >= s.totalSize {
+			s.mu.Unlock()
+			return 0, io.EOF
+		}
+
+		select {
+		case <-s.ctx.Done():
+			s.mu.Unlock()
+			return 0, s.ctx.Err()
+		default:
+		}
+
+		part, partIdx := s.findPart(s.offset)
+		if part == nil {
+			s.mu.Unlock()
+			return 0, fmt.Errorf("offset %d not mapped in %d parts", s.offset, len(s.parts))
+		}
+
+		if err := s.ensureReader(part, partIdx); err != nil {
+			s.mu.Unlock()
+			return 0, err
+		}
+
+		remaining := part.VirtualEnd - s.offset
+		buf := p
+		if int64(len(buf)) > remaining {
+			buf = buf[:remaining]
+		}
+
+		expectedOffset := s.offset
+		reader := s.currentReader
+		s.mu.Unlock()
+
+		n, err := reader.Read(buf)
+
+		s.mu.Lock()
+		if s.closed {
+			s.mu.Unlock()
+			return n, io.ErrClosedPipe
+		}
+
+		if s.offset != expectedOffset || s.currentReader != reader {
+			s.mu.Unlock()
+			return 0, fmt.Errorf("virtual stream: concurrent seek or read detected")
+		}
+
+		s.offset += int64(n)
+
+		if err == io.EOF {
+			if s.currentReader == reader {
+				s.closeReader()
+			}
+
+			if n == 0 && s.offset < part.VirtualEnd {
+				// Exhausted this volume before the packed span ends (trailing RAR bytes).
+				// Advance to the next virtual part instead of stalling on a dead reader.
+				s.offset = part.VirtualEnd
+			}
+			if n > 0 {
+				if s.offset >= part.VirtualEnd && s.offset < s.totalSize {
+					s.prefetchPart(partIdx + 1)
+				}
+				s.mu.Unlock()
+				return n, nil
+			}
+			if s.offset < s.totalSize {
+				s.mu.Unlock()
+				continue
+			}
+			s.mu.Unlock()
+			return 0, io.EOF
+		}
+
+		if s.offset >= part.VirtualEnd && s.offset < s.totalSize {
+			s.prefetchPart(partIdx + 1)
+		}
+
+		s.mu.Unlock()
+		return n, err
+	}
 }
 
 func (s *VirtualStream) Seek(offset int64, whence int) (int64, error) {
@@ -141,17 +177,8 @@ func (s *VirtualStream) Seek(offset int64, whence int) (int64, error) {
 		volOff := part.VolOffset + localOff
 
 		if seeker, ok := s.currentReader.(io.Seeker); ok {
-
-			currentLocalOff := s.offset - part.VirtualStart
-			currentVolOff := part.VolOffset + currentLocalOff
-			seekDelta := volOff - currentVolOff
-			if seekDelta != 0 {
-				_, err := seeker.Seek(seekDelta, io.SeekCurrent)
-				if err == nil {
-					s.offset = target
-					return target, nil
-				}
-			} else {
+			_, err := seeker.Seek(volOff, io.SeekStart)
+			if err == nil {
 				s.offset = target
 				return target, nil
 			}
@@ -203,7 +230,7 @@ func (s *VirtualStream) ensureReader(part *virtualPart, partIdx int) error {
 	localOff := s.offset - part.VirtualStart
 	volOff := part.VolOffset + localOff
 
-	r, err := part.VolFile.OpenReaderAt(s.ctx, volOff)
+	r, err := openPlaybackReaderAt(part.VolFile, playbackSegmentMapCtx(s.ctx), volOff)
 	if err != nil {
 		return fmt.Errorf("open volume part %d at offset %d: %w", partIdx, volOff, err)
 	}
@@ -211,6 +238,16 @@ func (s *VirtualStream) ensureReader(part *virtualPart, partIdx int) error {
 	s.currentReader = r
 	s.currentPart = partIdx
 	return nil
+}
+
+func (s *VirtualStream) prefetchPart(partIdx int) {
+	if partIdx < 0 || partIdx >= len(s.parts) {
+		return
+	}
+	part := &s.parts[partIdx]
+	if prefetcher, ok := part.VolFile.(playbackPrefetcher); ok {
+		prefetcher.PrefetchPlaybackOffset(playbackSegmentMapCtx(s.ctx), part.VolOffset)
+	}
 }
 
 func (s *VirtualStream) closeReader() {
@@ -254,17 +291,18 @@ func NewEncryptedVirtualStream(
 
 func (s *EncryptedVirtualStream) Read(p []byte) (int, error) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	if s.closed {
+		s.mu.Unlock()
 		return 0, io.ErrClosedPipe
 	}
 	if s.offset >= s.totalSize {
+		s.mu.Unlock()
 		return 0, io.EOF
 	}
 
 	n := len(p)
 	if n == 0 {
+		s.mu.Unlock()
 		return 0, nil
 	}
 
@@ -273,6 +311,7 @@ func (s *EncryptedVirtualStream) Read(p []byte) (int, error) {
 		n = int(s.totalSize - s.offset)
 	}
 	if n <= 0 {
+		s.mu.Unlock()
 		return 0, io.EOF
 	}
 
@@ -286,7 +325,10 @@ func (s *EncryptedVirtualStream) Read(p []byte) (int, error) {
 		alignedEnd = s.packedSize
 	}
 
-	// 1. Obtain the IV
+	expectedOffset := s.offset
+	s.mu.Unlock()
+
+	// 1. Obtain the IV (no lock held)
 	var iv []byte
 	if alignedStart == 0 {
 		iv = make([]byte, 16)
@@ -301,7 +343,7 @@ func (s *EncryptedVirtualStream) Read(p []byte) (int, error) {
 		}
 	}
 
-	// 2. Read the ciphertext
+	// 2. Read the ciphertext (no lock held)
 	cipherLen := alignedEnd - alignedStart
 	if cipherLen <= 0 {
 		return 0, io.EOF
@@ -314,7 +356,7 @@ func (s *EncryptedVirtualStream) Read(p []byte) (int, error) {
 		return 0, fmt.Errorf("read ciphertext at offset %d: %w", alignedStart, err)
 	}
 
-	// 3. Decrypt ciphertext
+	// 3. Decrypt ciphertext (no lock held)
 	block, err := aes.NewCipher(s.aesKey)
 	if err != nil {
 		return 0, fmt.Errorf("new aes cipher: %w", err)
@@ -325,11 +367,22 @@ func (s *EncryptedVirtualStream) Read(p []byte) (int, error) {
 		mode.CryptBlocks(ciphertext[:decryptLen], ciphertext[:decryptLen])
 	}
 
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return 0, io.ErrClosedPipe
+	}
+	if s.offset != expectedOffset {
+		s.mu.Unlock()
+		return 0, fmt.Errorf("encrypted virtual stream: concurrent seek or read detected")
+	}
+
 	// 4. Copy to user buffer
 	startInBuf := s.offset - alignedStart
 	copied := copy(p[:n], ciphertext[startInBuf:])
 	s.offset += int64(copied)
 
+	s.mu.Unlock()
 	return copied, nil
 }
 

--- a/pkg/media/unpack/virtual_stream.go
+++ b/pkg/media/unpack/virtual_stream.go
@@ -2,6 +2,8 @@ package unpack
 
 import (
 	"context"
+	"crypto/aes"
+	"crypto/cipher"
 	"errors"
 	"fmt"
 	"io"
@@ -14,6 +16,8 @@ type virtualPart struct {
 	VirtualEnd   int64
 	VolFile      UnpackableFile
 	VolOffset    int64
+	AesKey       []byte
+	AesIV        []byte
 }
 
 type VirtualStream struct {
@@ -215,4 +219,155 @@ func (s *VirtualStream) closeReader() {
 		s.currentReader = nil
 		s.currentPart = -1
 	}
+}
+
+type EncryptedVirtualStream struct {
+	source     *VirtualStream
+	totalSize  int64 // Unpacked size
+	packedSize int64 // Ciphertext size
+	aesKey     []byte
+	aesIV      []byte
+	offset     int64
+	mu         sync.Mutex
+	closed     bool
+}
+
+func NewEncryptedVirtualStream(
+	ctx context.Context,
+	parts []virtualPart,
+	totalSize int64,
+	packedSize int64,
+	aesKey []byte,
+	aesIV []byte,
+	startOffset int64,
+) *EncryptedVirtualStream {
+	source := NewVirtualStream(ctx, parts, packedSize, 0)
+	return &EncryptedVirtualStream{
+		source:     source,
+		totalSize:  totalSize,
+		packedSize: packedSize,
+		aesKey:     aesKey,
+		aesIV:      aesIV,
+		offset:     startOffset,
+	}
+}
+
+func (s *EncryptedVirtualStream) Read(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.closed {
+		return 0, io.ErrClosedPipe
+	}
+	if s.offset >= s.totalSize {
+		return 0, io.EOF
+	}
+
+	n := len(p)
+	if n == 0 {
+		return 0, nil
+	}
+
+	// Clamp the requested size to the remaining unpacked bytes
+	if s.offset+int64(n) > s.totalSize {
+		n = int(s.totalSize - s.offset)
+	}
+	if n <= 0 {
+		return 0, io.EOF
+	}
+
+	alignedStart := s.offset - (s.offset % 16)
+	alignedEnd := s.offset + int64(n)
+	// Align alignedEnd to 16 bytes
+	if alignedEnd%16 != 0 {
+		alignedEnd = (alignedEnd/16 + 1) * 16
+	}
+	if alignedEnd > s.packedSize {
+		alignedEnd = s.packedSize
+	}
+
+	// 1. Obtain the IV
+	var iv []byte
+	if alignedStart == 0 {
+		iv = make([]byte, 16)
+		copy(iv, s.aesIV)
+	} else {
+		iv = make([]byte, 16)
+		if _, err := s.source.Seek(alignedStart-16, io.SeekStart); err != nil {
+			return 0, fmt.Errorf("seek to IV offset %d: %w", alignedStart-16, err)
+		}
+		if _, err := io.ReadFull(s.source, iv); err != nil {
+			return 0, fmt.Errorf("read IV at offset %d: %w", alignedStart-16, err)
+		}
+	}
+
+	// 2. Read the ciphertext
+	cipherLen := alignedEnd - alignedStart
+	if cipherLen <= 0 {
+		return 0, io.EOF
+	}
+	ciphertext := make([]byte, cipherLen)
+	if _, err := s.source.Seek(alignedStart, io.SeekStart); err != nil {
+		return 0, fmt.Errorf("seek to ciphertext offset %d: %w", alignedStart, err)
+	}
+	if _, err := io.ReadFull(s.source, ciphertext); err != nil {
+		return 0, fmt.Errorf("read ciphertext at offset %d: %w", alignedStart, err)
+	}
+
+	// 3. Decrypt ciphertext
+	block, err := aes.NewCipher(s.aesKey)
+	if err != nil {
+		return 0, fmt.Errorf("new aes cipher: %w", err)
+	}
+	decryptLen := (cipherLen / 16) * 16
+	if decryptLen > 0 {
+		mode := cipher.NewCBCDecrypter(block, iv)
+		mode.CryptBlocks(ciphertext[:decryptLen], ciphertext[:decryptLen])
+	}
+
+	// 4. Copy to user buffer
+	startInBuf := s.offset - alignedStart
+	copied := copy(p[:n], ciphertext[startInBuf:])
+	s.offset += int64(copied)
+
+	return copied, nil
+}
+
+func (s *EncryptedVirtualStream) Seek(offset int64, whence int) (int64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.closed {
+		return 0, io.ErrClosedPipe
+	}
+
+	var target int64
+	switch whence {
+	case io.SeekStart:
+		target = offset
+	case io.SeekCurrent:
+		target = s.offset + offset
+	case io.SeekEnd:
+		target = s.totalSize + offset
+	default:
+		return 0, errors.New("invalid whence")
+	}
+
+	if target < 0 || target > s.totalSize {
+		return 0, errors.New("seek out of bounds")
+	}
+
+	s.offset = target
+	return target, nil
+}
+
+func (s *EncryptedVirtualStream) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.closed {
+		return nil
+	}
+	s.closed = true
+	return s.source.Close()
 }

--- a/pkg/media/unpack/virtual_stream_test.go
+++ b/pkg/media/unpack/virtual_stream_test.go
@@ -1,7 +1,10 @@
 package unpack
 
 import (
+	"bytes"
 	"context"
+	"crypto/aes"
+	"crypto/cipher"
 	"errors"
 	"io"
 	"testing"
@@ -82,5 +85,84 @@ func TestVirtualStreamSeekToEndReturnsEOFOnRead(t *testing.T) {
 	n, err := stream.Read(buf)
 	if n != 0 || !errors.Is(err, io.EOF) {
 		t.Fatalf("expected EOF after seek to end, got (%d, %v)", n, err)
+	}
+}
+
+func TestEncryptedVirtualStreamCorrectDecryptionAndSeeking(t *testing.T) {
+	// AES block size is 16. Use a 64-byte plaintext.
+	plaintext := []byte("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
+	key := []byte("0123456789abcdef0123456789abcdef") // 32 bytes (AES-256)
+	iv := []byte("fedcba9876543210")                  // 16 bytes
+
+	// Encrypt plaintext using AES-256-CBC
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		t.Fatalf("NewCipher: %v", err)
+	}
+	ciphertext := make([]byte, len(plaintext))
+	mode := cipher.NewCBCEncrypter(block, iv)
+	mode.CryptBlocks(ciphertext, plaintext)
+
+	// Split ciphertext into two virtual parts:
+	// Part 1: virtual offsets [0, 30), file name "vol1"
+	// Part 2: virtual offsets [30, 64), file name "vol2"
+	parts := []virtualPart{
+		{
+			VirtualStart: 0,
+			VirtualEnd:   30,
+			VolFile:      &memoryUnpackableFile{name: "vol1", data: ciphertext[:30]},
+			VolOffset:    0,
+			AesKey:       key,
+			AesIV:        iv,
+		},
+		{
+			VirtualStart: 30,
+			VirtualEnd:   64,
+			VolFile:      &memoryUnpackableFile{name: "vol2", data: ciphertext[30:]},
+			VolOffset:    0,
+			AesKey:       key,
+			AesIV:        iv,
+		},
+	}
+
+	stream := NewEncryptedVirtualStream(context.Background(), parts, int64(len(plaintext)), int64(len(ciphertext)), key, iv, 0)
+	defer stream.Close()
+
+	// 1. Verify sequential Read
+	buf := make([]byte, len(plaintext))
+	if _, err := io.ReadFull(stream, buf); err != nil {
+		t.Fatalf("io.ReadFull: %v", err)
+	}
+	if !bytes.Equal(buf, plaintext) {
+		t.Fatalf("decrypted sequential output mismatch:\ngot:  %q\nwant: %q", string(buf), string(plaintext))
+	}
+
+	// 2. Verify Seek and Read (instant random-access decryption)
+	seeks := []struct {
+		offset int64
+		length int
+		want   string
+	}{
+		{offset: 0, length: 16, want: "0123456789abcdef"},
+		{offset: 16, length: 16, want: "0123456789abcdef"},
+		{offset: 32, length: 16, want: "0123456789abcdef"},
+		{offset: 48, length: 16, want: "0123456789abcdef"},
+		// Unaligned seek & read
+		{offset: 5, length: 10, want: "56789abcde"},
+		{offset: 25, length: 15, want: "9abcdef01234567"},
+		{offset: 40, length: 20, want: "89abcdef0123456789ab"},
+	}
+
+	for _, tc := range seeks {
+		if _, err := stream.Seek(tc.offset, io.SeekStart); err != nil {
+			t.Fatalf("Seek to %d: %v", tc.offset, err)
+		}
+		readBuf := make([]byte, tc.length)
+		if _, err := io.ReadFull(stream, readBuf); err != nil {
+			t.Fatalf("ReadFull at offset %d: %v", tc.offset, err)
+		}
+		if string(readBuf) != tc.want {
+			t.Errorf("at offset %d: got %q, want %q", tc.offset, string(readBuf), tc.want)
+		}
 	}
 }

--- a/pkg/media/unpack/virtual_stream_test.go
+++ b/pkg/media/unpack/virtual_stream_test.go
@@ -166,3 +166,118 @@ func TestEncryptedVirtualStreamCorrectDecryptionAndSeeking(t *testing.T) {
 		}
 	}
 }
+
+func TestVirtualStreamSeekToDifferentPartAndRead(t *testing.T) {
+	stream := NewVirtualStream(context.Background(), []virtualPart{
+		{VirtualStart: 0, VirtualEnd: 3, VolFile: &memoryUnpackableFile{name: "part1", data: []byte("abc")}},
+		{VirtualStart: 3, VirtualEnd: 7, VolFile: &memoryUnpackableFile{name: "part2", data: []byte("defg")}},
+		{VirtualStart: 7, VirtualEnd: 12, VolFile: &memoryUnpackableFile{name: "part3", data: []byte("hijkl")}},
+	}, 12, 0)
+	defer stream.Close()
+
+	if _, err := stream.Seek(4, io.SeekStart); err != nil {
+		t.Fatalf("Seek to 4 failed: %v", err)
+	}
+
+	buf := make([]byte, 5)
+	n, err := stream.Read(buf)
+	if err != nil {
+		t.Fatalf("Read failed: %v", err)
+	}
+	if n != 3 {
+		t.Fatalf("expected to read 3 bytes, got %d", n)
+	}
+	if string(buf[:n]) != "efg" {
+		t.Fatalf("expected %q, got %q", "efg", string(buf[:n]))
+	}
+
+	n, err = stream.Read(buf)
+	if err != nil {
+		t.Fatalf("Read failed: %v", err)
+	}
+	if n != 5 {
+		t.Fatalf("expected to read 5 bytes, got %d", n)
+	}
+	if string(buf[:n]) != "hijkl" {
+		t.Fatalf("expected %q, got %q", "hijkl", string(buf[:n]))
+	}
+}
+
+type seekableMemoryReader struct {
+	*bytes.Reader
+}
+
+func (s *seekableMemoryReader) Close() error { return nil }
+
+type seekableMemoryUnpackableFile struct {
+	name string
+	data []byte
+}
+
+func (f *seekableMemoryUnpackableFile) Name() string { return f.name }
+func (f *seekableMemoryUnpackableFile) Size() int64 { return int64(len(f.data)) }
+func (f *seekableMemoryUnpackableFile) EnsureSegmentMap() error { return nil }
+func (f *seekableMemoryUnpackableFile) OpenStream() (io.ReadSeekCloser, error) {
+	return &nopReadSeekCloser{Reader: bytes.NewReader(f.data)}, nil
+}
+func (f *seekableMemoryUnpackableFile) OpenStreamCtx(ctx context.Context) (io.ReadSeekCloser, error) {
+	return &nopReadSeekCloser{Reader: bytes.NewReader(f.data)}, nil
+}
+func (f *seekableMemoryUnpackableFile) OpenReaderAt(ctx context.Context, offset int64) (io.ReadCloser, error) {
+	if offset < 0 {
+		offset = 0
+	}
+	if offset > int64(len(f.data)) {
+		offset = int64(len(f.data))
+	}
+	r := bytes.NewReader(f.data)
+	_, _ = r.Seek(offset, io.SeekStart)
+	return &seekableMemoryReader{Reader: r}, nil
+}
+func (f *seekableMemoryUnpackableFile) ReadAt(p []byte, off int64) (int, error) {
+	return bytes.NewReader(f.data).ReadAt(p, off)
+}
+
+func TestVirtualStreamAbsoluteSeekInsideSamePart(t *testing.T) {
+	fileData := []byte("abcdefghijklmnopqrstuvwxyz")
+	f := &seekableMemoryUnpackableFile{name: "part1", data: fileData}
+	parts := []virtualPart{
+		{VirtualStart: 0, VirtualEnd: int64(len(fileData)), VolFile: f, VolOffset: 0},
+	}
+	stream := NewVirtualStream(context.Background(), parts, int64(len(fileData)), 0)
+	defer stream.Close()
+
+	// Read first 5 bytes ("abcde")
+	buf := make([]byte, 5)
+	if _, err := io.ReadFull(stream, buf); err != nil {
+		t.Fatalf("ReadFull: %v", err)
+	}
+	if string(buf) != "abcde" {
+		t.Fatalf("expected abcde, got %s", string(buf))
+	}
+
+	// Seek to offset 10 ("klmno...")
+	if _, err := stream.Seek(10, io.SeekStart); err != nil {
+		t.Fatalf("Seek: %v", err)
+	}
+
+	// Verify that it reads "klmno"
+	if _, err := io.ReadFull(stream, buf); err != nil {
+		t.Fatalf("ReadFull after seek: %v", err)
+	}
+	if string(buf) != "klmno" {
+		t.Fatalf("expected klmno, got %s", string(buf))
+	}
+
+	// Seek back to offset 2 ("cdefg...")
+	if _, err := stream.Seek(2, io.SeekStart); err != nil {
+		t.Fatalf("Seek back: %v", err)
+	}
+	if _, err := io.ReadFull(stream, buf); err != nil {
+		t.Fatalf("ReadFull after seek back: %v", err)
+	}
+	if string(buf) != "cdefg" {
+		t.Fatalf("expected cdefg, got %s", string(buf))
+	}
+}
+

--- a/pkg/server/stremio/handlers_failover_test.go
+++ b/pkg/server/stremio/handlers_failover_test.go
@@ -298,3 +298,38 @@ func TestIsIndexerLimitErr(t *testing.T) {
 		})
 	}
 }
+
+func TestRecoverPlaySessionAfterEvictionPrioritizesRequestedSlot(t *testing.T) {
+	initFailoverTestLogger()
+	t.Parallel()
+
+	manager := session.NewManager(nil, nil, time.Minute)
+	t.Cleanup(manager.Shutdown)
+	server := &Server{config: &config.Config{}, sessionManager: manager}
+	key := StreamSlotKey{StreamID: "stream_test", ContentType: "movie", ID: "tt123"}
+
+	server.playlistCache.Store(key.CacheKey(), &playlistCacheEntry{
+		result: &playlistResult{
+			Candidates: []triage.Candidate{
+				{Release: &release.Release{Link: "https://example.invalid/0"}},
+				{Release: &release.Release{Link: "https://example.invalid/1"}},
+				{Release: &release.Release{Link: "https://example.invalid/2"}},
+			},
+			Params: &SearchParams{ContentType: key.ContentType, ID: key.ID},
+		},
+		until: time.Now().Add(time.Minute),
+	})
+
+	// When slot index 1 is requested and is valid, recoverPlaySessionAfterEviction should try index 1 first.
+	sess, recoveredID, err := server.recoverPlaySessionAfterEviction(context.Background(), key.SlotPath(1), nil)
+	if err != nil {
+		t.Fatalf("recoverPlaySessionAfterEviction returned error: %v", err)
+	}
+	if recoveredID != key.SlotPath(1) {
+		t.Fatalf("recoveredID = %q, want %q", recoveredID, key.SlotPath(1))
+	}
+	if sess == nil || sess.ID != key.SlotPath(1) {
+		t.Fatalf("recovered session = %#v, want id %q", sess, key.SlotPath(1))
+	}
+}
+

--- a/pkg/server/stremio/handlers_playback.go
+++ b/pkg/server/stremio/handlers_playback.go
@@ -320,10 +320,10 @@ func (s *Server) bootstrapPlaylistForPlay(ctx context.Context, key StreamSlotKey
 	return list, nil
 }
 
-// recoverPlaySessionAfterEviction re-runs the /stream bootstrap and returns the first playable slot.
-// The index encoded in the requested play URL is ignored because rankings may have changed.
+// recoverPlaySessionAfterEviction re-runs the /stream bootstrap and resolves to a playable slot.
+// Prioritizes the requested slot index from sessionID, falling back sequentially and wrapping around.
 func (s *Server) recoverPlaySessionAfterEviction(ctx context.Context, sessionID string, stream *auth.Stream) (*session.Session, string, error) {
-	streamId, contentType, id, _, ok := parseStreamSlotID(sessionID)
+	streamId, contentType, id, requestedIndex, ok := parseStreamSlotID(sessionID)
 	if !ok {
 		return nil, "", fmt.Errorf("invalid slot path %q", sessionID)
 	}
@@ -334,9 +334,22 @@ func (s *Server) recoverPlaySessionAfterEviction(ctx context.Context, sessionID 
 	}
 	currentID := ""
 	currentIndex := -1
+	startAtRequested := false
+	if ok && requestedIndex < len(list.Candidates) {
+		currentIndex = requestedIndex - 1
+		startAtRequested = true
+	}
+	scannedFromStart := !startAtRequested
+
 	for {
 		nextID := s.deriveNextSlotIDFromPlaylist(currentID, key, currentIndex, list, stream)
 		if nextID == "" {
+			if !scannedFromStart {
+				scannedFromStart = true
+				currentID = ""
+				currentIndex = -1
+				continue
+			}
 			return nil, "", fmt.Errorf("no playable slot in rebuilt play list")
 		}
 		nextSess, err := s.sessionManager.GetSession(nextID)
@@ -1145,10 +1158,6 @@ func (s *Server) handlePlay(w http.ResponseWriter, r *http.Request, streamConfig
 		return
 	}
 
-	tSec, hasTimeOffset := seek.ParseTSeconds(r.URL.Query().Get("t"))
-	wantTimeOffset := r.Header.Get("Range") == "" && hasTimeOffset
-	var startupInfo seek.StreamStartInfo
-	var haveStartupInfo bool
 	streamMode := ""
 
 	var mergedCtx context.Context
@@ -1192,7 +1201,7 @@ func (s *Server) handlePlay(w http.ResponseWriter, r *http.Request, streamConfig
 		}
 
 		s.sessionManager.BeginPlaybackStartup(sessionID)
-		preparedStream, prepareErr := s.preparePlaybackStream(mergedCtx, sess, requestedSessionID, sessionID, wantTimeOffset)
+		preparedStream, prepareErr := s.preparePlaybackStream(mergedCtx, sess)
 		s.sessionManager.EndPlaybackStartup(sessionID)
 		if prepareErr != nil {
 			mergedCancel()
@@ -1243,15 +1252,26 @@ func (s *Server) handlePlay(w http.ResponseWriter, r *http.Request, streamConfig
 		stream = preparedStream.Stream
 		name = preparedStream.Spec.Name
 		size = preparedStream.Spec.Size
-		startupInfo = preparedStream.StartupInfo
-		haveStartupInfo = preparedStream.HasStartupInfo
 		streamMode = preparedStream.Mode
 		break
+	}
+	if sessionID != requestedSessionID {
+		if stream != nil {
+			stream.Close()
+		}
+		nextURL := s.baseURLWithToken(streamConfig) + "/play/" + sessionID
+		if r.URL.RawQuery != "" {
+			nextURL += "?" + r.URL.RawQuery
+		}
+		logger.Info("Redirecting client to resolved/failover slot", "from", requestedSessionID, "to", sessionID)
+		w.Header().Set("Location", nextURL)
+		w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
+		w.WriteHeader(http.StatusTemporaryRedirect)
+		return
 	}
 	defer mergedCancel()
 	servedSessionID := sessionID
 	requestedRange := r.Header.Get("Range")
-	requestedTimeOffset := r.URL.Query().Get("t")
 	userAgent := r.Header.Get("User-Agent")
 	var closeReason atomic.Value
 	var closeStreamOnce sync.Once
@@ -1270,15 +1290,10 @@ func (s *Server) handlePlay(w http.ResponseWriter, r *http.Request, streamConfig
 		closeStream("playback canceled")
 	}(mergedCtx.Done())
 
-	// After internal failover we serve a different file; don't apply the original request's Range or t= to it.
+	// After internal failover we serve a different file; don't apply the original request's Range to it.
 	failedOver := sessionID != requestedSessionID
 	if failedOver {
 		r.Header.Del("Range")
-	}
-	if !failedOver && wantTimeOffset && r.Header.Get("Range") == "" && haveStartupInfo {
-		if byteOffset, seekOK := seek.TimeToByteOffsetFromDuration(size, startupInfo.DurationSec, tSec); seekOK {
-			r.Header.Set("Range", "bytes="+strconv.FormatInt(byteOffset, 10)+"-")
-		}
 	}
 
 	clientIP, _, _ := net.SplitHostPort(r.RemoteAddr)
@@ -1365,7 +1380,6 @@ func (s *Server) handlePlay(w http.ResponseWriter, r *http.Request, streamConfig
 		"method", r.Method,
 		"requested_range", requestedRange,
 		"effective_range", effectiveRange,
-		"time_offset", requestedTimeOffset,
 		"user_agent", userAgent,
 		"client_ip", clientIP,
 		"failed_over", failedOver,
@@ -1391,7 +1405,6 @@ func (s *Server) handlePlay(w http.ResponseWriter, r *http.Request, streamConfig
 			"method", r.Method,
 			"requested_range", requestedRange,
 			"effective_range", effectiveRange,
-			"time_offset", requestedTimeOffset,
 			"user_agent", userAgent,
 			"response_status", responseStats.StatusCode,
 			"response_wrote_header", responseStats.WroteHeader,
@@ -1512,9 +1525,8 @@ type preparedPlaybackStream struct {
 // preparePlaybackStream probes with a temporary reader when startup metadata is missing,
 // then opens a fresh playback reader for the current HTTP request while caching the
 // validated playback spec/startup metadata on the session.
-func (s *Server) preparePlaybackStream(ctx context.Context, sess *session.Session, requestedSessionID, currentSessionID string, wantTimeOffset bool) (preparedPlaybackStream, error) {
+func (s *Server) preparePlaybackStream(ctx context.Context, sess *session.Session) (preparedPlaybackStream, error) {
 	preparedStream := preparedPlaybackStream{}
-	needDurationProbe := wantTimeOffset && currentSessionID == requestedSessionID
 
 	snapshot, haveSnapshot := sess.PlaybackStreamSnapshot()
 	if haveSnapshot {
@@ -1523,11 +1535,11 @@ func (s *Server) preparePlaybackStream(ctx context.Context, sess *session.Sessio
 		preparedStream.HasStartupInfo = snapshot.HasStartupInfo
 	}
 
-	needProbe := !haveSnapshot || !snapshot.HasStartupInfo || (needDurationProbe && !snapshot.StartupInfo.DurationKnown)
+	needProbe := !haveSnapshot || !snapshot.HasStartupInfo
 	if needProbe {
 		startupTimeout := s.playbackStartupTimeout()
 		probeCtx, cancel := context.WithTimeout(ctx, startupTimeout)
-		spec, startupInfo, err := s.probePlaybackSource(probeCtx, sess, needDurationProbe)
+		spec, startupInfo, err := s.probePlaybackSource(probeCtx, sess)
 		err = classifyPlaybackStartupErr("probe", startupTimeout, probeCtx, err)
 		cancel()
 		if err != nil {
@@ -1615,19 +1627,14 @@ func (s *Server) openExpectedPlaybackSource(ctx context.Context, sess *session.S
 
 // probePlaybackSource validates the selected media and gathers startup metadata using
 // a disposable probe reader so that small scans never disturb the session body stream.
-func (s *Server) probePlaybackSource(ctx context.Context, sess *session.Session, needDurationProbe bool) (session.PlaybackStreamSpec, seek.StreamStartInfo, error) {
+func (s *Server) probePlaybackSource(ctx context.Context, sess *session.Session) (session.PlaybackStreamSpec, seek.StreamStartInfo, error) {
 	probeStream, probeName, probeSize, err := s.openPlaybackSource(ctx, sess)
 	if err != nil {
 		return session.PlaybackStreamSpec{}, seek.StreamStartInfo{}, err
 	}
 	defer probeStream.Close()
 
-	inspectBytes := unpack.ProbeSize
-	if needDurationProbe && seek.MaxBytesToRead > inspectBytes {
-		inspectBytes = seek.MaxBytesToRead
-	}
-
-	startInfo, inspectErr := seek.InspectStreamStart(probeStream, probeSize, probeName, inspectBytes)
+	startInfo, inspectErr := seek.InspectStreamStart(probeStream, probeSize, probeName, unpack.ProbeSize)
 	if inspectErr != nil {
 		return session.PlaybackStreamSpec{}, seek.StreamStartInfo{}, fmt.Errorf("probe inspect: %w", inspectErr)
 	}
@@ -2506,16 +2513,6 @@ func (s *Server) handleDebugPlay(w http.ResponseWriter, r *http.Request, streamC
 		<-done
 		closeStream("playback canceled")
 	}(mergedCtx.Done())
-
-	if tStr := r.URL.Query().Get("t"); tStr != "" && r.Header.Get("Range") == "" {
-		if tSec, parseOK := seek.ParseTSeconds(tStr); parseOK {
-			if startInfo, err := seek.InspectStreamStart(stream, size, name, seek.MaxBytesToRead); err == nil {
-				if byteOffset, seekOK := seek.TimeToByteOffsetFromDuration(size, startInfo.DurationSec, tSec); seekOK {
-					r.Header.Set("Range", "bytes="+strconv.FormatInt(byteOffset, 10)+"-")
-				}
-			}
-		}
-	}
 
 	clientIP, _, _ := net.SplitHostPort(r.RemoteAddr)
 	if clientIP == "" {

--- a/pkg/server/stremio/handlers_playback.go
+++ b/pkg/server/stremio/handlers_playback.go
@@ -1632,6 +1632,15 @@ func (s *Server) probePlaybackSource(ctx context.Context, sess *session.Session,
 		return session.PlaybackStreamSpec{}, seek.StreamStartInfo{}, fmt.Errorf("probe inspect: %w", inspectErr)
 	}
 	if !startInfo.HeaderValid {
+		if peek, err := readProbePrefix(probeStream, 16); err == nil && len(peek) > 0 {
+			logger.Debug("Probe rejected container header",
+				"session", sess.ID,
+				"name", probeName,
+				"size", probeSize,
+				"prefix_hex", fmt.Sprintf("% x", peek),
+				"encrypted_blueprint", blueprintAnyEncrypted(sess),
+				"password_len", nzbPasswordLen(sess))
+		}
 		return session.PlaybackStreamSpec{}, seek.StreamStartInfo{}, fmt.Errorf("probe: invalid container header for %s", probeName)
 	}
 
@@ -1653,6 +1662,38 @@ func cacheReturnedPlaybackBlueprint(sess *session.Session, bp interface{}) {
 		return
 	}
 	sess.SetBlueprint(bp)
+}
+
+func readProbePrefix(stream io.ReadSeeker, n int) ([]byte, error) {
+	if _, err := stream.Seek(0, io.SeekStart); err != nil {
+		return nil, err
+	}
+	buf := make([]byte, n)
+	got, err := io.ReadFull(stream, buf)
+	if err != nil && !errors.Is(err, io.ErrUnexpectedEOF) && err != io.EOF {
+		return buf[:got], err
+	}
+	if _, err := stream.Seek(0, io.SeekStart); err != nil {
+		return buf[:got], err
+	}
+	return buf[:got], nil
+}
+
+func blueprintAnyEncrypted(sess *session.Session) bool {
+	if sess == nil || sess.Blueprint == nil {
+		return false
+	}
+	if bp, ok := sess.Blueprint.(*unpack.ArchiveBlueprint); ok {
+		return bp.AnyEncrypted
+	}
+	return false
+}
+
+func nzbPasswordLen(sess *session.Session) int {
+	if sess == nil || sess.NZB == nil {
+		return 0
+	}
+	return len(sess.NZB.Password())
 }
 
 // openPlaybackSource opens a fresh reader for the currently selected playback source.

--- a/third_party/rardecode/bufio.go
+++ b/third_party/rardecode/bufio.go
@@ -83,6 +83,7 @@ func (br *bufVolumeReader) seek(offset int64) error {
 	br.i = 0
 	br.n = 0
 	br.off = offset
+	br.err = nil
 	return nil
 }
 
@@ -254,6 +255,7 @@ func (br *bufVolumeReader) Reset(r io.Reader) error {
 	br.i = 0
 	br.n = 0
 	br.off = 0
+	br.err = nil
 	ver, err := br.findSig()
 	if err != nil {
 		if errors.Is(err, io.EOF) {

--- a/third_party/rardecode/reader.go
+++ b/third_party/rardecode/reader.go
@@ -202,6 +202,27 @@ type packedFileReader struct {
 	blocks     *fileBlockList
 	opt        *options
 	peekedNext *fileBlockHeader
+	exhausted  bool
+}
+
+// isListEndOfData reports whether err means the current (available) volume data ended.
+// Used in tolerant listing to return a split file discovered in the mounted volume(s).
+//
+// ErrBadHeaderCRC / ErrCorruptBlockHeader are tolerated here as well: when only the
+// first volume of a multi-volume set is mounted, a file whose data block continues
+// into a sibling volume can leave a trailing region that rardecode tries to parse as
+// the next block header. Without the continuation volume those bytes are not a valid
+// header and fail the CRC check. Since the file entry we care about has already been
+// recorded (guarded by len(blocks) > 0 at the call sites), treat this as the end of
+// the available data rather than aborting discovery.
+func isListEndOfData(err error) bool {
+	return err == io.EOF ||
+		err == errVolumeOrArchiveEnd ||
+		err == io.ErrUnexpectedEOF ||
+		err == ErrUnexpectedArcEnd ||
+		err == ErrBadHeaderCRC ||
+		err == ErrCorruptBlockHeader ||
+		errors.Is(err, fs.ErrNotExist)
 }
 
 func (f *packedFileReader) init(blocks *fileBlockList) error {
@@ -248,12 +269,19 @@ func (f *packedFileReader) nextBlock() error {
 }
 
 func (f *packedFileReader) nextFile() (*fileBlockList, error) {
+	if f.exhausted {
+		return nil, io.EOF
+	}
 
 	var err error
 	for err == nil {
 		err = f.nextBlock()
 	}
 	if err != io.EOF {
+		if f.opt != nil && f.opt.listTolerant && f.blocks != nil && len(f.blocks.blocks) > 0 && isListEndOfData(err) {
+			f.exhausted = true
+			return f.blocks, nil
+		}
 		return nil, err
 	}
 
@@ -282,8 +310,15 @@ func (f *packedFileReader) nextFile() (*fileBlockList, error) {
 	}
 
 	for !f.h.last {
+		if f.opt != nil && f.opt.streamLazyVolumes {
+			break
+		}
 		nextH, err := f.v.nextBlock()
 		if err != nil {
+			if f.opt != nil && f.opt.listTolerant && len(blocks.blocks) > 0 && isListEndOfData(err) {
+				f.exhausted = true
+				return blocks, nil
+			}
 			if err == io.EOF || err == errVolumeOrArchiveEnd {
 
 				return nil, ErrUnexpectedArcEnd

--- a/third_party/rardecode/volume.go
+++ b/third_party/rardecode/volume.go
@@ -40,6 +40,8 @@ type options struct {
 	skipVolumeCheck      bool
 	openCheck            bool
 	parallelRead         bool
+	listTolerant         bool
+	streamLazyVolumes    bool
 	maxConcurrentVolumes int
 }
 
@@ -70,6 +72,16 @@ func OpenFSCheck(o *options) { o.openCheck = true }
 func ParallelRead(enable bool) Option {
 	return func(o *options) { o.parallelRead = enable }
 }
+
+// ListTolerant makes listing return a split file found in the available volume(s)
+// instead of failing when continuation volumes are missing. Intended for listing
+// a single first volume of a multi-volume set to discover file names/layout.
+func ListTolerant(o *options) { o.listTolerant = true }
+
+// StreamLazyVolumes defers opening continuation volumes until their packed data is
+// read. Use when streaming a split file across many volumes so Next() does not
+// have to scan every volume before the first Read.
+func StreamLazyVolumes(o *options) { o.streamLazyVolumes = true }
 
 func MaxConcurrentVolumes(n int) Option {
 	return func(o *options) { o.maxConcurrentVolumes = n }


### PR DESCRIPTION
…s for multi-volume STORE RARs

- Introduce `EncryptedVirtualStream` for stateless, random-access AES-CBC decryption using the preceding ciphertext block as the IV.
- Fix a critical bug where continuation volume data offsets beyond the second volume were reset to 0, causing payload shifts and decryption corruption.
- Optimize playback seeking latency by skipping segment gap-probing during active streaming.
- Prevent byte-loss on dot-unstuffed yEnc streams by rewriting line-leading data dots to escape codes and normalizing line endings to CRLF.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed yEnc decoding with bare-LF/CRLF and leading-dot edge cases to prevent byte-loss.
  * Prevented advancing past mapped segment ends and improved short-segment error reporting.

* **New Features**
  * Encrypted RAR support with AES-CBC streaming decryption.
  * Parallel segment-probing and playback read-ahead for faster, more reliable playback.

* **Tests**
  * Extensive regression and unit tests covering yEnc, segment probing, virtual/encrypted streams, RAR probing, and playback recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->