### PR TITLE
feat(probe): read track languages and counts from ffprobe

### DIFF
--- a/docs/result-formatting.md
+++ b/docs/result-formatting.md
@@ -25,7 +25,7 @@ release's parsed data.
 |---|---|
 | Request | `.Service` `.Stream` `.Content` `.Index` `.Count` `.TopScore` `.Kind` `.IsAnime` |
 | Release | `.ReleaseTitle` `.Size` `.Indexer` `.Variants` `.VariantIndexers` `.Grabs` `.Age` `.Duration` `.Score` `.Avail` `.Library` `.Caps` `.MatchedRules` |
-| Measured | `.Verified` `.Probed.VideoCodec` `.Probed.AudioCodec` `.Probed.Width` `.Probed.Height` `.Probed.Profile` `.Probed.BitDepth` `.Probed.HDR` `.Probed.DolbyVision` `.Probed.HasHDRFallback` `.Probed.DynamicRange` |
+| Measured | `.Verified` `.Probed.VideoCodec` `.Probed.AudioCodec` `.Probed.Width` `.Probed.Height` `.Probed.Profile` `.Probed.BitDepth` `.Probed.HDR` `.Probed.DolbyVision` `.Probed.HasHDRFallback` `.Probed.DynamicRange` `.Probed.AudioLanguages` `.Probed.SubtitleLanguages` `.Probed.AudioStreams` `.Probed.SubtitleStreams` |
 | Availability | `.Availability.Status` `.Availability.Known` `.Availability.OnMyBackbone` `.Availability.CheckedDaysAgo` `.Availability.Compression` |
 | SeaDex | `.Seadex.Checked` `.Seadex.Known` `.Seadex.Best` `.Seadex.Alternative` |
 | Parsed | `.ParsedTitle` `.Year` `.Date` `.Resolution` `.Quality` `.Codec` `.BitDepth` `.Bitrate` `.Container` `.Extension` `.Group` `.Edition` `.Network` `.Site` `.Country` `.Region` `.Audio` `.Channels` `.HDR` `.Languages` |
@@ -105,6 +105,17 @@ an HDR10 base layer is tellable apart from one without — the difference betwee
 a file that looks right on a non-DV TV and one that does not.
 `.Probed.HasHDRFallback` answers that directly, and `.Probed.DynamicRange`
 renders it as `DV + HDR10`, `DV only`, `HDR10`, or empty for SDR.
+
+`.Probed.AudioLanguages` and `.Probed.SubtitleLanguages` are the tagged track
+languages as ISO 639-1 codes, the same codes `.Languages` holds, so one
+template line covers both the claimed and the measured case:
+
+```
+{{if .Verified}}⛿ {{join .Probed.AudioLanguages " · " | upper}}{{else}}⛿ {{join .Languages " · " | upper}}{{end}}
+```
+
+`.Probed.AudioStreams` and `.Probed.SubtitleStreams` count tracks whether or
+not they carry a tag.
 
 ### Availability
 

--- a/docs/result-formatting.md
+++ b/docs/result-formatting.md
@@ -107,13 +107,14 @@ a file that looks right on a non-DV TV and one that does not.
 renders it as `DV + HDR10`, `DV only`, `HDR10`, or empty for SDR.
 
 `.Probed.AudioLanguages` and `.Probed.SubtitleLanguages` are the tagged track
-languages as ISO 639-1 codes, the same codes `.Languages` holds. Guard them
-with `.Probed.TracksProbed` rather than `.Verified`: a library item probed
-before the tracks were captured is verified and has none, and should fall
-back to what the name claims. One line then covers both cases:
+languages as ISO 639-1 codes, the same codes `.Languages` holds. Guard on the
+list itself rather than on `.Verified`: a library item probed before the
+tracks were captured is verified and has none, and a probed file whose muxer
+tagged nothing has an empty list — both should fall back to what the name
+claims rather than print a bare marker. One line then covers every case:
 
 ```
-{{if .Probed.TracksProbed}}⛿ {{join .Probed.AudioLanguages " · " | upper}}{{else}}⛿ {{join .Languages " · " | upper}}{{end}}
+{{if .Probed.AudioLanguages}}⛿ {{join .Probed.AudioLanguages " · " | upper}}{{else if .Languages}}⛿ {{join .Languages " · " | upper}}{{end}}
 ```
 
 `.Probed.AudioStreams` and `.Probed.SubtitleStreams` count tracks whether or

--- a/docs/result-formatting.md
+++ b/docs/result-formatting.md
@@ -25,7 +25,7 @@ release's parsed data.
 |---|---|
 | Request | `.Service` `.Stream` `.Content` `.Index` `.Count` `.TopScore` `.Kind` `.IsAnime` |
 | Release | `.ReleaseTitle` `.Size` `.Indexer` `.Variants` `.VariantIndexers` `.Grabs` `.Age` `.Duration` `.Score` `.Avail` `.Library` `.Caps` `.MatchedRules` |
-| Measured | `.Verified` `.Probed.VideoCodec` `.Probed.AudioCodec` `.Probed.Width` `.Probed.Height` `.Probed.Profile` `.Probed.BitDepth` `.Probed.HDR` `.Probed.DolbyVision` `.Probed.HasHDRFallback` `.Probed.DynamicRange` `.Probed.AudioLanguages` `.Probed.SubtitleLanguages` `.Probed.AudioStreams` `.Probed.SubtitleStreams` |
+| Measured | `.Verified` `.Probed.VideoCodec` `.Probed.AudioCodec` `.Probed.Width` `.Probed.Height` `.Probed.Profile` `.Probed.BitDepth` `.Probed.HDR` `.Probed.DolbyVision` `.Probed.HasHDRFallback` `.Probed.DynamicRange` `.Probed.TracksProbed` `.Probed.AudioLanguages` `.Probed.SubtitleLanguages` `.Probed.AudioStreams` `.Probed.SubtitleStreams` |
 | Availability | `.Availability.Status` `.Availability.Known` `.Availability.OnMyBackbone` `.Availability.CheckedDaysAgo` `.Availability.Compression` |
 | SeaDex | `.Seadex.Checked` `.Seadex.Known` `.Seadex.Best` `.Seadex.Alternative` |
 | Parsed | `.ParsedTitle` `.Year` `.Date` `.Resolution` `.Quality` `.Codec` `.BitDepth` `.Bitrate` `.Container` `.Extension` `.Group` `.Edition` `.Network` `.Site` `.Country` `.Region` `.Audio` `.Channels` `.HDR` `.Languages` |
@@ -107,11 +107,13 @@ a file that looks right on a non-DV TV and one that does not.
 renders it as `DV + HDR10`, `DV only`, `HDR10`, or empty for SDR.
 
 `.Probed.AudioLanguages` and `.Probed.SubtitleLanguages` are the tagged track
-languages as ISO 639-1 codes, the same codes `.Languages` holds, so one
-template line covers both the claimed and the measured case:
+languages as ISO 639-1 codes, the same codes `.Languages` holds. Guard them
+with `.Probed.TracksProbed` rather than `.Verified`: a library item probed
+before the tracks were captured is verified and has none, and should fall
+back to what the name claims. One line then covers both cases:
 
 ```
-{{if .Verified}}⛿ {{join .Probed.AudioLanguages " · " | upper}}{{else}}⛿ {{join .Languages " · " | upper}}{{end}}
+{{if .Probed.TracksProbed}}⛿ {{join .Probed.AudioLanguages " · " | upper}}{{else}}⛿ {{join .Languages " · " | upper}}{{end}}
 ```
 
 `.Probed.AudioStreams` and `.Probed.SubtitleStreams` count tracks whether or

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -393,7 +393,10 @@ stream order. They answer what a release name only claims: a title tagged
 `DUAL` says nothing about which two, the tracks say `["ja", "en"]`. Not every
 muxer tags its tracks, so `probed.audioStreams` and `probed.subtitleStreams`
 count them regardless — `probed.audioStreams >= 2` is dual audio even when the
-language list is empty.
+language list is empty. The four carry their own tier: a library item probed
+before they were captured has codec and HDR measurements but nothing about
+its tracks, and a rule reading them is skipped for it rather than judged
+against an empty list.
 
 ```
 "ja" in probed.audioLanguages and "en" in probed.audioLanguages   → +800

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -379,12 +379,27 @@ attributes. Answers are cached for a day. The base URL can be overridden with
 
 `probed.height` `probed.width` `probed.videoCodec` `probed.audioCodec`
 `probed.profile` `probed.bitDepth` `probed.hdr` `probed.dolbyVision`
-`probed.hasHDRFallback` `probed.dynamicRange`
+`probed.hasHDRFallback` `probed.dynamicRange` `probed.audioLanguages`
+`probed.subtitleLanguages` `probed.audioStreams` `probed.subtitleStreams`
 
 Only library releases have ever been opened, so these are only populated for
 them. `probed.hdr` is the base layer (`"HDR10"`, `"HDR10+"`, `"HLG"`, or empty)
 and `probed.dolbyVision` is independent of it — that pair is what makes
 "Dolby Vision with no fallback" a measurement rather than a guess.
+
+`probed.audioLanguages` and `probed.subtitleLanguages` are the languages the
+tracks are tagged with, as the same ISO 639-1 codes `languages` uses, in
+stream order. They answer what a release name only claims: a title tagged
+`DUAL` says nothing about which two, the tracks say `["ja", "en"]`. Not every
+muxer tags its tracks, so `probed.audioStreams` and `probed.subtitleStreams`
+count them regardless — `probed.audioStreams >= 2` is dual audio even when the
+language list is empty.
+
+```
+"ja" in probed.audioLanguages and "en" in probed.audioLanguages   → +800
+probed.audioStreams >= 2                                          → +400
+"ar" in probed.subtitleLanguages                                  → +300
+```
 
 ### Traits
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -392,15 +392,19 @@ tracks are tagged with, as the same ISO 639-1 codes `languages` uses, in
 stream order. They answer what a release name only claims: a title tagged
 `DUAL` says nothing about which two, the tracks say `["ja", "en"]`. Not every
 muxer tags its tracks, so `probed.audioStreams` and `probed.subtitleStreams`
-count them regardless — `probed.audioStreams >= 2` is dual audio even when the
-language list is empty. The four carry their own tier: a library item probed
+count them regardless. A count is not a language claim, though: a
+single-language file routinely carries two audio streams — a commentary, or a
+5.1 track beside a stereo downmix — so "dual audio" is
+`len(probed.audioLanguages) >= 2`, and `probed.audioStreams` is for what the
+count itself says (a file with no audio at all, an untagged mux you still want
+ranked by track count). The four carry their own tier: a library item probed
 before they were captured has codec and HDR measurements but nothing about
 its tracks, and a rule reading them is skipped for it rather than judged
 against an empty list.
 
 ```
 "ja" in probed.audioLanguages and "en" in probed.audioLanguages   → +800
