### PR TITLE
fix(filters): make profiles global and persist attribute resets

### DIFF
--- a/frontend/src/components/FiltersPage.jsx
+++ b/frontend/src/components/FiltersPage.jsx
@@ -150,14 +150,6 @@ export function FiltersPage({ config, onSave, isSaving, saveStatus }) {
     commit(next)
   }
 
-  const toggleKind = (kind) => {
-    const current = draft.applies_to || []
-    setDraft({
-      ...draft,
-      applies_to: current.includes(kind) ? current.filter((k) => k !== kind) : [...current, kind],
-    })
-  }
-
   return (
     <div className="space-y-6">
       <div className="flex flex-wrap items-start justify-between gap-3">
@@ -223,15 +215,6 @@ export function FiltersPage({ config, onSave, isSaving, saveStatus }) {
                       </span>
                     : <span className="text-muted-foreground/70">Not in use</span>}
                 </div>
-                {profile.applies_to?.length > 0 && (
-                  <div className="mt-1.5 flex flex-wrap gap-1">
-                    {profile.applies_to.map((kind) => (
-                      <Badge key={kind} variant="secondary" className="text-[10px]">
-                        {CONTENT_KINDS.find((k) => k.key === kind)?.label || kind}
-                      </Badge>
-                    ))}
-                  </div>
-                )}
               </button>
             ))}
           </div>
