### PR TITLE
feat(seadex): expose the dual-audio flag as seadex.dualAudio

### DIFF
--- a/docs/result-formatting.md
+++ b/docs/result-formatting.md
@@ -27,7 +27,7 @@ release's parsed data.
 | Release | `.ReleaseTitle` `.Size` `.Indexer` `.Variants` `.VariantIndexers` `.Grabs` `.Age` `.Duration` `.Score` `.Avail` `.Library` `.Caps` `.MatchedRules` |
 | Measured | `.Verified` `.Probed.VideoCodec` `.Probed.AudioCodec` `.Probed.Width` `.Probed.Height` `.Probed.Profile` `.Probed.BitDepth` `.Probed.HDR` `.Probed.DolbyVision` `.Probed.HasHDRFallback` `.Probed.DynamicRange` `.Probed.TracksProbed` `.Probed.AudioLanguages` `.Probed.SubtitleLanguages` `.Probed.AudioStreams` `.Probed.SubtitleStreams` |
 | Availability | `.Availability.Status` `.Availability.Known` `.Availability.OnMyBackbone` `.Availability.CheckedDaysAgo` `.Availability.Compression` |
-| SeaDex | `.Seadex.Checked` `.Seadex.Known` `.Seadex.Best` `.Seadex.Alternative` |
+| SeaDex | `.Seadex.Checked` `.Seadex.Known` `.Seadex.Best` `.Seadex.Alternative` `.Seadex.DualAudio` |
 | Parsed | `.ParsedTitle` `.Year` `.Date` `.Resolution` `.Quality` `.Codec` `.BitDepth` `.Bitrate` `.Container` `.Extension` `.Group` `.Edition` `.Network` `.Site` `.Country` `.Region` `.Audio` `.Channels` `.HDR` `.Languages` |
 | Episode | `.Season` `.Episode` `.Seasons` `.Episodes` `.EpisodeCode` `.Volumes` |
 | Flags | `.Proper` `.Repack` `.Remastered` `.Upscaled` `.ThreeD` `.Scene` `.Retail` `.Hardcoded` `.Dubbed` `.Subbed` `.Commentary` `.Complete` `.Documentary` `.Unrated` `.Uncensored` `.PPV` |