-probed.audioStreams >= 2                                          → +400
+len(probed.audioLanguages) >= 2                                   → +400
 "ar" in probed.subtitleLanguages                                  → +300
 ```
 

--- a/frontend/src/components/ResultFormatEditor.jsx
+++ b/frontend/src/components/ResultFormatEditor.jsx
@@ -36,7 +36,7 @@ const FORMAT_FIELDS = [
   { group: 'Episode', fields: ['.Season', '.Episode', '.Seasons', '.Episodes', '.EpisodeCode', '.Volumes'] },
   { group: 'Flags', fields: ['.Proper', '.Repack', '.Remastered', '.Upscaled', '.ThreeD', '.Scene', '.Retail', '.Hardcoded', '.Dubbed', '.Subbed', '.Commentary', '.Complete', '.Documentary', '.Unrated', '.Uncensored', '.PPV'] },
   { group: 'Kind', fields: ['.Kind', '.IsAnime'] },
-  { group: 'Probed', fields: ['.Verified', '.Probed.VideoCodec', '.Probed.AudioCodec', '.Probed.Width', '.Probed.Height', '.Probed.Profile', '.Probed.BitDepth', '.Probed.HDR', '.Probed.DolbyVision', '.Probed.HasHDRFallback', '.Probed.DynamicRange'] },
+  { group: 'Probed', fields: ['.Verified', '.Probed.VideoCodec', '.Probed.AudioCodec', '.Probed.Width', '.Probed.Height', '.Probed.Profile', '.Probed.BitDepth', '.Probed.HDR', '.Probed.DolbyVision', '.Probed.HasHDRFallback', '.Probed.DynamicRange', '.Probed.TracksProbed', '.Probed.AudioLanguages', '.Probed.SubtitleLanguages', '.Probed.AudioStreams', '.Probed.SubtitleStreams'] },
   { group: 'Avail', fields: ['.Availability.Status', '.Availability.Known', '.Availability.OnMyBackbone', '.Availability.CheckedDaysAgo', '.Availability.Compression'] },
   { group: 'SeaDex', fields: ['.Seadex.Checked', '.Seadex.Known', '.Seadex.Best', '.Seadex.Alternative'] },
   { group: 'Helpers', fields: ['size .Size', 'score .Score', 'join .HDR "|"', 'upper .Codec', 'lower', 'trim', 'replace .Resolution "1080p" "HD"', 'default "?" .Group', 'title .ParsedTitle', 'truncate 24 .ParsedTitle', 'remove "DD" .Audio', 'translate "0123456789" "₀₁₂₃₄₅₆₇₈₉" .Score', 'smallcaps .Network', '.ParsedTitle | title | truncate 24'] },

--- a/frontend/src/components/RulesEditor.jsx
+++ b/frontend/src/components/RulesEditor.jsx
@@ -47,6 +47,7 @@ function tierOf(when = "", rules = []) {
   const stripped = stripSetCalls(
     inlineRuleRefs(when, rules).replace(/"(?:[^"\\]|\\.)*"/g, "").replace(/'(?:[^'\\]|\\.)*'/g, ""),
   )
+  if (/\bprobed\.(?:audioLanguages|subtitleLanguages|audioStreams|subtitleStreams)\b/.test(stripped)) return "tracks"
   if (/\bprobed\./.test(stripped)) return "measured"
   if (/\bseadex\./.test(stripped)) return "seadex"
   if (/\bavail\./.test(stripped)) return "community"
@@ -59,10 +60,11 @@ function tierOf(when = "", rules = []) {
 // The chip shows how far a value can be trusted; seadex is community-curated
 // data with its own skip behavior, so it keys its own note but wears the
 // community chip.
-const CHIP_TIER = { seadex: "community" }
+const CHIP_TIER = { seadex: "community", tracks: "measured" }
 
 const SKIP_NOTE = {
   measured: "Only judges releases that have been probed — library items. Everything else passes untouched.",
+  tracks: "Only judges library items whose probe read the audio and subtitle tracks — newer than the codec and HDR fields, so older library items pass untouched along with everything unprobed.",
   community: "Only judges releases AvailNZB has an opinion about. Everything else passes untouched.",
   seadex: "Only judges anime requested through Kitsu, and only when the title could be looked up on SeaDex. Everything else passes untouched.",
   // Not a fail-open caveat like the two above: this one runs on every real

--- a/frontend/src/components/SampleRelease.jsx
+++ b/frontend/src/components/SampleRelease.jsx
@@ -18,6 +18,9 @@ const DEFAULT_PROBE = {
   // a real probe's are (jpn → ja); sampleForRequest splits them.
   audio_languages: "",
   subtitle_languages: "",
+  // Counts include untagged tracks, which the language lists cannot show.
+  audio_streams: 0,
+  subtitle_streams: 0,
 }
 
 const HDR_OPTIONS = [
@@ -162,7 +165,7 @@ export function SampleRelease({ value, onChange, open, onOpenChange }) {
                 <SettingRow
                   label="Audio track languages"
                   htmlFor="sample-audio-languages"
-                  description="Comma-separated tags as a muxer writes them (jpn, eng, ara). Leave empty for a probe that read no track languages; rules on the tracks then skip."
+                  description="Tagged tracks only, comma-separated as a muxer writes them (jpn, eng, ara). Leave both lists and counts empty for a probe that read no tracks; rules on the tracks then skip."
                 >
                   <Input
                     id="sample-audio-languages"
@@ -182,6 +185,26 @@ export function SampleRelease({ value, onChange, open, onOpenChange }) {
                     onChange={(e) => patch({ probed: { ...sample.probed, subtitle_languages: e.target.value } })}
                     placeholder="eng, ara"
                     className="h-9 w-44 font-mono text-xs"
+                  />
+                </SettingRow>
+                <SettingRow
+                  label="Audio tracks"
+                  description="Total audio tracks, tagged or not. At least the number of languages above; higher stands in for untagged or duplicate-language tracks."
+                >
+                  <NumberField
+                    value={sample.probed.audio_streams}
+                    min={0}
+                    onCommit={(audio_streams) => patch({ probed: { ...sample.probed, audio_streams } })}
+                  />
+                </SettingRow>
+                <SettingRow
+                  label="Subtitle tracks"
+                  description="Total subtitle tracks, tagged or not."
+                >
+                  <NumberField
+                    value={sample.probed.subtitle_streams}
+                    min={0}
+                    onCommit={(subtitle_streams) => patch({ probed: { ...sample.probed, subtitle_streams } })}
                   />
                 </SettingRow>
                 <SettingRow label="Dolby Vision">

--- a/frontend/src/components/SampleRelease.jsx
+++ b/frontend/src/components/SampleRelease.jsx
@@ -14,6 +14,10 @@ const DEFAULT_PROBE = {
   bit_depth: 10,
   hdr: "HDR10",
   dolby_vision: false,
+  // Track languages are typed as comma-separated tags and normalized the way
+  // a real probe's are (jpn → ja); sampleForRequest splits them.
+  audio_languages: "",
+  subtitle_languages: "",
 }
 
 const HDR_OPTIONS = [
@@ -154,6 +158,31 @@ export function SampleRelease({ value, onChange, open, onOpenChange }) {
                   >
                     {HDR_OPTIONS.map((o) => <option key={o.label} value={o.value}>{o.label}</option>)}
                   </select>
+                </SettingRow>
+                <SettingRow
+                  label="Audio track languages"
+                  htmlFor="sample-audio-languages"
+                  description="Comma-separated tags as a muxer writes them (jpn, eng, ara). Leave empty for a probe that read no track languages; rules on the tracks then skip."
+                >
+                  <Input
+                    id="sample-audio-languages"
+                    value={sample.probed.audio_languages || ""}
+                    onChange={(e) => patch({ probed: { ...sample.probed, audio_languages: e.target.value } })}
+                    placeholder="jpn, eng"
+                    className="h-9 w-44 font-mono text-xs"
+                  />
+                </SettingRow>
+                <SettingRow
+                  label="Subtitle track languages"
+                  htmlFor="sample-subtitle-languages"
+                >
+                  <Input
+                    id="sample-subtitle-languages"
+                    value={sample.probed.subtitle_languages || ""}
+                    onChange={(e) => patch({ probed: { ...sample.probed, subtitle_languages: e.target.value } })}
+                    placeholder="eng, ara"
+                    className="h-9 w-44 font-mono text-xs"
+                  />
                 </SettingRow>
                 <SettingRow label="Dolby Vision">
                   <Switch

--- a/frontend/src/lib/profiles.js
+++ b/frontend/src/lib/profiles.js
@@ -370,7 +370,7 @@ export const RULE_ATTRIBUTES = [
     items: [
       { name: "probed.audioLanguages", type: "list", example: '"ja" in probed.audioLanguages — ISO 639-1, the same codes as languages' },
       { name: "probed.subtitleLanguages", type: "list", example: '"ar" in probed.subtitleLanguages' },
-      { name: "probed.audioStreams", type: "number", example: "probed.audioStreams >= 2 — counts untagged tracks too" },
+      { name: "probed.audioStreams", type: "number", example: "counts every audio track, tagged or not — a commentary or a stereo downmix counts, so dual audio is len(probed.audioLanguages) >= 2" },
       { name: "probed.subtitleStreams", type: "number" },
     ],
   },

--- a/frontend/src/lib/profiles.js
+++ b/frontend/src/lib/profiles.js
@@ -364,6 +364,17 @@ export const RULE_ATTRIBUTES = [
     ],
   },
   {
+    tier: "measured",
+    title: "From ffprobe — tracks",
+    note: "The file's audio and subtitle tracks, read by probes newer than the codec and HDR fields. A library item probed before then has those but nothing about its tracks, so rules reading these skip it as well as everything unprobed.",
+    items: [
+      { name: "probed.audioLanguages", type: "list", example: '"ja" in probed.audioLanguages — ISO 639-1, the same codes as languages' },
+      { name: "probed.subtitleLanguages", type: "list", example: '"ar" in probed.subtitleLanguages' },
+      { name: "probed.audioStreams", type: "number", example: "probed.audioStreams >= 2 — counts untagged tracks too" },
+      { name: "probed.subtitleStreams", type: "number" },
+    ],
+  },
+  {
     tier: "inferred",
     title: "Detected traits",
     note: "Every trait the parser found, by key. `\"remux\" in traits` reaches anything the baseline has an opinion about, without a separate control for each one.",