@@ -241,7 +224,7 @@ export function FiltersPage({ config, onSave, isSaving, saveStatus }) {
               <Card className="border border-border bg-card">
                 <CardHeader className="pb-3">
                   <CardTitle className="text-base font-semibold">Profile</CardTitle>
-                  <CardDescription>Give it a name and choose what it applies to.</CardDescription>
+                  <CardDescription>Give it a name, then assign it to a stream from the Streams page.</CardDescription>
                 </CardHeader>
                 <CardContent className="space-y-4">
                   <div className="space-y-1.5">
@@ -252,33 +235,6 @@ export function FiltersPage({ config, onSave, isSaving, saveStatus }) {
                       onChange={(e) => { setDraft({ ...draft, name: e.target.value }); setNameError("") }}
                     />
                     {nameError && <p className="text-xs text-destructive">{nameError}</p>}
-                  </div>
-
-                  <div className="space-y-1.5">
-                    <Label>Applies to</Label>
-                    <p className="text-xs text-muted-foreground">
-                      Leave these off to use this profile for anything.
-                    </p>
-                    <div className="flex flex-wrap gap-2 pt-1">
-                      {CONTENT_KINDS.map((kind) => {
-                        const on = (draft.applies_to || []).includes(kind.key)
-                        return (
-                          <button
-                            key={kind.key}
-                            type="button"
-                            onClick={() => toggleKind(kind.key)}
-                            className={cn(
-                              "rounded-md border px-3 py-1.5 text-xs transition-colors",
-                              on
-                                ? "border-primary/40 bg-primary/10 text-foreground"
-                                : "border-border text-muted-foreground hover:text-foreground"
-                            )}
-                          >
-                            {kind.label}
-                          </button>
-                        )
-                      })}
-                    </div>
                   </div>
 
                   <div className="flex flex-wrap items-center gap-2 pt-1">

--- a/frontend/src/components/StreamManagement.jsx
+++ b/frontend/src/components/StreamManagement.jsx
@@ -3,7 +3,7 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Switch } from "@/components/ui/switch"
-import { CONTENT_KINDS, eligibleProfiles } from "@/lib/profiles"
+import { CONTENT_KINDS } from "@/lib/profiles"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, focusDialogCloseButton } from "@/components/ui/dialog"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
@@ -578,17 +578,16 @@ function StreamDialog({
                   Apply a predefined stream mode (like AIOStreams) or select a filter profile to decide which releases this stream offers.
                 </p>
 
-                {(filterProfiles || []).length > 0 && (
+                {/* AIOStreams returns every release for AIOStreams itself to filter, so
+                    per-content-type profiles have nothing to act on and are hidden. */}
+                {!aiostreamsMode && (filterProfiles || []).length > 0 && (
                   <div className="mt-4 space-y-2 border-t border-border/60 pt-3">
                     <div className="text-sm font-medium">By content type</div>
                     <p className="text-sm text-muted-foreground">
-                      {draft.filter_sorting_mode === 'aiostreams'
-                        ? 'AIOStreams mode returns every release and lets AIOStreams filter them, so profiles are not applied. Switch Filter/Sorting off AIOStreams to use them.'
-                        : 'Override the profile above for a specific kind of content. Anything left on Default uses the profile selected above. Anime means animation that is not originally in English, which needs TMDB configured to detect outside of Kitsu catalogues.'}
+                      Override the profile above for a specific kind of content. Anything left on Default uses the profile selected above. Anime means animation that is not originally in English, which needs TMDB configured to detect outside of Kitsu catalogues.
                     </p>
-                    <div className={`grid gap-2 pt-1 sm:grid-cols-2 ${draft.filter_sorting_mode === 'aiostreams' ? 'opacity-50' : ''}`}>
+                    <div className="grid gap-2 pt-1 sm:grid-cols-2">
                       {CONTENT_KINDS.map((kind) => {
-                        const options = eligibleProfiles(filterProfiles || [], kind.key)
                         const current = draft.filter_profile_by_type?.[kind.key] || ''
                         const setKind = (name) => setDraft((prev) => {
                           const next = { ...(prev.filter_profile_by_type || {}) }
@@ -601,19 +600,14 @@ function StreamDialog({
                             <span className="text-sm text-muted-foreground">{kind.label}</span>
                             <DropdownMenu>
                               <DropdownMenuTrigger asChild>
-                                <Button
-                                  type="button"
-                                  variant="outline"
-                                  disabled={draft.filter_sorting_mode === 'aiostreams'}
-                                  className="h-8 w-44 justify-between"
-                                >
+                                <Button type="button" variant="outline" className="h-8 w-44 justify-between">
                                   <span className="truncate text-xs">{current || 'Default'}</span>
                                   <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
                                 </Button>
                               </DropdownMenuTrigger>
                               <DropdownMenuContent align="end" className="w-44 max-h-60 overflow-y-auto">
                                 <DropdownMenuItem onClick={() => setKind('')}>Default</DropdownMenuItem>
-                                {options.map((fp) => (
+                                {(filterProfiles || []).map((fp) => (
                                   <DropdownMenuItem key={fp.name} onClick={() => setKind(fp.name)}>
                                     {fp.name}
                                   </DropdownMenuItem>

--- a/frontend/src/lib/profiles.js
+++ b/frontend/src/lib/profiles.js
@@ -239,7 +239,6 @@ export const SORT_KEYS = [
   { key: "grabs", label: "Grabs", hint: "Most grabbed first" },
 ]
 
-// Content kinds partition every request, so exactly one profile ever applies.
 // Common weighted patterns, so the usual preferences do not need a regex.
 // These match on the release name, which is the only place they appear.
 export const PATTERN_PRESETS = [
@@ -251,18 +250,14 @@ export const PATTERN_PRESETS = [
   { label: "Hardcoded subs", pattern: "\\bHC\\b|\\bHardsub", rank: -3000 },
 ]
 
+// Content kinds partition every request, so exactly one profile ever applies.
+// A profile itself is global; a stream picks which one each kind uses.
 export const CONTENT_KINDS = [
   { key: "movie", label: "Movies" },
   { key: "series", label: "Shows" },
   { key: "anime_movie", label: "Anime films" },
   { key: "anime_show", label: "Anime shows" },
 ]
-
-// eligibleProfiles returns the profiles offered for a kind. An untagged
-// profile is offered everywhere.
-export function eligibleProfiles(profiles = [], kind) {
-  return profiles.filter((p) => !p.applies_to?.length || p.applies_to.includes(kind))
-}
 
 // The traits a new profile rejects, matching defaultBlockedAttrs in
 // pkg/core/config/filterprofile.go: the CAM-class rips, the fake audio dubbed
@@ -331,7 +326,6 @@ export function defaultProfile(name = "New Profile") {
   return {
     name,
     ranking: defaultRankProfile(name),
-    applies_to: [],
     sort_order: ["resolution", "rank", "size", "age"],
   }
 }

--- a/pkg/core/config/config.go
+++ b/pkg/core/config/config.go
@@ -112,10 +112,6 @@ type FilterProfileConfig struct {
 	// migration, in which case it is synthesized from the legacy fields on load.
 	Ranking *rank.Profile `json:"ranking,omitempty"`
 
-	// AppliesTo restricts this profile to certain content: "movie", "series",
-	// "anime". Empty means it is selectable for anything.
-	AppliesTo []string `json:"applies_to,omitempty"`
-
 	AllowedResolutions []string `json:"allowed_resolutions,omitempty"`
 	BlockedResolutions []string `json:"blocked_resolutions,omitempty"`
 	AllowedQualities   []string `json:"allowed_qualities,omitempty"`

--- a/pkg/server/api/handlers_config.go
+++ b/pkg/server/api/handlers_config.go
@@ -98,6 +98,7 @@ func (s *Server) handlePutConfig(w http.ResponseWriter, r *http.Request) {
 		s.writeSaveStatus(w, "error", "Failed to prepare config update", nil)
 		return
 	}
+	clearPatchedFilterProfiles(body, &newCfg)
 	if err := json.Unmarshal(body, &newCfg); err != nil {
 		s.writeSaveStatus(w, "error", "Invalid config data", nil)
 		return

--- a/pkg/server/api/websocket.go
+++ b/pkg/server/api/websocket.go
@@ -237,6 +237,7 @@ func (s *Server) handleSaveConfigWS(conn *websocket.Conn, client *Client, payloa
 			trySendWS(client, WSMessage{Type: "save_status", Payload: json.RawMessage(`{"status":"error","message":"Failed to prepare config update"}`)})
 			return
 		}
+		clearPatchedFilterProfiles(payload, &newCfg)
 		if err := json.Unmarshal(payload, &newCfg); err != nil {
 			trySendWS(client, WSMessage{Type: "save_status", Payload: json.RawMessage(`{"status":"error","message":"Invalid config data"}`)})
 			return
@@ -776,6 +777,28 @@ func fullConfigValidationPlan() configValidationPlan {
 		validateTVDBAPIKey:             true,
 		validateSpeculativePreProbing:  true,
 		validateFilterProfiles:         true,
+	}
+}
+
+// clearPatchedFilterProfiles empties the filter profiles a save is about to
+// replace, so the patch lands on a clean slate.
+//
+// A save is applied by seeding the config from the current one and unmarshalling
+// the patch over it. encoding/json merges rather than replaces: decoding into a
+// non-nil map keeps the entries the patch does not mention. A profile's
+// attribute overrides are such a map, so resetting a trait back to its default —
+// which drops its key — left the old override in place and the reset never
+// stuck. Nil-ing the slice first makes the patch authoritative.
+func clearPatchedFilterProfiles(body []byte, cfg *config.Config) {
+	if len(body) == 0 || cfg == nil {
+		return
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return
+	}
+	if _, ok := raw["filter_profiles"]; ok {
+		cfg.FilterProfiles = nil
 	}
 }
 

--- a/pkg/server/api/websocket_test.go
+++ b/pkg/server/api/websocket_test.go
@@ -407,3 +407,62 @@ func TestValidateConfigTMDBAndTVDBAPIKeys(t *testing.T) {
 		t.Fatalf("expected empty keys to pass, got errors: %#v", errs)
 	}
 }
+
+// Resetting a trait back to its default drops its key from the profile's
+// attribute map. The save path unmarshals the patch over the current config, and
+// encoding/json keeps map entries the patch does not mention, so without
+// clearPatchedFilterProfiles the removed override would survive the round trip.
+func TestClearPatchedFilterProfilesDropsResetAttribute(t *testing.T) {
+	current := &config.Config{FilterProfiles: []config.FilterProfileConfig{config.DefaultFilterProfile()}}
+	currentJSON, err := json.Marshal(current)
+	if err != nil {
+		t.Fatalf("marshal current: %v", err)
+	}
+
+	// The UI sends the profile back with "cam" reset to its default.
+	profile := config.DefaultFilterProfile()
+	attrs := map[string]any{}
+	rawAttrs, err := json.Marshal(profile.Ranking.Attributes)
+	if err != nil {
+		t.Fatalf("marshal attributes: %v", err)
+	}
+	if err := json.Unmarshal(rawAttrs, &attrs); err != nil {
+		t.Fatalf("unmarshal attributes: %v", err)
+	}
+	delete(attrs, "cam")
+
+	body, err := json.Marshal(map[string]any{
+		"filter_profiles": []map[string]any{{
+			"name":    profile.Name,
+			"ranking": map[string]any{"name": profile.Name, "attributes": attrs},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+
+	var newCfg config.Config
+	if err := json.Unmarshal(currentJSON, &newCfg); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+	clearPatchedFilterProfiles(body, &newCfg)
+	if err := json.Unmarshal(body, &newCfg); err != nil {
+		t.Fatalf("apply patch: %v", err)
+	}
+
+	if len(newCfg.FilterProfiles) != 1 {
+		t.Fatalf("expected 1 filter profile, got %d", len(newCfg.FilterProfiles))
+	}
+	if _, still := newCfg.FilterProfiles[0].Ranking.Attributes["cam"]; still {
+		t.Fatal("reset attribute survived the patch")
+	}
+}
+
+// A save that does not mention filter profiles must leave them untouched.
+func TestClearPatchedFilterProfilesLeavesUnrelatedPatchAlone(t *testing.T) {
+	cfg := &config.Config{FilterProfiles: []config.FilterProfileConfig{config.DefaultFilterProfile()}}
+	clearPatchedFilterProfiles([]byte(`{"keep_log_files":9}`), cfg)
+	if len(cfg.FilterProfiles) != 1 {
+		t.Fatalf("expected filter profiles preserved, got %d", len(cfg.FilterProfiles))
+	}
+}


### PR DESCRIPTION
Three fixes to filter profiles.

## Profiles are global

A profile carried an `applies_to` tag restricting it to certain content types. This duplicated the per-content-type profile bindings a stream already has, so a profile had to be tagged for a type *and* selected for it. Removed the tag — every profile is now offered for all four content types, and the stream decides which one each type uses.

Existing configs need no migration: `applies_to` is simply dropped on the next save, and the stream bindings that actually drive the behaviour are untouched.

## Per-content-type selection under AIOStreams

AIOStreams mode returns every release unfiltered and never applies a profile. The selection was shown dimmed and disabled with an explanatory note; it is now hidden.

## Attribute resets did not save

Resetting a trait to its default silently did nothing, while blocking it with the switch saved fine.

A save seeds the new config from the current one and unmarshals the patch over it:

```go
json.Unmarshal(currentJSON, &newCfg)  // seed
json.Unmarshal(body, &newCfg)         // overlay
```

`encoding/json` merges into a non-nil destination — decoding an object into an existing map keeps entries the patch does not mention. The reset button drops the attribute key, so the old override survived. The switch writes an explicit `{fetch:false}`, which overwrites, which is why that path worked.

Fixed by clearing the profiles before the patch is applied, on both the HTTP and WebSocket save paths. Scoped to `filter_profiles` since that is the reported bug; the same merge semantics apply to other collections if that ever needs generalising.

## Testing

- Reproduced the save bug in a failing test first, then confirmed the fix. Two regression tests added.
- Full suite passes, `go vet` and eslint clean.
- Verified against a real server running a copy of a production config: resets persist to disk, `applies_to` no longer round-trips, and rename/delete/toggle still behave (rename correctly propagates to the stream binding).
- UI verified by hand.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Profiles are now assigned to streams through the Streams page, simplifying profile setup.
  - Stream filter and sorting controls provide clearer profile selection by content type.
  - Profile options are presented consistently across stream configuration views.

- **Bug Fixes**
  - Configuration updates now reliably apply profile changes and resets without retaining outdated settings.
  - Removed profile applicability labels and controls that could cause confusing or inconsistent assignments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->