@@ -141,8 +141,11 @@ rules](rules.md#community--from-seadex) for how the lookup works. `.Best` and
 recommended for *this* anime rather than groups with a good name in general:
 
 ```
-{{if .Seadex.Best}}🥇 SeaDex best{{else if .Seadex.Alternative}}🥈 SeaDex pick{{end}}
+{{if .Seadex.Best}}🥇 SeaDex best{{else if .Seadex.Alternative}}🥈 SeaDex pick{{end}}{{if .Seadex.DualAudio}} · dual audio{{end}}
 ```
+
+`.DualAudio` is SeaDex's own flag on the group's recommended release, so it
+marks dual audio even when the release name does not say so.
 
 `.Checked` reports a lookup ran at all (only anime requested through Kitsu is
 looked up), and `.Known` that SeaDex has an entry for the title. Both are false

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -366,9 +366,10 @@ seadex.dualAudio                           → +800
 `seadex.best` is true when this release's group made a release SeaDex marks
 best for the requested title; `seadex.alternative` when the group is
 recommended without the best mark; `seadex.dualAudio` when the group's
-recommended release is marked dual audio — SeaDex's own flag, independent of
-the best mark, and the one answer to "does this carry both languages" a
-release name tagged `DUAL` cannot give; `seadex.known` when SeaDex has an
+recommended release is marked dual audio — SeaDex's own flag, judged on the
+group's best release when it has one and on its alternatives otherwise, and
+the one answer to "does this carry both languages" a release name tagged
+`DUAL` cannot give; `seadex.known` when SeaDex has an
 entry for the title at all. Matching is by release-group name, case-insensitively —
 SeaDex catalogs torrents, so the recommendation transfers to usenet whenever
 the same group's release circulates under its group tag.

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -349,7 +349,7 @@ is not a release you can play.
 
 ### community — from SeaDex
 
-`seadex.known` `seadex.best` `seadex.alternative`
+`seadex.known` `seadex.best` `seadex.alternative` `seadex.dualAudio`
 
 [SeaDex](https://releases.moe) curates, per anime title, which release groups
 produced the best and the notable alternative releases of *that* title — a
@@ -360,12 +360,16 @@ attributes carry:
 ```
 seadex.best                                → +1000
 seadex.alternative                         → +500
+seadex.dualAudio                           → +800
 ```
 
 `seadex.best` is true when this release's group made a release SeaDex marks
 best for the requested title; `seadex.alternative` when the group is
-recommended without the best mark; `seadex.known` when SeaDex has an entry for
-the title at all. Matching is by release-group name, case-insensitively —
+recommended without the best mark; `seadex.dualAudio` when the group's
+recommended release is marked dual audio — SeaDex's own flag, independent of
+the best mark, and the one answer to "does this carry both languages" a
+release name tagged `DUAL` cannot give; `seadex.known` when SeaDex has an
+entry for the title at all. Matching is by release-group name, case-insensitively —
 SeaDex catalogs torrents, so the recommendation transfers to usenet whenever
 the same group's release circulates under its group tag.
 

--- a/frontend/src/components/ResultFormatEditor.jsx
+++ b/frontend/src/components/ResultFormatEditor.jsx
@@ -38,7 +38,7 @@ const FORMAT_FIELDS = [
   { group: 'Kind', fields: ['.Kind', '.IsAnime'] },
   { group: 'Probed', fields: ['.Verified', '.Probed.VideoCodec', '.Probed.AudioCodec', '.Probed.Width', '.Probed.Height', '.Probed.Profile', '.Probed.BitDepth', '.Probed.HDR', '.Probed.DolbyVision', '.Probed.HasHDRFallback', '.Probed.DynamicRange', '.Probed.TracksProbed', '.Probed.AudioLanguages', '.Probed.SubtitleLanguages', '.Probed.AudioStreams', '.Probed.SubtitleStreams'] },
   { group: 'Avail', fields: ['.Availability.Status', '.Availability.Known', '.Availability.OnMyBackbone', '.Availability.CheckedDaysAgo', '.Availability.Compression'] },
-  { group: 'SeaDex', fields: ['.Seadex.Checked', '.Seadex.Known', '.Seadex.Best', '.Seadex.Alternative'] },
+  { group: 'SeaDex', fields: ['.Seadex.Checked', '.Seadex.Known', '.Seadex.Best', '.Seadex.Alternative', '.Seadex.DualAudio'] },
   { group: 'Helpers', fields: ['size .Size', 'score .Score', 'join .HDR "|"', 'upper .Codec', 'lower', 'trim', 'replace .Resolution "1080p" "HD"', 'default "?" .Group', 'title .ParsedTitle', 'truncate 24 .ParsedTitle', 'remove "DD" .Audio', 'translate "0123456789" "₀₁₂₃₄₅₆₇₈₉" .Score', 'smallcaps .Network', '.ParsedTitle | title | truncate 24'] },
   { group: 'Lists', fields: ['sortAsc .Audio', 'sortDesc .Channels', 'first .Audio', 'last .Audio', 'length .HDR', 'join (sortAsc .Audio) " · "'] },
   { group: 'Math', fields: ['add 100 .Score', 'sub 100 .Score', 'mul 2 .Season', 'div 1000 .Score', 'mod 10 .Score', 'min 50 .Score', 'max 0 .Score', 'stars 5 .TopScore .Score', 'repeat "▰" 3', '.Score | div 1000 | repeat "▰"'] },

--- a/frontend/src/components/SampleRelease.jsx
+++ b/frontend/src/components/SampleRelease.jsx
@@ -302,7 +302,7 @@ export function SampleRelease({ value, onChange, open, onOpenChange }) {
                 </SettingRow>
                 <SettingRow
                   label="Groups with dual audio"
-                  description="Groups whose recommended release SeaDex marks dual audio. A group may also be in either list above."
+                  description="Groups from the two lists above whose recommended release SeaDex marks dual audio. A group listed only here is ignored: dual audio is a property of a recommendation."
                 >
                   <Input
                     value={sample.seadex.dual_audio_groups || ""}

--- a/frontend/src/components/SampleRelease.jsx
+++ b/frontend/src/components/SampleRelease.jsx
@@ -300,6 +300,17 @@ export function SampleRelease({ value, onChange, open, onOpenChange }) {
                     className="h-9 w-52 font-mono text-xs"
                   />
                 </SettingRow>
+                <SettingRow
+                  label="Groups with dual audio"
+                  description="Groups whose recommended release SeaDex marks dual audio. A group may also be in either list above."
+                >
+                  <Input
+                    value={sample.seadex.dual_audio_groups || ""}
+                    onChange={(e) => patch({ seadex: { ...sample.seadex, dual_audio_groups: e.target.value } })}
+                    placeholder="Anime Time"
+                    className="h-9 w-52 font-mono text-xs"
+                  />
+                </SettingRow>
               </>
             )}
           </SettingGroup>

--- a/frontend/src/lib/profiles.js
+++ b/frontend/src/lib/profiles.js
@@ -344,6 +344,7 @@ export const RULE_ATTRIBUTES = [
       { name: "seadex.known", type: "yes/no", example: "SeaDex has an entry for this title" },
       { name: "seadex.best", type: "yes/no", example: "this group made a release marked best for this title" },
       { name: "seadex.alternative", type: "yes/no", example: "recommended for this title, without the best mark" },
+      { name: "seadex.dualAudio", type: "yes/no", example: "this group's recommended release is marked dual audio" },
     ],
   },
   {

--- a/frontend/src/lib/sample.js
+++ b/frontend/src/lib/sample.js
@@ -22,6 +22,7 @@ export const DEFAULT_SEADEX = {
   known: true,
   best_groups: "",
   alt_groups: "",
+  dual_audio_groups: "",
 }
 
 // activeCount says how much of the release is being pretended about, so the
@@ -55,6 +56,7 @@ export function sampleForRequest(sample) {
       known: sample.seadex.known === true,
       best_groups: splitList(sample.seadex.best_groups),
       alt_groups: splitList(sample.seadex.alt_groups),
+      dual_audio_groups: splitList(sample.seadex.dual_audio_groups),
     }
   }
   return out

--- a/pkg/search/ranking/service.go
+++ b/pkg/search/ranking/service.go
@@ -584,6 +584,7 @@ func (p *Profile) recordVerdicts(req Request, results []Result) {
 				Known:       se.Known,
 				Best:        se.Best,
 				Alternative: se.Alternative,
+				DualAudio:   se.DualAudio,
 			}
 		}
 	}