--- a/frontend/src/lib/sample.js
+++ b/frontend/src/lib/sample.js
@@ -36,18 +36,27 @@ export function sampleActiveCount(sample) {
 }
 
 // sampleForRequest converts the editor's sample state into the explain API
-// shape: the SeaDex group lists are typed as comma-separated text but the API
-// takes them as lists.
+// shape: the SeaDex group lists and the probe's track languages are typed as
+// comma-separated text but the API takes them as lists.
 export function sampleForRequest(sample) {
-  if (!sample?.seadex) return sample || undefined
-  const splitGroups = (text) => (text || "").split(",").map((g) => g.trim()).filter(Boolean)
-  return {
-    ...sample,
-    seadex: {
-      known: sample.seadex.known === true,
-      best_groups: splitGroups(sample.seadex.best_groups),
-      alt_groups: splitGroups(sample.seadex.alt_groups),
-    },
+  if (!sample) return undefined
+  const splitList = (text) => (text || "").split(",").map((g) => g.trim()).filter(Boolean)
+  const out = { ...sample }
+  if (sample.probed) {
+    const { audio_languages, subtitle_languages, ...probed } = sample.probed
+    out.probed = {
+      ...probed,
+      audio_languages: splitList(audio_languages),
+      subtitle_languages: splitList(subtitle_languages),
+    }
   }
+  if (sample.seadex) {
+    out.seadex = {
+      known: sample.seadex.known === true,
+      best_groups: splitList(sample.seadex.best_groups),
+      alt_groups: splitList(sample.seadex.alt_groups),
+    }
+  }
+  return out
 }
 

--- a/pkg/media/ffprobe/ffprobe.go
+++ b/pkg/media/ffprobe/ffprobe.go
@@ -27,6 +27,14 @@ const DefaultDecodeFrames = 120
 // ffprobeDisposition captures the stream disposition flags we care about.
 type ffprobeDisposition struct {
 	AttachedPic int `json:"attached_pic"`
+	Default     int `json:"default"`
+}
+
+// ffprobeTags is the per-stream tag block. language is the only tag read: the
+// ISO 639-2 code a muxer wrote on an audio or subtitle track.
+type ffprobeTags struct {
+	Language string `json:"language"`
+	Title    string `json:"title"`
 }
 
 type FFprobeStream struct {
@@ -43,6 +51,7 @@ type FFprobeStream struct {
 	BitsPerRawSample string             `json:"bits_per_raw_sample"`
 	NbReadFrames     string             `json:"nb_read_frames"`
 	Disposition      ffprobeDisposition `json:"disposition"`
+	Tags             ffprobeTags        `json:"tags"`
 }
 
 // FFprobeFormat carries the container-level fields we ask for. Duration comes
@@ -84,6 +93,18 @@ type FFprobeResult struct {
 	// DurationSeconds is the container-reported duration, 0 when the header
 	// does not state one.
 	DurationSeconds float64
+
+	// Track languages, as ISO 639-1 codes in stream order, deduplicated. A
+	// track with no language tag (or "und") contributes nothing, so a file
+	// can have AudioStreams == 2 and one entry in AudioLanguages. This is the
+	// measured counterpart of what a release name claims: the name says
+	// "DUAL", the tracks say ["ja", "en"].
+	AudioLanguages    []string
+	SubtitleLanguages []string
+	// AudioStreams and SubtitleStreams count the tracks whether or not they
+	// were tagged, so "dual audio" is answerable even from an untagged file.
+	AudioStreams    int
+	SubtitleStreams int
 }
 
 // ProbeOptions tunes how aggressively ProbeStream inspects the input.
@@ -148,7 +169,8 @@ func FindFFprobeBinary(customPath string) (string, bool) {
 // playability and capture client-relevant capabilities (profile, bit depth, HDR).
 const showEntries = "stream=codec_type,codec_name,profile,width,height,pix_fmt," +
 	"color_transfer,color_primaries,codec_tag_string,bit_rate,bits_per_raw_sample,nb_read_frames:" +
-	"stream_disposition=attached_pic:" +
+	"stream_disposition=attached_pic,default:" +
+	"stream_tags=language,title:" +
 	"format=duration"
 
 // ProbeStream runs a lightweight, header-only inspection (backwards-compatible).
@@ -278,6 +300,10 @@ func ProbeStreamWithOptions(ctx context.Context, stream io.Reader, customPath st
 		"frames_decoded", res.FramesDecoded,
 		"has_audio", res.HasAudio,
 		"audio_codec", res.AudioCodec,
+		"audio_streams", res.AudioStreams,
+		"audio_languages", res.AudioLanguages,
+		"subtitle_streams", res.SubtitleStreams,
+		"subtitle_languages", res.SubtitleLanguages,
 		"duration_s", res.DurationSeconds,
 	)
 
@@ -314,12 +340,32 @@ func summarizeStreams(streams []FFprobeStream) *FFprobeResult {
 			videoChosen = true
 		case "audio":
 			res.HasAudio = true
+			res.AudioStreams++
 			if res.AudioCodec == "" {
 				res.AudioCodec = st.CodecName
 			}
+			res.AudioLanguages = appendLanguage(res.AudioLanguages, st.Tags.Language)
+		case "subtitle":
+			res.SubtitleStreams++
+			res.SubtitleLanguages = appendLanguage(res.SubtitleLanguages, st.Tags.Language)
 		}
 	}
 	return res
+}
+
+// appendLanguage adds a track's language tag to the list as an ISO 639-1 code,
+// skipping untagged and undetermined tracks and codes already present.
+func appendLanguage(list []string, tag string) []string {
+	code := NormalizeLanguageTag(tag)
+	if code == "" {
+		return list
+	}
+	for _, have := range list {
+		if have == code {
+			return list
+		}
+	}
+	return append(list, code)
 }
 
 // isRealVideoStream rejects "video" streams that are actually embedded cover art

--- a/pkg/media/ffprobe/ffprobe.go
+++ b/pkg/media/ffprobe/ffprobe.go
@@ -27,14 +27,12 @@ const DefaultDecodeFrames = 120
 // ffprobeDisposition captures the stream disposition flags we care about.
 type ffprobeDisposition struct {
 	AttachedPic int `json:"attached_pic"`
-	Default     int `json:"default"`
 }
 
 // ffprobeTags is the per-stream tag block. language is the only tag read: the
 // ISO 639-2 code a muxer wrote on an audio or subtitle track.
 type ffprobeTags struct {
 	Language string `json:"language"`
-	Title    string `json:"title"`
 }
 
 type FFprobeStream struct {
@@ -169,8 +167,8 @@ func FindFFprobeBinary(customPath string) (string, bool) {
 // playability and capture client-relevant capabilities (profile, bit depth, HDR).
 const showEntries = "stream=codec_type,codec_name,profile,width,height,pix_fmt," +
 	"color_transfer,color_primaries,codec_tag_string,bit_rate,bits_per_raw_sample,nb_read_frames:" +
-	"stream_disposition=attached_pic,default:" +
-	"stream_tags=language,title:" +
+	"stream_disposition=attached_pic:" +
+	"stream_tags=language:" +
 	"format=duration"
 
 // ProbeStream runs a lightweight, header-only inspection (backwards-compatible).

--- a/pkg/media/ffprobe/ffprobe_test.go
+++ b/pkg/media/ffprobe/ffprobe_test.go
@@ -119,7 +119,8 @@ func TestNormalizeLanguageTag(t *testing.T) {
 	for tag, want := range map[string]string{
 		"jpn": "ja", "eng": "en", "ara": "ar", "ger": "de", "deu": "de",
 		"JA": "ja", "en_US": "en", "pt-BR": "pt", "und": "", "": "", "mul": "",
-		"xyz": "", "chi": "zh", "zho": "zh",
+		"xyz": "", "chi": "zh", "zho": "zh", "afr": "af", "bel": "be", "bos": "bs",
+		"cym": "cy", "wel": "cy", "gle": "ga", "swa": "sw", "fil": "tl", "nob": "nb",
 	} {
 		if got := NormalizeLanguageTag(tag); got != want {
 			t.Errorf("NormalizeLanguageTag(%q) = %q, want %q", tag, got, want)

--- a/pkg/media/ffprobe/ffprobe_test.go
+++ b/pkg/media/ffprobe/ffprobe_test.go
@@ -85,6 +85,60 @@ func TestSummarizeStreamsFirstQualifyingVideoWins(t *testing.T) {
 	}
 }
 
+func TestSummarizeStreamsTrackLanguages(t *testing.T) {
+	// A dual-audio anime episode as muxers actually tag it: ISO 639-2 codes,
+	// a second untagged audio track, and a subtitle track with a region.
+	streams := []FFprobeStream{
+		{CodecType: "video", CodecName: "hevc", Width: 1920, Height: 1080, NbReadFrames: "120"},
+		{CodecType: "audio", CodecName: "aac", Tags: ffprobeTags{Language: "jpn"}},
+		{CodecType: "audio", CodecName: "eac3", Tags: ffprobeTags{Language: "eng"}},
+		{CodecType: "audio", CodecName: "aac"},
+		{CodecType: "subtitle", CodecName: "ass", Tags: ffprobeTags{Language: "eng"}},
+		{CodecType: "subtitle", CodecName: "subrip", Tags: ffprobeTags{Language: "pt-BR"}},
+		{CodecType: "subtitle", CodecName: "subrip", Tags: ffprobeTags{Language: "und"}},
+	}
+	res := summarizeStreams(streams)
+	if got, want := res.AudioLanguages, []string{"ja", "en"}; !equalStrings(got, want) {
+		t.Fatalf("audio languages = %v, want %v", got, want)
+	}
+	if res.AudioStreams != 3 {
+		t.Fatalf("audio streams = %d, want 3 (untagged track still counts)", res.AudioStreams)
+	}
+	if got, want := res.SubtitleLanguages, []string{"en", "pt"}; !equalStrings(got, want) {
+		t.Fatalf("subtitle languages = %v, want %v", got, want)
+	}
+	if res.SubtitleStreams != 3 {
+		t.Fatalf("subtitle streams = %d, want 3", res.SubtitleStreams)
+	}
+	if res.AudioCodec != "aac" {
+		t.Fatalf("first audio codec = %q, want aac", res.AudioCodec)
+	}
+}
+
+func TestNormalizeLanguageTag(t *testing.T) {
+	for tag, want := range map[string]string{
+		"jpn": "ja", "eng": "en", "ara": "ar", "ger": "de", "deu": "de",
+		"JA": "ja", "en_US": "en", "pt-BR": "pt", "und": "", "": "", "mul": "",
+		"xyz": "", "chi": "zh", "zho": "zh",
+	} {
+		if got := NormalizeLanguageTag(tag); got != want {
+			t.Errorf("NormalizeLanguageTag(%q) = %q, want %q", tag, got, want)
+		}
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 func TestSummarizeStreamsCoverArtIsNotVideo(t *testing.T) {
 	// Audio file with embedded cover art: attached_pic video + audio. Must be
 	// treated as audio-only so the audio-only guard fires.

--- a/pkg/media/ffprobe/ffprobe_test.go
+++ b/pkg/media/ffprobe/ffprobe_test.go
@@ -120,7 +120,10 @@ func TestNormalizeLanguageTag(t *testing.T) {
 		"jpn": "ja", "eng": "en", "ara": "ar", "ger": "de", "deu": "de",
 		"JA": "ja", "en_US": "en", "pt-BR": "pt", "und": "", "": "", "mul": "",
 		"xyz": "", "chi": "zh", "zho": "zh", "afr": "af", "bel": "be", "bos": "bs",
-		"cym": "cy", "wel": "cy", "gle": "ga", "swa": "sw", "fil": "tl", "nob": "nb",
+		"cym": "cy", "wel": "cy", "gle": "ga", "swa": "sw", "fil": "tl",
+		// jhin's vocabulary, not bare ISO: one Norwegian, and no Latin because
+		// "la" is Latino downstream.
+		"nob": "no", "nno": "no", "nor": "no", "nb": "no", "nn": "no", "lat": "", "la": "",
 	} {
 		if got := NormalizeLanguageTag(tag); got != want {
 			t.Errorf("NormalizeLanguageTag(%q) = %q, want %q", tag, got, want)

--- a/pkg/media/ffprobe/ffprobe_test.go
+++ b/pkg/media/ffprobe/ffprobe_test.go
@@ -124,6 +124,7 @@ func TestNormalizeLanguageTag(t *testing.T) {
 		// jhin's vocabulary, not bare ISO: one Norwegian, and no Latin because
 		// "la" is Latino downstream.
 		"nob": "no", "nno": "no", "nor": "no", "nb": "no", "nn": "no", "lat": "", "la": "",
+		"scr": "hr", "scc": "sr",
 	} {
 		if got := NormalizeLanguageTag(tag); got != want {
 			t.Errorf("NormalizeLanguageTag(%q) = %q, want %q", tag, got, want)

--- a/pkg/media/ffprobe/langtags.go
+++ b/pkg/media/ffprobe/langtags.go
@@ -1,0 +1,56 @@
+package ffprobe
+
+import "strings"
+
+// iso6392to1 maps the ISO 639-2 codes muxers write on tracks — both the
+// bibliographic (ger, fre, chi) and terminologic (deu, fra, zho) forms — to
+// the ISO 639-1 codes the rest of StreamNZB speaks: jhin's languages list,
+// rules like `"ja" in languages`, and the formatter. Only languages that show
+// up on media tracks in practice are listed; anything else passes through
+// unchanged when it is already two letters and is dropped otherwise.
+var iso6392to1 = map[string]string{
+	"eng": "en", "jpn": "ja", "ara": "ar", "chi": "zh", "zho": "zh", "kor": "ko",
+	"fre": "fr", "fra": "fr", "ger": "de", "deu": "de", "spa": "es", "ita": "it",
+	"por": "pt", "rus": "ru", "hin": "hi", "tur": "tr", "pol": "pl", "dut": "nl",
+	"nld": "nl", "swe": "sv", "nor": "no", "nob": "no", "nno": "no", "dan": "da",
+	"fin": "fi", "hun": "hu", "cze": "cs", "ces": "cs", "gre": "el", "ell": "el",
+	"heb": "he", "tha": "th", "vie": "vi", "ind": "id", "may": "ms", "msa": "ms",
+	"ukr": "uk", "rum": "ro", "ron": "ro", "bul": "bg", "hrv": "hr", "srp": "sr",
+	"slv": "sl", "slo": "sk", "slk": "sk", "lit": "lt", "lav": "lv", "est": "et",
+	"per": "fa", "fas": "fa", "tam": "ta", "tel": "te", "mal": "ml", "kan": "kn",
+	"mar": "mr", "guj": "gu", "pan": "pa", "ben": "bn", "urd": "ur", "fil": "tl",
+	"tgl": "tl", "cat": "ca", "baq": "eu", "eus": "eu", "glg": "gl", "ice": "is",
+	"isl": "is", "alb": "sq", "sqi": "sq", "mac": "mk", "mkd": "mk", "lat": "la",
+}
+
+// NormalizeLanguageTag turns a track language tag into an ISO 639-1 code, or
+// "" when the tag carries no language: empty, "und" (undetermined), "mul"
+// (multiple), "zxx" (no linguistic content), or something unrecognised. A
+// region suffix ("pt-BR", "en_US") is dropped; the base language is what
+// rules and formatters compare against.
+func NormalizeLanguageTag(tag string) string {
+	tag = strings.ToLower(strings.TrimSpace(tag))
+	if i := strings.IndexAny(tag, "-_"); i > 0 {
+		tag = tag[:i]
+	}
+	switch tag {
+	case "", "und", "mul", "zxx", "mis":
+		return ""
+	}
+	if code, ok := iso6392to1[tag]; ok {
+		return code
+	}
+	if len(tag) == 2 && isASCIILetters(tag) {
+		return tag
+	}
+	return ""
+}
+
+func isASCIILetters(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] < 'a' || s[i] > 'z' {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/media/ffprobe/langtags.go
+++ b/pkg/media/ffprobe/langtags.go
@@ -52,6 +52,8 @@ var iso6392to1 = map[string]string{
 	"uzb": "uz", "ven": "ve", "vie": "vi", "vol": "vo", "wel": "cy", "cym": "cy",
 	"wln": "wa", "wol": "wo", "xho": "xh", "yid": "yi", "yor": "yo", "zha": "za",
 	"zul": "zu",
+	// Retired ISO 639-2 codes still found on older muxes.
+	"scr": "hr", "scc": "sr",
 }
 
 // NormalizeLanguageTag turns a track language tag into an ISO 639-1 code, or

--- a/pkg/media/ffprobe/langtags.go
+++ b/pkg/media/ffprobe/langtags.go
@@ -3,11 +3,19 @@ package ffprobe
 import "strings"
 
 // iso6392to1 maps ISO 639-2 codes — both the bibliographic (ger, fre, chi)
-// and terminologic (deu, fra, zho) forms — to the ISO 639-1 codes the rest of
-// StreamNZB speaks: jhin's languages list, rules like `"ja" in languages`, and
-// the formatter. Every 639-2 code that has a 639-1 equivalent is listed;
-// codes without one (e.g. fil is handled as tl by convention below) pass
-// through unchanged only when already two letters and are dropped otherwise.
+// and terminologic (deu, fra, zho) forms — to the codes the rest of StreamNZB
+// speaks: jhin's languages list, rules like `"ja" in languages`, and the
+// formatter. That vocabulary is ISO 639-1 with two deliberate departures a
+// probe has to follow so that "the same codes languages uses" stays true:
+//
+//   - Norwegian is one language, "no". jhin folds Bokmål and Nynorsk into it,
+//     so nob and nno land on "no" here as well, never on nb/nn.
+//   - "la" means Latin American Spanish in jhin (PTT's `latino`), not Latin.
+//     A Latin track (lat) therefore maps to nothing rather than to a code a
+//     rule would read as Latino.
+//
+// Every other 639-2 code with a 639-1 equivalent is listed. A code without
+// one passes through only when already two letters and is dropped otherwise.
 var iso6392to1 = map[string]string{
 	"aar": "aa", "abk": "ab", "afr": "af", "aka": "ak", "alb": "sq", "sqi": "sq",
 	"amh": "am", "ara": "ar", "arg": "an", "arm": "hy", "hye": "hy", "asm": "as",
@@ -26,12 +34,12 @@ var iso6392to1 = map[string]string{
 	"ina": "ia", "ind": "id", "ipk": "ik", "ita": "it", "jav": "jv", "jpn": "ja",
 	"kal": "kl", "kan": "kn", "kas": "ks", "kau": "kr", "kaz": "kk", "khm": "km",
 	"kik": "ki", "kin": "rw", "kir": "ky", "kom": "kv", "kon": "kg", "kor": "ko",
-	"kua": "kj", "kur": "ku", "lao": "lo", "lat": "la", "lav": "lv", "lim": "li",
+	"kua": "kj", "kur": "ku", "lao": "lo", "lav": "lv", "lim": "li",
 	"lin": "ln", "lit": "lt", "ltz": "lb", "lub": "lu", "lug": "lg", "mac": "mk",
 	"mkd": "mk", "mah": "mh", "mal": "ml", "mao": "mi", "mri": "mi", "mar": "mr",
 	"may": "ms", "msa": "ms", "mlg": "mg", "mlt": "mt", "mon": "mn", "nau": "na",
-	"nav": "nv", "nbl": "nr", "nde": "nd", "ndo": "ng", "nep": "ne", "nno": "nn",
-	"nob": "nb", "nor": "no", "nya": "ny", "oci": "oc", "oji": "oj", "ori": "or",
+	"nav": "nv", "nbl": "nr", "nde": "nd", "ndo": "ng", "nep": "ne", "nno": "no",
+	"nob": "no", "nor": "no", "nya": "ny", "oci": "oc", "oji": "oj", "ori": "or",
 	"orm": "om", "oss": "os", "pan": "pa", "per": "fa", "fas": "fa", "pli": "pi",
 	"pol": "pl", "por": "pt", "pus": "ps", "que": "qu", "roh": "rm", "rum": "ro",
 	"ron": "ro", "run": "rn", "rus": "ru", "sag": "sg", "san": "sa", "sin": "si",
@@ -57,11 +65,17 @@ func NormalizeLanguageTag(tag string) string {
 		tag = tag[:i]
 	}
 	switch tag {
-	case "", "und", "mul", "zxx", "mis":
+	case "", "und", "mul", "zxx", "mis", "lat":
 		return ""
 	}
 	if code, ok := iso6392to1[tag]; ok {
 		return code
+	}
+	switch tag {
+	case "nb", "nn":
+		return "no" // jhin's single Norwegian
+	case "la":
+		return "" // Latin as a two-letter tag; "la" is Latino downstream
 	}
 	if len(tag) == 2 && isASCIILetters(tag) {
 		return tag

--- a/pkg/media/ffprobe/langtags.go
+++ b/pkg/media/ffprobe/langtags.go
@@ -2,32 +2,55 @@ package ffprobe
 
 import "strings"
 
-// iso6392to1 maps the ISO 639-2 codes muxers write on tracks — both the
-// bibliographic (ger, fre, chi) and terminologic (deu, fra, zho) forms — to
-// the ISO 639-1 codes the rest of StreamNZB speaks: jhin's languages list,
-// rules like `"ja" in languages`, and the formatter. Only languages that show
-// up on media tracks in practice are listed; anything else passes through
-// unchanged when it is already two letters and is dropped otherwise.
+// iso6392to1 maps ISO 639-2 codes — both the bibliographic (ger, fre, chi)
+// and terminologic (deu, fra, zho) forms — to the ISO 639-1 codes the rest of
+// StreamNZB speaks: jhin's languages list, rules like `"ja" in languages`, and
+// the formatter. Every 639-2 code that has a 639-1 equivalent is listed;
+// codes without one (e.g. fil is handled as tl by convention below) pass
+// through unchanged only when already two letters and are dropped otherwise.
 var iso6392to1 = map[string]string{
-	"eng": "en", "jpn": "ja", "ara": "ar", "chi": "zh", "zho": "zh", "kor": "ko",
-	"fre": "fr", "fra": "fr", "ger": "de", "deu": "de", "spa": "es", "ita": "it",
-	"por": "pt", "rus": "ru", "hin": "hi", "tur": "tr", "pol": "pl", "dut": "nl",
-	"nld": "nl", "swe": "sv", "nor": "no", "nob": "no", "nno": "no", "dan": "da",
-	"fin": "fi", "hun": "hu", "cze": "cs", "ces": "cs", "gre": "el", "ell": "el",
-	"heb": "he", "tha": "th", "vie": "vi", "ind": "id", "may": "ms", "msa": "ms",
-	"ukr": "uk", "rum": "ro", "ron": "ro", "bul": "bg", "hrv": "hr", "srp": "sr",
-	"slv": "sl", "slo": "sk", "slk": "sk", "lit": "lt", "lav": "lv", "est": "et",
-	"per": "fa", "fas": "fa", "tam": "ta", "tel": "te", "mal": "ml", "kan": "kn",
-	"mar": "mr", "guj": "gu", "pan": "pa", "ben": "bn", "urd": "ur", "fil": "tl",
-	"tgl": "tl", "cat": "ca", "baq": "eu", "eus": "eu", "glg": "gl", "ice": "is",
-	"isl": "is", "alb": "sq", "sqi": "sq", "mac": "mk", "mkd": "mk", "lat": "la",
+	"aar": "aa", "abk": "ab", "afr": "af", "aka": "ak", "alb": "sq", "sqi": "sq",
+	"amh": "am", "ara": "ar", "arg": "an", "arm": "hy", "hye": "hy", "asm": "as",
+	"ava": "av", "ave": "ae", "aym": "ay", "aze": "az", "bak": "ba", "bam": "bm",
+	"baq": "eu", "eus": "eu", "bel": "be", "ben": "bn", "bih": "bh", "bis": "bi",
+	"bos": "bs", "bre": "br", "bul": "bg", "bur": "my", "mya": "my", "cat": "ca",
+	"cha": "ch", "che": "ce", "chi": "zh", "zho": "zh", "chu": "cu", "chv": "cv",
+	"cor": "kw", "cos": "co", "cre": "cr", "cze": "cs", "ces": "cs", "dan": "da",
+	"div": "dv", "dut": "nl", "nld": "nl", "dzo": "dz", "eng": "en", "epo": "eo",
+	"est": "et", "ewe": "ee", "fao": "fo", "fij": "fj", "fin": "fi", "fre": "fr",
+	"fra": "fr", "fry": "fy", "ful": "ff", "geo": "ka", "kat": "ka", "ger": "de",
+	"deu": "de", "gla": "gd", "gle": "ga", "glg": "gl", "glv": "gv", "gre": "el",
+	"ell": "el", "grn": "gn", "guj": "gu", "hat": "ht", "hau": "ha", "heb": "he",
+	"her": "hz", "hin": "hi", "hmo": "ho", "hrv": "hr", "hun": "hu", "ibo": "ig",
+	"ice": "is", "isl": "is", "ido": "io", "iii": "ii", "iku": "iu", "ile": "ie",
+	"ina": "ia", "ind": "id", "ipk": "ik", "ita": "it", "jav": "jv", "jpn": "ja",
+	"kal": "kl", "kan": "kn", "kas": "ks", "kau": "kr", "kaz": "kk", "khm": "km",
+	"kik": "ki", "kin": "rw", "kir": "ky", "kom": "kv", "kon": "kg", "kor": "ko",
+	"kua": "kj", "kur": "ku", "lao": "lo", "lat": "la", "lav": "lv", "lim": "li",
+	"lin": "ln", "lit": "lt", "ltz": "lb", "lub": "lu", "lug": "lg", "mac": "mk",
+	"mkd": "mk", "mah": "mh", "mal": "ml", "mao": "mi", "mri": "mi", "mar": "mr",
+	"may": "ms", "msa": "ms", "mlg": "mg", "mlt": "mt", "mon": "mn", "nau": "na",
+	"nav": "nv", "nbl": "nr", "nde": "nd", "ndo": "ng", "nep": "ne", "nno": "nn",
+	"nob": "nb", "nor": "no", "nya": "ny", "oci": "oc", "oji": "oj", "ori": "or",
+	"orm": "om", "oss": "os", "pan": "pa", "per": "fa", "fas": "fa", "pli": "pi",
+	"pol": "pl", "por": "pt", "pus": "ps", "que": "qu", "roh": "rm", "rum": "ro",
+	"ron": "ro", "run": "rn", "rus": "ru", "sag": "sg", "san": "sa", "sin": "si",
+	"slo": "sk", "slk": "sk", "slv": "sl", "sme": "se", "smo": "sm", "sna": "sn",
+	"snd": "sd", "som": "so", "sot": "st", "spa": "es", "srd": "sc", "srp": "sr",
+	"ssw": "ss", "sun": "su", "swa": "sw", "swe": "sv", "tah": "ty", "tam": "ta",
+	"tat": "tt", "tel": "te", "tgk": "tg", "tgl": "tl", "fil": "tl", "tha": "th",
+	"tib": "bo", "bod": "bo", "tir": "ti", "ton": "to", "tsn": "tn", "tso": "ts",
+	"tuk": "tk", "tur": "tr", "twi": "tw", "uig": "ug", "ukr": "uk", "urd": "ur",
+	"uzb": "uz", "ven": "ve", "vie": "vi", "vol": "vo", "wel": "cy", "cym": "cy",
+	"wln": "wa", "wol": "wo", "xho": "xh", "yid": "yi", "yor": "yo", "zha": "za",
+	"zul": "zu",
 }
 
 // NormalizeLanguageTag turns a track language tag into an ISO 639-1 code, or
 // "" when the tag carries no language: empty, "und" (undetermined), "mul"
-// (multiple), "zxx" (no linguistic content), or something unrecognised. A
-// region suffix ("pt-BR", "en_US") is dropped; the base language is what
-// rules and formatters compare against.
+// (multiple), "zxx" (no linguistic content), "mis" (uncoded), or something
+// unrecognised. A region suffix ("pt-BR", "en_US") is dropped; the base
+// language is what rules and formatters compare against.
 func NormalizeLanguageTag(tag string) string {
 	tag = strings.ToLower(strings.TrimSpace(tag))
 	if i := strings.IndexAny(tag, "-_"); i > 0 {

--- a/pkg/playback/service.go
+++ b/pkg/playback/service.go
@@ -840,5 +840,10 @@ func MediaCapabilitiesFromProbe(res *ffprobe.FFprobeResult) *session.MediaCapabi
 		ColorTransfer:   res.ColorTransfer,
 		CodecTag:        res.CodecTag,
 		DurationSeconds: res.DurationSeconds,
+
+		AudioLanguages:    res.AudioLanguages,
+		SubtitleLanguages: res.SubtitleLanguages,
+		AudioStreams:      res.AudioStreams,
+		SubtitleStreams:   res.SubtitleStreams,
 	}
 }

--- a/pkg/playback/service.go
+++ b/pkg/playback/service.go
@@ -841,6 +841,7 @@ func MediaCapabilitiesFromProbe(res *ffprobe.FFprobeResult) *session.MediaCapabi
 		CodecTag:        res.CodecTag,
 		DurationSeconds: res.DurationSeconds,
 
+		TracksProbed:      true,
 		AudioLanguages:    res.AudioLanguages,
 		SubtitleLanguages: res.SubtitleLanguages,
 		AudioStreams:      res.AudioStreams,

--- a/pkg/release/mediacaps.go
+++ b/pkg/release/mediacaps.go
@@ -29,10 +29,15 @@ type MediaCaps struct {
 	// DurationSeconds is the container-reported duration, 0 when the probe
 	// could not see one (and on library items saved before it was captured).
 	DurationSeconds float64
+	// TracksProbed reports the track fields below were captured at all. It is
+	// what tells a library item probed before they existed — which has real
+	// codec and HDR measurements but nothing about its tracks — apart from a
+	// file that was measured and has no tagged tracks. Rules and formats read
+	// the track fields only when it is set.
+	TracksProbed bool
 	// AudioLanguages and SubtitleLanguages are the tagged track languages as
 	// ISO 639-1 codes in stream order; AudioStreams and SubtitleStreams count
-	// every track, tagged or not. Nil on library items saved before they
-	// were captured.
+	// every track, tagged or not.
 	AudioLanguages    []string
 	SubtitleLanguages []string
 	AudioStreams      int

--- a/pkg/release/mediacaps.go
+++ b/pkg/release/mediacaps.go
@@ -29,6 +29,14 @@ type MediaCaps struct {
 	// DurationSeconds is the container-reported duration, 0 when the probe
 	// could not see one (and on library items saved before it was captured).
 	DurationSeconds float64
+	// AudioLanguages and SubtitleLanguages are the tagged track languages as
+	// ISO 639-1 codes in stream order; AudioStreams and SubtitleStreams count
+	// every track, tagged or not. Nil on library items saved before they
+	// were captured.
+	AudioLanguages    []string
+	SubtitleLanguages []string
+	AudioStreams      int
+	SubtitleStreams   int
 }
 
 // Summary renders a short human-readable capability string suitable for a

--- a/pkg/search/rules/env.go
+++ b/pkg/search/rules/env.go
@@ -450,8 +450,10 @@ type ProbedEnv struct {
 	TracksProbed bool
 	// AudioLanguages and SubtitleLanguages are the tagged track languages
 	// (ISO 639-1, stream order). AudioStreams and SubtitleStreams count every
-	// track, so `probed.audioStreams >= 2` reads dual audio off an untagged
-	// file where `"en" in probed.audioLanguages` cannot.
+	// track, tagged or not. The count is not a language claim — a commentary
+	// or a stereo downmix is a second stream in one language — so dual audio
+	// is len(probed.audioLanguages) >= 2, and the counts are for what a count
+	// says on its own.
 	AudioLanguages    []string
 	SubtitleLanguages []string
 	AudioStreams      int

--- a/pkg/search/rules/env.go
+++ b/pkg/search/rules/env.go
@@ -307,6 +307,14 @@ func (e *Env) Lookup(path string) (jhinrules.Value, bool) {
 		return jhinrules.BoolOf(e.Probed.HasHDRFallback), true
 	case "probed.dynamicRange":
 		return jhinrules.StrOf(e.Probed.DynamicRange), true
+	case "probed.audioLanguages":
+		return jhinrules.StrListOf(e.Probed.AudioLanguages), true
+	case "probed.subtitleLanguages":
+		return jhinrules.StrListOf(e.Probed.SubtitleLanguages), true
+	case "probed.audioStreams":
+		return jhinrules.NumOf(float64(e.Probed.AudioStreams)), true
+	case "probed.subtitleStreams":
+		return jhinrules.NumOf(float64(e.Probed.SubtitleStreams)), true
 
 	case "kind":
 		return jhinrules.StrOf(e.Kind), true
@@ -433,6 +441,14 @@ type ProbedEnv struct {
 	// DynamicRange is the human-readable form: "DV + HDR10", "DV only",
 	// "HDR10", or "" for SDR.
 	DynamicRange string
+	// AudioLanguages and SubtitleLanguages are the tagged track languages
+	// (ISO 639-1, stream order). AudioStreams and SubtitleStreams count every
+	// track, so `probed.audioStreams >= 2` reads dual audio off an untagged
+	// file where `"en" in probed.audioLanguages` cannot.
+	AudioLanguages    []string
+	SubtitleLanguages []string
+	AudioStreams      int
+	SubtitleStreams   int
 }
 
 // Context is the per-request half of the environment, the same for every
@@ -693,6 +709,11 @@ func probedEnv(caps *release.MediaCaps) ProbedEnv {
 		DolbyVision:    caps.DolbyVision,
 		HasHDRFallback: caps.HasHDRFallback(),
 		DynamicRange:   caps.DynamicRange(),
+
+		AudioLanguages:    caps.AudioLanguages,
+		SubtitleLanguages: caps.SubtitleLanguages,
+		AudioStreams:      caps.AudioStreams,
+		SubtitleStreams:   caps.SubtitleStreams,
 	}
 }
 

--- a/pkg/search/rules/env.go
+++ b/pkg/search/rules/env.go
@@ -363,6 +363,8 @@ func (e *Env) TierPresent(tier string) bool {
 		return true
 	case tierMeasured:
 		return e.Verified
+	case tierTracks:
+		return e.Verified && e.Probed.TracksProbed
 	case tierAvail:
 		return e.Avail.Known
 	case tierSeadex:
@@ -441,6 +443,11 @@ type ProbedEnv struct {
 	// DynamicRange is the human-readable form: "DV + HDR10", "DV only",
 	// "HDR10", or "" for SDR.
 	DynamicRange string
+	// TracksProbed reports the four track fields were captured; a library
+	// item probed before they existed leaves it false and the tracks tier
+	// absent, so rules reading them are skipped rather than judged against
+	// empty lists.
+	TracksProbed bool
 	// AudioLanguages and SubtitleLanguages are the tagged track languages
 	// (ISO 639-1, stream order). AudioStreams and SubtitleStreams count every
 	// track, so `probed.audioStreams >= 2` reads dual audio off an untagged
@@ -710,6 +717,7 @@ func probedEnv(caps *release.MediaCaps) ProbedEnv {
 		HasHDRFallback: caps.HasHDRFallback(),
 		DynamicRange:   caps.DynamicRange(),
 
+		TracksProbed:      caps.TracksProbed,
 		AudioLanguages:    caps.AudioLanguages,
 		SubtitleLanguages: caps.SubtitleLanguages,
 		AudioStreams:      caps.AudioStreams,

--- a/pkg/search/rules/rules.go
+++ b/pkg/search/rules/rules.go
@@ -80,7 +80,9 @@ func buildRegistry() *jhinrules.Registry {
 	reg.Namespace("probed", tierMeasured).
 		Str("videoCodec").Str("audioCodec").Num("width").Num("height").
 		Str("profile").Num("bitDepth").Str("hdr").Bool("dolbyVision").
-		Bool("hasHDRFallback").Str("dynamicRange")
+		Bool("hasHDRFallback").Str("dynamicRange").
+		StrList("audioLanguages").StrList("subtitleLanguages").
+		Num("audioStreams").Num("subtitleStreams")
 
 	// Request context, the same for every release in one result set. title
 	// shadows jhin's core field: here it is the requested title, and the

--- a/pkg/search/rules/rules.go
+++ b/pkg/search/rules/rules.go
@@ -21,6 +21,11 @@ const (
 	tierAvail    = "avail"
 	tierSeadex   = "seadex"
 	tierIndexer  = "indexer"
+	// tierTracks is the measured tier's younger half: the track languages
+	// and counts, captured only by probes newer than the field. A library
+	// item probed before then has real codec and HDR measurements and
+	// nothing about its tracks, so those four fields fail open on their own.
+	tierTracks = "tracks"
 )
 
 // registry declares StreamNZB's rule vocabulary: jhin's core release-name
@@ -37,6 +42,7 @@ func buildRegistry() *jhinrules.Registry {
 	reg.Tier(tierAvail, "an availability record, which this release has none of")
 	reg.Tier(tierSeadex, "a SeaDex lookup, which this request did not run")
 	reg.Tier(tierIndexer, "size, age or grabs, which a release name does not carry")
+	reg.Tier(tierTracks, "a probed file with its tracks read, which this release is not")
 
 	// Verified reports whether the merged bare attributes (resolution, codec,
 	// hdr, bitDepth) came from the file rather than from its name. It is
@@ -80,9 +86,13 @@ func buildRegistry() *jhinrules.Registry {
 	reg.Namespace("probed", tierMeasured).
 		Str("videoCodec").Str("audioCodec").Num("width").Num("height").
 		Str("profile").Num("bitDepth").Str("hdr").Bool("dolbyVision").
-		Bool("hasHDRFallback").Str("dynamicRange").
-		StrList("audioLanguages").StrList("subtitleLanguages").
-		Num("audioStreams").Num("subtitleStreams")
+		Bool("hasHDRFallback").Str("dynamicRange")
+	// The track fields sit under probed.* but carry their own tier: a probe
+	// that predates them leaves them absent, not empty.
+	reg.Field("probed.audioLanguages", jhinrules.StrList, tierTracks)
+	reg.Field("probed.subtitleLanguages", jhinrules.StrList, tierTracks)
+	reg.Field("probed.audioStreams", jhinrules.Num, tierTracks)
+	reg.Field("probed.subtitleStreams", jhinrules.Num, tierTracks)
 
 	// Request context, the same for every release in one result set. title
 	// shadows jhin's core field: here it is the requested title, and the

--- a/pkg/search/rules/rules_test.go
+++ b/pkg/search/rules/rules_test.go
@@ -112,7 +112,7 @@ func TestDolbyVisionWithoutFallbackFromProbe(t *testing.T) {
 func TestTrackLanguagesFromProbe(t *testing.T) {
 	set := compile(t,
 		config.RuleConfig{Name: "Japanese audio, measured", When: `"ja" in probed.audioLanguages`, Points: 800},
-		config.RuleConfig{Name: "Dual audio, measured", When: `probed.audioStreams >= 2`, Points: 400},
+		config.RuleConfig{Name: "Two audio streams, measured", When: `probed.audioStreams >= 2`, Points: 400},
 		config.RuleConfig{Name: "Arabic subs, measured", When: `"ar" in probed.subtitleLanguages`, Points: 300},
 	)
 
@@ -144,8 +144,8 @@ func TestTrackLanguagesFromProbe(t *testing.T) {
 	// the tracks are not, so the track rules are skipped rather than told
 	// "no audio at all". A rule on the older measurements still runs.
 	set = compile(t,
-		config.RuleConfig{Name: "Dual audio, measured", When: `probed.audioStreams >= 2`, Points: 400},
-		config.RuleConfig{Name: "Mono, measured", When: `probed.audioStreams < 2`, Points: -400},
+		config.RuleConfig{Name: "Two audio streams, measured", When: `probed.audioStreams >= 2`, Points: 400},
+		config.RuleConfig{Name: "One audio stream, measured", When: `probed.audioStreams < 2`, Points: -400},
 		config.RuleConfig{Name: "HEVC, measured", When: `probed.videoCodec == "hevc"`, Points: 50},
 	)
 	legacy := envFor("Show S01E01 1080p DUAL WEB-DL-GRP", func(c *triage.Candidate) {

--- a/pkg/search/rules/rules_test.go
+++ b/pkg/search/rules/rules_test.go
@@ -118,7 +118,7 @@ func TestTrackLanguagesFromProbe(t *testing.T) {
 
 	tagged := envFor("Show S01E01 1080p DUAL WEB-DL-GRP", func(c *triage.Candidate) {
 		c.Verdict.Probed = &release.MediaCaps{
-			VideoCodec: "hevc", Height: 1080,
+			VideoCodec: "hevc", Height: 1080, TracksProbed: true,
 			AudioLanguages: []string{"ja", "en"}, AudioStreams: 2,
 			SubtitleLanguages: []string{"en", "ar"}, SubtitleStreams: 2,
 		}
@@ -128,7 +128,7 @@ func TestTrackLanguagesFromProbe(t *testing.T) {
 	}
 
 	untagged := envFor("Show S01E01 1080p DUAL WEB-DL-GRP", func(c *triage.Candidate) {
-		c.Verdict.Probed = &release.MediaCaps{VideoCodec: "hevc", Height: 1080, AudioStreams: 2}
+		c.Verdict.Probed = &release.MediaCaps{VideoCodec: "hevc", Height: 1080, TracksProbed: true, AudioStreams: 2}
 	})
 	if got := set.Evaluate(untagged, "anime_show"); got.Points != 400 {
 		t.Errorf("untagged two-track file scored %d, want 400 (count only)", got.Points)
@@ -138,6 +138,25 @@ func TestTrackLanguagesFromProbe(t *testing.T) {
 	unprobed := envFor("Show S01E01 1080p DUAL WEB-DL-GRP", nil)
 	if got := set.Evaluate(unprobed, "anime_show"); got.Points != 0 {
 		t.Errorf("unprobed release scored %d, want 0 (measured tier absent)", got.Points)
+	}
+
+	// Probed before the track fields existed: codec and HDR are measured,
+	// the tracks are not, so the track rules are skipped rather than told
+	// "no audio at all". A rule on the older measurements still runs.
+	set = compile(t,
+		config.RuleConfig{Name: "Dual audio, measured", When: `probed.audioStreams >= 2`, Points: 400},
+		config.RuleConfig{Name: "Mono, measured", When: `probed.audioStreams < 2`, Points: -400},
+		config.RuleConfig{Name: "HEVC, measured", When: `probed.videoCodec == "hevc"`, Points: 50},
+	)
+	legacy := envFor("Show S01E01 1080p DUAL WEB-DL-GRP", func(c *triage.Candidate) {
+		c.Verdict.Probed = &release.MediaCaps{VideoCodec: "hevc", Height: 1080}
+	})
+	got := set.Evaluate(legacy, "anime_show")
+	if got.Points != 50 {
+		t.Errorf("legacy probe scored %d, want 50 (track rules skipped, codec rule kept)", got.Points)
+	}
+	if len(got.Skipped) != 2 {
+		t.Errorf("legacy probe skipped %v, want the two track rules", got.Skipped)
 	}
 }
 

--- a/pkg/search/rules/rules_test.go
+++ b/pkg/search/rules/rules_test.go
@@ -106,6 +106,41 @@ func TestDolbyVisionWithoutFallbackFromProbe(t *testing.T) {
 	}
 }
 
+// Track languages come from the file, not the name. A release tagged DUAL says
+// nothing about which two languages; the probe says ["ja", "en"]. And a muxer
+// that tagged nothing still leaves a track count to read dual audio from.
+func TestTrackLanguagesFromProbe(t *testing.T) {
+	set := compile(t,
+		config.RuleConfig{Name: "Japanese audio, measured", When: `"ja" in probed.audioLanguages`, Points: 800},
+		config.RuleConfig{Name: "Dual audio, measured", When: `probed.audioStreams >= 2`, Points: 400},
+		config.RuleConfig{Name: "Arabic subs, measured", When: `"ar" in probed.subtitleLanguages`, Points: 300},
+	)
+
+	tagged := envFor("Show S01E01 1080p DUAL WEB-DL-GRP", func(c *triage.Candidate) {
+		c.Verdict.Probed = &release.MediaCaps{
+			VideoCodec: "hevc", Height: 1080,
+			AudioLanguages: []string{"ja", "en"}, AudioStreams: 2,
+			SubtitleLanguages: []string{"en", "ar"}, SubtitleStreams: 2,
+		}
+	})
+	if got := set.Evaluate(tagged, "anime_show"); got.Points != 1500 {
+		t.Errorf("tagged dual-audio file scored %d, want 1500 (800+400+300)", got.Points)
+	}
+
+	untagged := envFor("Show S01E01 1080p DUAL WEB-DL-GRP", func(c *triage.Candidate) {
+		c.Verdict.Probed = &release.MediaCaps{VideoCodec: "hevc", Height: 1080, AudioStreams: 2}
+	})
+	if got := set.Evaluate(untagged, "anime_show"); got.Points != 400 {
+		t.Errorf("untagged two-track file scored %d, want 400 (count only)", got.Points)
+	}
+
+	// Never opened: every probed.* rule is skipped, not judged against zeros.
+	unprobed := envFor("Show S01E01 1080p DUAL WEB-DL-GRP", nil)
+	if got := set.Evaluate(unprobed, "anime_show"); got.Points != 0 {
+		t.Errorf("unprobed release scored %d, want 0 (measured tier absent)", got.Points)
+	}
+}
+
 // What lookarounds were being asked for: a condition over two attributes at
 // once. RE2 cannot express it in one pattern; a rule does not need to.
 func TestConditionCombinesAttributes(t *testing.T) {

--- a/pkg/server/api/handlers_ranking.go
+++ b/pkg/server/api/handlers_ranking.go
@@ -130,6 +130,8 @@ func (e *explainSample) toSample() *ranking.Sample {
 			HDR:         p.HDR,
 			DolbyVision: p.DolbyVision,
 
+			TracksProbed: len(p.AudioLanguages) > 0 || len(p.SubtitleLanguages) > 0 ||
+				p.AudioStreams > 0 || p.SubtitleStreams > 0,
 			AudioLanguages:    p.AudioLanguages,
 			SubtitleLanguages: p.SubtitleLanguages,
 			AudioStreams:      max(p.AudioStreams, len(p.AudioLanguages)),

--- a/pkg/server/api/handlers_ranking.go
+++ b/pkg/server/api/handlers_ranking.go
@@ -97,6 +97,12 @@ type explainProbe struct {
 	BitDepth    int    `json:"bit_depth,omitempty"`
 	HDR         string `json:"hdr,omitempty"`
 	DolbyVision bool   `json:"dolby_vision,omitempty"`
+	// Track languages as ISO 639-1 codes, and track counts, so a preview can
+	// exercise `"ja" in probed.audioLanguages` and `probed.audioStreams >= 2`.
+	AudioLanguages    []string `json:"audio_languages,omitempty"`
+	SubtitleLanguages []string `json:"subtitle_languages,omitempty"`
+	AudioStreams      int      `json:"audio_streams,omitempty"`
+	SubtitleStreams   int      `json:"subtitle_streams,omitempty"`
 }
 
 // toSample turns the request's pretend-release into what ranking evaluates
@@ -123,6 +129,11 @@ func (e *explainSample) toSample() *ranking.Sample {
 			BitDepth:    p.BitDepth,
 			HDR:         p.HDR,
 			DolbyVision: p.DolbyVision,
+
+			AudioLanguages:    p.AudioLanguages,
+			SubtitleLanguages: p.SubtitleLanguages,
+			AudioStreams:      max(p.AudioStreams, len(p.AudioLanguages)),
+			SubtitleStreams:   max(p.SubtitleStreams, len(p.SubtitleLanguages)),
 		}
 	}
 	switch strings.ToLower(strings.TrimSpace(e.AvailStatus)) {

--- a/pkg/server/api/handlers_ranking.go
+++ b/pkg/server/api/handlers_ranking.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 
 	"streamnzb/pkg/auth"
 	"streamnzb/pkg/core/config"
+	"streamnzb/pkg/media/ffprobe"
 	"streamnzb/pkg/release"
 	"streamnzb/pkg/search/ranking"
 	"streamnzb/pkg/search/rules"
@@ -105,6 +107,21 @@ type explainProbe struct {
 	SubtitleStreams   int      `json:"subtitle_streams,omitempty"`
 }
 
+// normalizeLanguageTags puts sample-supplied track tags through the same
+// normalization the probe applies, so a preview typed as "jpn" or "JA" agrees
+// with the live pipeline's "ja" instead of making a correct rule look broken.
+func normalizeLanguageTags(tags []string) []string {
+	out := make([]string, 0, len(tags))
+	for _, tag := range tags {
+		code := ffprobe.NormalizeLanguageTag(tag)
+		if code == "" || slices.Contains(out, code) {
+			continue
+		}
+		out = append(out, code)
+	}
+	return out
+}
+
 // toSample turns the request's pretend-release into what ranking evaluates
 // against.
 func (e *explainSample) toSample() *ranking.Sample {
@@ -132,8 +149,8 @@ func (e *explainSample) toSample() *ranking.Sample {
 
 			TracksProbed: len(p.AudioLanguages) > 0 || len(p.SubtitleLanguages) > 0 ||
 				p.AudioStreams > 0 || p.SubtitleStreams > 0,
-			AudioLanguages:    p.AudioLanguages,
-			SubtitleLanguages: p.SubtitleLanguages,
+			AudioLanguages:    normalizeLanguageTags(p.AudioLanguages),
+			SubtitleLanguages: normalizeLanguageTags(p.SubtitleLanguages),
 			AudioStreams:      max(p.AudioStreams, len(p.AudioLanguages)),
 			SubtitleStreams:   max(p.SubtitleStreams, len(p.SubtitleLanguages)),
 		}

--- a/pkg/server/stremio/formatter.go
+++ b/pkg/server/stremio/formatter.go
@@ -144,6 +144,9 @@ type ProbedCaps struct {
 	DolbyVision    bool
 	HasHDRFallback bool
 	DynamicRange   string // "DV + HDR10", "DV only", "HDR10", or "" for SDR
+	// TracksProbed reports the track fields were captured; false for a
+	// library item probed before they existed, whose .Verified is still true.
+	TracksProbed bool
 	// AudioLanguages and SubtitleLanguages are the tagged track languages as
 	// ISO 639-1 codes; AudioStreams and SubtitleStreams count every track.
 	AudioLanguages    stringList
@@ -666,6 +669,7 @@ func newFormatContext(cand triage.Candidate, index, count, topScore int, service
 			HasHDRFallback: probed.HasHDRFallback(),
 			DynamicRange:   probed.DynamicRange(),
 
+			TracksProbed:      probed.TracksProbed,
 			AudioLanguages:    probed.AudioLanguages,
 			SubtitleLanguages: probed.SubtitleLanguages,
 			AudioStreams:      probed.AudioStreams,

--- a/pkg/server/stremio/formatter.go
+++ b/pkg/server/stremio/formatter.go
@@ -144,6 +144,12 @@ type ProbedCaps struct {
 	DolbyVision    bool
 	HasHDRFallback bool
 	DynamicRange   string // "DV + HDR10", "DV only", "HDR10", or "" for SDR
+	// AudioLanguages and SubtitleLanguages are the tagged track languages as
+	// ISO 639-1 codes; AudioStreams and SubtitleStreams count every track.
+	AudioLanguages    stringList
+	SubtitleLanguages stringList
+	AudioStreams      int
+	SubtitleStreams   int
 }
 
 // AvailInfo is the community availability record for one release.
@@ -659,6 +665,11 @@ func newFormatContext(cand triage.Candidate, index, count, topScore int, service
 			DolbyVision:    probed.DolbyVision,
 			HasHDRFallback: probed.HasHDRFallback(),
 			DynamicRange:   probed.DynamicRange(),
+
+			AudioLanguages:    probed.AudioLanguages,
+			SubtitleLanguages: probed.SubtitleLanguages,
+			AudioStreams:      probed.AudioStreams,
+			SubtitleStreams:   probed.SubtitleStreams,
 		}
 	}
 	rel := cand.Release


### PR DESCRIPTION
### What

The probe already opens the container and walks its streams, but only asks for codec, resolution and HDR. This adds the per-stream `language` tag and `default` disposition to `show_entries`, and summarises audio and subtitle tracks into four new measured fields:

| field | meaning |
|---|---|
| `probed.audioLanguages` | tagged audio track languages, ISO 639-1, stream order, deduplicated |
| `probed.subtitleLanguages` | same for subtitle tracks |
| `probed.audioStreams` | audio track count, tagged or not |
| `probed.subtitleStreams` | subtitle track count, tagged or not |

They ride along with the other measured capabilities: `MediaCaps` (so library items persist them in `media_caps_json`), the rules env under the existing `probed.*` measured tier, the formatter as `.Probed.AudioLanguages` etc., and the preview's sample probe.

### Why

A release name only claims languages, and for dual-audio anime it usually claims nothing: `DUAL`, `Dual-Audio` and `MULTi` all parse to `dubbed=true` with an empty `languages` list, so `"ja" in languages` never fires on them. The tracks know. With this, a rule can say what it means:

```
"ja" in probed.audioLanguages and "en" in probed.audioLanguages   → +800
probed.audioStreams >= 2                                          → +400
"ar" in probed.subtitleLanguages                                  → +300
```

The count fields exist because not every muxer tags its tracks; `probed.audioStreams >= 2` still reads dual audio off an untagged file.

### Details

- Muxers write ISO 639-2 (`jpn`, `eng`, `ger`/`deu`, `chi`/`zho`). `NormalizeLanguageTag` maps both the B and T forms to the two-letter codes jhin's `languages` uses, drops region suffixes (`pt-BR` → `pt`), and treats `und`/`mul`/`zxx` as untagged.
- `probed.*` keeps its tier, so an unprobed release skips these rules rather than being judged against empty lists (covered by `TestTrackLanguagesFromProbe`).
- Docs: `rules.md` measured section and `result-formatting.md` updated.

### Tests

`go test` passes for `pkg/media/ffprobe`, `pkg/search/rules`, `pkg/release`, `pkg/playback`, `pkg/server/stremio`, `pkg/search/ranking`. `gofmt` and `go vet` clean. Note: `pkg/server/api` has `TestHandleDownloadLogsReturnsNotFoundWhenMissing` failing on an untouched `main` checkout in my environment (status 200, want 404), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MzJz3CvfuTMMDWn2jnntV3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added normalized audio and subtitle language information.
  - Added audio and subtitle track counts, including untagged tracks.
  - Exposed track data in media rules, ranking previews, playback formatting, and field references.
  - Added audio and subtitle track inputs to sample release previews.
  - Track-based rules now apply only when track data was captured.
  - Improved language-tag normalization and fallback behavior.

- **Documentation**
  - Updated measured-property and rule documentation with new fields, examples, and usage guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->