--- a/pkg/search/rules/env.go
+++ b/pkg/search/rules/env.go
@@ -286,6 +286,8 @@ func (e *Env) Lookup(path string) (jhinrules.Value, bool) {
 		return jhinrules.BoolOf(e.Seadex.Best), true
 	case "seadex.alternative":
 		return jhinrules.BoolOf(e.Seadex.Alternative), true
+	case "seadex.dualAudio":
+		return jhinrules.BoolOf(e.Seadex.DualAudio), true
 
 	case "probed.videoCodec":
 		return jhinrules.StrOf(e.Probed.VideoCodec), true
@@ -415,6 +417,10 @@ type SeadexEnv struct {
 	// Alternative is true when the group is recommended for this title without
 	// the best mark.
 	Alternative bool
+	// DualAudio is true when the group has a recommended release SeaDex marks
+	// dual audio for this title. Per title, like Best: the same group can
+	// ship dual audio for one anime and sub-only for the next.
+	DualAudio bool
 	// Checked reports that the lookup ran at all. When it is false — not an
 	// anime request, no AniList mapping, or SeaDex unreachable — rules reading
 	// seadex.* are skipped rather than judged against zero values. Not exposed
@@ -489,9 +495,12 @@ type SeadexContext struct {
 	// the title.
 	Known bool
 	// Best holds the groups with a release marked best for this title, Alt
-	// the recommended groups without a best mark.
-	Best map[string]bool
-	Alt  map[string]bool
+	// the recommended groups without a best mark, DualAudio the groups with
+	// a recommended release marked dual audio. A group may be in DualAudio
+	// and either of the other two.
+	Best      map[string]bool
+	Alt       map[string]bool
+	DualAudio map[string]bool
 }
 
 // BuildEnv assembles the environment for one release. parsed may be nil when
@@ -590,6 +599,7 @@ func (c *SeadexContext) For(group string) SeadexEnv {
 		Known:       c.Known,
 		Best:        g != "" && c.Best[g],
 		Alternative: g != "" && c.Alt[g],
+		DualAudio:   g != "" && c.DualAudio[g],
 	}
 }
 

--- a/pkg/search/rules/rules.go
+++ b/pkg/search/rules/rules.go
@@ -80,7 +80,7 @@ func buildRegistry() *jhinrules.Registry {
 		Str("status").Bool("known").Bool("onMyBackbone").
 		Num("checkedDaysAgo").Str("compression")
 	reg.Namespace("seadex", tierSeadex).
-		Bool("known").Bool("best").Bool("alternative")
+		Bool("known").Bool("best").Bool("alternative").Bool("dualAudio")
 
 	// Measured: what ffprobe found in the file itself.
 	reg.Namespace("probed", tierMeasured).

--- a/pkg/search/rules/rules_test.go
+++ b/pkg/search/rules/rules_test.go
@@ -547,6 +547,31 @@ func TestSeadexJudgesByGroup(t *testing.T) {
 	}
 }
 
+// Dual audio is SeaDex's own flag on a recommended release, independent of the
+// best mark: a best release may be sub-only and an alternative dual.
+func TestSeadexDualAudioIsPerGroup(t *testing.T) {
+	set := compile(t,
+		config.RuleConfig{Name: "SeaDex best", When: `seadex.best`, Points: 1000},
+		config.RuleConfig{Name: "SeaDex dual audio", When: `seadex.dualAudio`, Points: 800},
+	)
+	seadex := &rules.SeadexContext{
+		Known:     true,
+		Best:      map[string]bool{"koala": true},
+		Alt:       map[string]bool{"anime time": true},
+		DualAudio: map[string]bool{"anime time": true},
+	}
+
+	if got := set.Evaluate(seadexEnvFor("Anime S01E01 1080p BluRay x265-KoaLa", seadex), "anime_show"); got.Points != 1000 {
+		t.Errorf("sub-only best group scored %d, want 1000", got.Points)
+	}
+	if got := set.Evaluate(seadexEnvFor("[Anime Time] Anime - 01 [1080p][Dual-Audio]", seadex), "anime_show"); got.Points != 800 {
+		t.Errorf("dual-audio alternative scored %d, want 800", got.Points)
+	}
+	if got := set.Evaluate(seadexEnvFor("Anime S01E01 1080p BluRay x265-OTHER", seadex), "anime_show"); got.Points != 0 {
+		t.Errorf("an unlisted group scored %d, want 0", got.Points)
+	}
+}
+
 // No lookup and no entry are different claims. Without a lookup, seadex rules
 // are skipped; with a lookup that found nothing, they run and seadex.known is
 // simply false.

--- a/pkg/search/triage/verdict.go
+++ b/pkg/search/triage/verdict.go
@@ -74,6 +74,9 @@ type SeadexState struct {
 	// for this title; Alternative that it is recommended without the mark.
 	Best        bool
 	Alternative bool
+	// DualAudio reports the group has a recommended release SeaDex marks
+	// dual audio for this title.
+	DualAudio bool
 }
 
 // RuleMatch is one named scoring rule that fired on a release, in the shape

--- a/pkg/server/api/handlers_ranking.go
+++ b/pkg/server/api/handlers_ranking.go
@@ -66,6 +66,9 @@ type explainSeadex struct {
 	Known      bool     `json:"known,omitempty"`
 	BestGroups []string `json:"best_groups,omitempty"`
 	AltGroups  []string `json:"alt_groups,omitempty"`
+	// DualAudioGroups names the groups whose recommended release is marked
+	// dual audio; a group may appear here and in one of the lists above.
+	DualAudioGroups []string `json:"dual_audio_groups,omitempty"`
 }
 
 // toSeadex builds the request-level SeaDex context, nil when the sample does
@@ -75,9 +78,15 @@ func (e *explainSample) toSeadex() *rules.SeadexContext {
 		return nil
 	}
 	out := &rules.SeadexContext{
-		Known: e.Seadex.Known || len(e.Seadex.BestGroups) > 0 || len(e.Seadex.AltGroups) > 0,
-		Best:  make(map[string]bool, len(e.Seadex.BestGroups)),
-		Alt:   make(map[string]bool, len(e.Seadex.AltGroups)),
+		Known:     e.Seadex.Known || len(e.Seadex.BestGroups) > 0 || len(e.Seadex.AltGroups) > 0 || len(e.Seadex.DualAudioGroups) > 0,
+		Best:      make(map[string]bool, len(e.Seadex.BestGroups)),
+		Alt:       make(map[string]bool, len(e.Seadex.AltGroups)),
+		DualAudio: make(map[string]bool, len(e.Seadex.DualAudioGroups)),
+	}
+	for _, g := range e.Seadex.DualAudioGroups {
+		if g = strings.ToLower(strings.TrimSpace(g)); g != "" {
+			out.DualAudio[g] = true
+		}
 	}
 	for _, g := range e.Seadex.BestGroups {
 		if g = strings.ToLower(strings.TrimSpace(g)); g != "" {

--- a/pkg/server/api/handlers_ranking.go
+++ b/pkg/server/api/handlers_ranking.go
@@ -83,11 +83,6 @@ func (e *explainSample) toSeadex() *rules.SeadexContext {
 		Alt:       make(map[string]bool, len(e.Seadex.AltGroups)),
 		DualAudio: make(map[string]bool, len(e.Seadex.DualAudioGroups)),
 	}
-	for _, g := range e.Seadex.DualAudioGroups {
-		if g = strings.ToLower(strings.TrimSpace(g)); g != "" {
-			out.DualAudio[g] = true
-		}
-	}
 	for _, g := range e.Seadex.BestGroups {
 		if g = strings.ToLower(strings.TrimSpace(g)); g != "" {
 			out.Best[g] = true
@@ -96,6 +91,14 @@ func (e *explainSample) toSeadex() *rules.SeadexContext {
 	for _, g := range e.Seadex.AltGroups {
 		if g = strings.ToLower(strings.TrimSpace(g)); g != "" && !out.Best[g] {
 			out.Alt[g] = true
+		}
+	}
+	// Dual audio is a property of a recommended release, so it only holds
+	// for a group SeaDex recommends: the live lookup can never produce
+	// dualAudio without best or alternative, and neither may the preview.
+	for _, g := range e.Seadex.DualAudioGroups {
+		if g = strings.ToLower(strings.TrimSpace(g)); g != "" && (out.Best[g] || out.Alt[g]) {
+			out.DualAudio[g] = true
 		}
 	}
 	return out

--- a/pkg/server/api/handlers_ranking_test.go
+++ b/pkg/server/api/handlers_ranking_test.go
@@ -71,6 +71,39 @@ func TestHandleRankingExplainUsesPostedProfile(t *testing.T) {
 	}
 }
 
+// A SeaDex sample answers seadex.dualAudio only for a group it also
+// recommends, matching the invariant the live lookup keeps.
+func TestHandleRankingExplainSeadexDualAudioNeedsARecommendation(t *testing.T) {
+	s := &Server{config: adminConfig()}
+	profile := &config.FilterProfileConfig{
+		Name:  "Dual",
+		Rules: []config.RuleConfig{{Name: "No dual", When: `seadex.dualAudio`, Action: config.RuleActionReject}},
+	}
+	explain := func(seadex *explainSeadex) bool {
+		t.Helper()
+		rec := postExplain(t, s, explainRequest{
+			Titles:  []string{"Anime S01E01 1080p BluRay x265-Koala"},
+			Profile: profile,
+			Kind:    "anime_show",
+			Sample:  &explainSample{Seadex: seadex},
+		})
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+		}
+		var got explainResponse
+		if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+			t.Fatal(err)
+		}
+		return got.Results[0].Fetch
+	}
+	if explain(&explainSeadex{BestGroups: []string{"Koala"}, DualAudioGroups: []string{"Koala"}}) {
+		t.Error("a recommended dual-audio group must trip the reject rule")
+	}
+	if !explain(&explainSeadex{DualAudioGroups: []string{"Koala"}}) {
+		t.Error("dual audio without a recommendation must not be answered true")
+	}
+}
+
 func TestHandleRankingExplainResolvesSavedProfileByName(t *testing.T) {
 	s := &Server{config: adminConfig(config.DefaultFilterProfile())}
 

--- a/pkg/server/stremio/formatter.go
+++ b/pkg/server/stremio/formatter.go
@@ -183,6 +183,9 @@ type SeadexInfo struct {
 	// for the title; Alternative that it is recommended without the mark.
 	Best        bool
 	Alternative bool
+	// DualAudio reports the group has a recommended release SeaDex marks
+	// dual audio for the title.
+	DualAudio bool
 }
 
 // stringList and intList render as comma-separated text instead of Go's
@@ -653,6 +656,7 @@ func newFormatContext(cand triage.Candidate, index, count, topScore int, service
 			Known:       cand.Verdict.Seadex.Known,
 			Best:        cand.Verdict.Seadex.Best,
 			Alternative: cand.Verdict.Seadex.Alternative,
+			DualAudio:   cand.Verdict.Seadex.DualAudio,
 		},
 	}
 	if probed := cand.Verdict.Probed; probed != nil {

--- a/pkg/server/stremio/formatter.go
+++ b/pkg/server/stremio/formatter.go
@@ -990,7 +990,7 @@ func formatPreviewFixtures() []formatPreviewFixture {
 			pubDate: time.Now().Add(-300 * 24 * time.Hour).Format(time.RFC1123Z),
 			score:   3600,
 			runtime: 24 * 60,
-			seadex:  triage.SeadexState{Checked: true, Known: true, Best: true},
+			seadex:  triage.SeadexState{Checked: true, Known: true, Best: true, DualAudio: true},
 		},
 		{
 			label:   "Library hit · ffprobe verified",

--- a/pkg/server/stremio/seadex.go
+++ b/pkg/server/stremio/seadex.go
@@ -55,13 +55,15 @@ func (s *Server) seadexContext(ctx context.Context, source *playlistSource, stre
 		return &rules.SeadexContext{}
 	}
 	best, alt := entry.GroupSets()
+	dual := entry.DualAudioGroups()
 	logger.Debug("SeaDex entry resolved",
 		"kitsu_id", kitsuID,
 		"anilist_id", mapping.AniListID,
 		"best_groups", len(best),
 		"alt_groups", len(alt),
+		"dual_audio_groups", len(dual),
 	)
-	return &rules.SeadexContext{Known: true, Best: best, Alt: alt}
+	return &rules.SeadexContext{Known: true, Best: best, Alt: alt, DualAudio: dual}
 }
 
 // annotateSeadexVerdicts judges each candidate's parsed group against the
@@ -83,6 +85,7 @@ func annotateSeadexVerdicts(candidates []triage.Candidate, seadexCtx *rules.Sead
 			Known:       se.Known,
 			Best:        se.Best,
 			Alternative: se.Alternative,
+			DualAudio:   se.DualAudio,
 		}
 	}
 }

--- a/pkg/services/metadata/seadex/seadex.go
+++ b/pkg/services/metadata/seadex/seadex.go
@@ -66,6 +66,23 @@ func (e *Entry) GroupSets() (best, alt map[string]bool) {
 	return best, alt
 }
 
+// DualAudioGroups projects the entry onto the normalized release-group names
+// with at least one recommended release SeaDex marks dual audio for this
+// title. Like GroupSets it is per title: a group that ships dual audio for one
+// anime and sub-only for the next is judged per entry.
+func (e *Entry) DualAudioGroups() map[string]bool {
+	out := make(map[string]bool)
+	if e == nil {
+		return out
+	}
+	for _, t := range e.Torrents {
+		if g := NormalizeGroup(t.ReleaseGroup); g != "" && t.DualAudio {
+			out[g] = true
+		}
+	}
+	return out
+}
+
 // NormalizeGroup canonicalizes a release-group name for matching: SeaDex spells
 // groups as they name themselves ("SubsPlease"), release parsers report what
 // the filename carried, and case is the only difference that occurs in

--- a/pkg/services/metadata/seadex/seadex.go
+++ b/pkg/services/metadata/seadex/seadex.go
@@ -67,16 +67,39 @@ func (e *Entry) GroupSets() (best, alt map[string]bool) {
 }
 
 // DualAudioGroups projects the entry onto the normalized release-group names
-// with at least one recommended release SeaDex marks dual audio for this
-// title. Like GroupSets it is per title: a group that ships dual audio for one
-// anime and sub-only for the next is judged per entry.
+// whose recommended release for this title is dual audio. It follows the same
+// "stronger claim wins" rule as GroupSets: when a group has a release marked
+// best, that release decides, and its alternatives do not — so a group whose
+// best is sub-only stays false even if it also has a dual-audio alternative,
+// and `seadex.best and not seadex.dualAudio` means what it says. A group with
+// no best mark is judged by its recommended alternatives. Per title, like the
+// rest of the namespace.
 func (e *Entry) DualAudioGroups() map[string]bool {
 	out := make(map[string]bool)
 	if e == nil {
 		return out
 	}
+	type claim struct{ best, bestDual, altDual bool }
+	claims := make(map[string]*claim)
 	for _, t := range e.Torrents {
-		if g := NormalizeGroup(t.ReleaseGroup); g != "" && t.DualAudio {
+		g := NormalizeGroup(t.ReleaseGroup)
+		if g == "" {
+			continue
+		}
+		c := claims[g]
+		if c == nil {
+			c = &claim{}
+			claims[g] = c
+		}
+		if t.IsBest {
+			c.best = true
+			c.bestDual = c.bestDual || t.DualAudio
+		} else {
+			c.altDual = c.altDual || t.DualAudio
+		}
+	}
+	for g, c := range claims {
+		if (c.best && c.bestDual) || (!c.best && c.altDual) {
 			out[g] = true
 		}
 	}

--- a/pkg/services/metadata/seadex/seadex_test.go
+++ b/pkg/services/metadata/seadex/seadex_test.go
@@ -118,10 +118,20 @@ func TestDualAudioGroups(t *testing.T) {
 		{ReleaseGroup: "Anime Time", IsBest: false, DualAudio: true},
 		{ReleaseGroup: "LostYears", IsBest: true, DualAudio: true},
 		{ReleaseGroup: "  ", DualAudio: true},
+		// The best decides: a sub-only best is not made dual by a dual
+		// alternative from the same group.
+		{ReleaseGroup: "Judas", IsBest: true, DualAudio: false},
+		{ReleaseGroup: "judas", IsBest: false, DualAudio: true},
+		// ...and in the other order of appearance.
+		{ReleaseGroup: "Arid", IsBest: false, DualAudio: true},
+		{ReleaseGroup: "Arid", IsBest: true, DualAudio: false},
 	}}
 	dual := entry.DualAudioGroups()
 	if !dual["anime time"] || !dual["lostyears"] || len(dual) != 2 {
 		t.Fatalf("dual = %v, want exactly anime time and lostyears", dual)
+	}
+	if dual["judas"] || dual["arid"] {
+		t.Fatalf("a group whose best release is sub-only must not read as dual audio: %v", dual)
 	}
 	if len((*Entry)(nil).DualAudioGroups()) != 0 {
 		t.Fatal("a nil entry has no dual-audio groups")

--- a/pkg/services/metadata/seadex/seadex_test.go
+++ b/pkg/services/metadata/seadex/seadex_test.go
@@ -111,3 +111,19 @@ func TestGroupSetsBestWins(t *testing.T) {
 		t.Fatal("a nil entry recommends nothing")
 	}
 }
+
+func TestDualAudioGroups(t *testing.T) {
+	entry := &Entry{Torrents: []Torrent{
+		{ReleaseGroup: "Koala", IsBest: true, DualAudio: false},
+		{ReleaseGroup: "Anime Time", IsBest: false, DualAudio: true},
+		{ReleaseGroup: "LostYears", IsBest: true, DualAudio: true},
+		{ReleaseGroup: "  ", DualAudio: true},
+	}}
+	dual := entry.DualAudioGroups()
+	if !dual["anime time"] || !dual["lostyears"] || len(dual) != 2 {
+		t.Fatalf("dual = %v, want exactly anime time and lostyears", dual)
+	}
+	if len((*Entry)(nil).DualAudioGroups()) != 0 {
+		t.Fatal("a nil entry has no dual-audio groups")
+	}
+}


### PR DESCRIPTION
### What

The SeaDex client already decodes `dualAudio` per recommended release (`seadex.go`, `Torrent.DualAudio`) and then drops it on the floor; only `best` and `alternative` reach rules. This carries it through:

- `Entry.DualAudioGroups()` next to `GroupSets()`
- `SeadexContext.DualAudio` on the request, `SeadexEnv.DualAudio` per release, judged by group exactly like `best`
- `seadex.dualAudio` in the rules registry, under the existing SeaDex tier (skipped when no lookup ran)
- `triage.SeadexState.DualAudio` on the verdict, so the formatter gets `.Seadex.DualAudio`
- `dual_audio_groups` on the preview sample, mirroring `best_groups` / `alt_groups`

### Why

A release name tagged `DUAL` or `Dual-Audio` says two languages, not which two, and plenty of dual-audio releases say nothing at all. SeaDex's flag is a curated per-title answer for the group's release of *this* anime, so a rule can say:

```
seadex.dualAudio                           → +800
seadex.best and not seadex.dualAudio       → +200   # sub-only best still fine
```

It's independent of the best mark on purpose (a best release may be sub-only while an alternative is dual), which `TestSeadexDualAudioIsPerGroup` pins.

### Preview invariant

`dual_audio_groups` on the sample only counts for a group that is also in `best_groups` or `alt_groups`, the same invariant the live lookup keeps; the sample editor exposes all three lists.

### Tests

`go test` passes for `pkg/services/metadata/seadex`, `pkg/search/rules`, `pkg/search/ranking`, `pkg/server/stremio`. `gofmt` and `go vet` clean. Docs updated in `rules.md` and `result-formatting.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MzJz3CvfuTMMDWn2jnntV3