### PR TITLE
feat(rules): put the requested title's original language on the request

### DIFF
--- a/docs/result-formatting.md
+++ b/docs/result-formatting.md
@@ -78,8 +78,11 @@ guess from the release name. `.Kind` is the full content kind: `movie`,
 ```
 
 `.OriginalLanguage` is the requested title's original language from metadata
-(ISO 639-1, the same codes `.Languages` holds), empty when it did not say. A
-badge for original-audio releases needs no per-language line:
+as an ISO 639-1 code, empty when it did not say. `.Languages` holds the same
+codes when they came from the release name; when the name carried no language
+token it falls back to what the indexer reported, which may be a word
+(`English`) rather than a code, and the comparison below then simply does not
+fire. A badge for original-audio releases needs no per-language line:
 
 ```
 {{if and .OriginalLanguage (contains .OriginalLanguage .Languages)}}🎙 original audio{{end}}

--- a/docs/result-formatting.md
+++ b/docs/result-formatting.md
@@ -23,7 +23,7 @@ release's parsed data.
 
 | Group | Fields |
 |---|---|
-| Request | `.Service` `.Stream` `.Content` `.Index` `.Count` `.TopScore` `.Kind` `.IsAnime` |
+| Request | `.Service` `.Stream` `.Content` `.Index` `.Count` `.TopScore` `.Kind` `.IsAnime` `.OriginalLanguage` |
 | Release | `.ReleaseTitle` `.Size` `.Indexer` `.Variants` `.VariantIndexers` `.Grabs` `.Age` `.Duration` `.Score` `.Avail` `.Library` `.Caps` `.MatchedRules` |
 | Measured | `.Verified` `.Probed.VideoCodec` `.Probed.AudioCodec` `.Probed.Width` `.Probed.Height` `.Probed.Profile` `.Probed.BitDepth` `.Probed.HDR` `.Probed.DolbyVision` `.Probed.HasHDRFallback` `.Probed.DynamicRange` `.Probed.TracksProbed` `.Probed.AudioLanguages` `.Probed.SubtitleLanguages` `.Probed.AudioStreams` `.Probed.SubtitleStreams` |
 | Availability | `.Availability.Status` `.Availability.Known` `.Availability.OnMyBackbone` `.Availability.CheckedDaysAgo` `.Availability.Compression` |
@@ -75,6 +75,14 @@ guess from the release name. `.Kind` is the full content kind: `movie`,
 
 ```
 {{if .IsAnime}}🌸 {{end}}{{.Resolution}}
+```
+
+`.OriginalLanguage` is the requested title's original language from metadata
+(ISO 639-1, the same codes `.Languages` holds), empty when it did not say. A
+badge for original-audio releases needs no per-language line:
+
+```
+{{if and .OriginalLanguage (contains .OriginalLanguage .Languages)}}🎙 original audio{{end}}
 ```
 
 ### Matched rules

--- a/docs/result-formatting.md
+++ b/docs/result-formatting.md
@@ -81,11 +81,14 @@ guess from the release name. `.Kind` is the full content kind: `movie`,
 as an ISO 639-1 code, empty when it did not say. `.Languages` holds the same
 codes when they came from the release name; when the name carried no language
 token it falls back to what the indexer reported, which may be a word
-(`English`) rather than a code, and the comparison below then simply does not
-fire. A badge for original-audio releases needs no per-language line:
+(`English`) rather than a code — `has` then finds no match and the badge stays
+off, which is the honest answer. Use `has`, which is membership on the list;
+`contains` is a substring test over the list's text and would light up `en`
+inside `French`. A badge for original-audio releases needs no per-language
+line:
 
 ```
-{{if and .OriginalLanguage (contains .OriginalLanguage .Languages)}}🎙 original audio{{end}}
+{{if and .OriginalLanguage (has .OriginalLanguage .Languages)}}🎙 original audio{{end}}
 ```
 
 ### Matched rules

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -430,7 +430,21 @@ This is what makes rules a complete replacement for the old per-trait controls:
 
 ### About the request
 
-`kind` `isAnime` `season` `episode` `title`
+`kind` `isAnime` `season` `episode` `title` `originalLanguage`
+
+`originalLanguage` is the language the requested title was made in, as the
+metadata provider reports it — an ISO 639-1 code like `"ja"`, `"ko"` or
+`"fr"`, the same codes `languages` holds — or empty when the provider did not
+say. It turns "prefer the original audio" into one rule instead of one per
+language, and it is what makes a dub recognisable as a dub:
+
+```
+originalLanguage != "" and originalLanguage in languages            → +500
+originalLanguage != "" and dubbed and not (originalLanguage in languages) → -300
+```
+
+Guard on it being non-empty: a request whose metadata carries no language
+answers `""`, and `"" in languages` is never what a rule means.
 
 ### After scoring — prune rules only
 

--- a/frontend/src/components/ProfileEditor.jsx
+++ b/frontend/src/components/ProfileEditor.jsx
@@ -78,6 +78,7 @@ export function ProfileEditor({ profile, onChange, libraryRules = [] }) {
   const [sampleInput, setSampleInput] = useState(SAMPLE_TITLES.join("\n"))
   const [previewKind, setPreviewKind] = useState("movie")
   const [targetTitle, setTargetTitle] = useState("")
+  const [originalLanguage, setOriginalLanguage] = useState("")
   const [sample, setSample] = useState(EMPTY_SAMPLE)
 
   // One preview request serves the rules tab's per-rule counts and the panel's
@@ -91,6 +92,7 @@ export function ProfileEditor({ profile, onChange, libraryRules = [] }) {
     titles: sampleTitles,
     kind: previewKind,
     targetTitle,
+    originalLanguage,
     sample,
   })
 
@@ -148,6 +150,8 @@ export function ProfileEditor({ profile, onChange, libraryRules = [] }) {
             onKindChange={setPreviewKind}
             targetTitle={targetTitle}
             onTargetTitleChange={setTargetTitle}
+            originalLanguage={originalLanguage}
+            onOriginalLanguageChange={setOriginalLanguage}
             sample={sample}
             onSampleChange={setSample}
           />

--- a/frontend/src/components/ProfilePreview.jsx
+++ b/frontend/src/components/ProfilePreview.jsx
@@ -180,6 +180,8 @@ export function ProfilePreview({
   onKindChange,
   targetTitle,
   onTargetTitleChange,
+  originalLanguage,
+  onOriginalLanguageChange,
   sample,
   onSampleChange,
 }) {
@@ -257,6 +259,20 @@ export function ProfilePreview({
               onChange={(e) => onTargetTitleChange(e.target.value)}
               placeholder="The Matrix"
               className="h-9 w-44"
+            />
+          </SettingRow>
+
+          <SettingRow
+            label="Original language"
+            htmlFor="preview-original-language"
+            description="Optional. The language the pretend title was made in, as an ISO 639-1 code, for rules that read originalLanguage. Empty is what a title with no metadata answers."
+          >
+            <Input
+              id="preview-original-language"
+              value={originalLanguage}
+              onChange={(e) => onOriginalLanguageChange(e.target.value)}
+              placeholder="ja"
+              className="h-9 w-44 font-mono text-xs"
             />
           </SettingRow>
 

--- a/frontend/src/components/ResultFormatEditor.jsx
+++ b/frontend/src/components/ResultFormatEditor.jsx
@@ -35,7 +35,7 @@ const FORMAT_FIELDS = [
   { group: 'Parsed', fields: ['.ParsedTitle', '.Year', '.Date', '.Resolution', '.Quality', '.Codec', '.BitDepth', '.Bitrate', '.Container', '.Extension', '.Group', '.Edition', '.Network', '.Site', '.Country', '.Region', '.Audio', '.Channels', '.HDR', '.Languages'] },
   { group: 'Episode', fields: ['.Season', '.Episode', '.Seasons', '.Episodes', '.EpisodeCode', '.Volumes'] },
   { group: 'Flags', fields: ['.Proper', '.Repack', '.Remastered', '.Upscaled', '.ThreeD', '.Scene', '.Retail', '.Hardcoded', '.Dubbed', '.Subbed', '.Commentary', '.Complete', '.Documentary', '.Unrated', '.Uncensored', '.PPV'] },
-  { group: 'Kind', fields: ['.Kind', '.IsAnime'] },
+  { group: 'Kind', fields: ['.Kind', '.IsAnime', '.OriginalLanguage'] },
   { group: 'Probed', fields: ['.Verified', '.Probed.VideoCodec', '.Probed.AudioCodec', '.Probed.Width', '.Probed.Height', '.Probed.Profile', '.Probed.BitDepth', '.Probed.HDR', '.Probed.DolbyVision', '.Probed.HasHDRFallback', '.Probed.DynamicRange', '.Probed.TracksProbed', '.Probed.AudioLanguages', '.Probed.SubtitleLanguages', '.Probed.AudioStreams', '.Probed.SubtitleStreams'] },
   { group: 'Avail', fields: ['.Availability.Status', '.Availability.Known', '.Availability.OnMyBackbone', '.Availability.CheckedDaysAgo', '.Availability.Compression'] },
   { group: 'SeaDex', fields: ['.Seadex.Checked', '.Seadex.Known', '.Seadex.Best', '.Seadex.Alternative', '.Seadex.DualAudio'] },

--- a/frontend/src/components/ResultFormatEditor.jsx
+++ b/frontend/src/components/ResultFormatEditor.jsx
@@ -59,6 +59,7 @@ const FORMAT_FIELDS = [
       '{{if lt .Year 2000}}…{{end}}',
       '{{if le .Index 3}}…{{end}}',
       '{{if contains "DV" .HDR}}…{{end}}',
+      '{{if has "en" .Languages}}…{{end}}',
       '{{if hasPrefix "2160" .Resolution}}…{{end}}',
       '{{if hasSuffix "p" .Resolution}}…{{end}}',
     ],

--- a/frontend/src/hooks/useProfilePreview.js
+++ b/frontend/src/hooks/useProfilePreview.js
@@ -19,7 +19,7 @@ export const SAMPLE_TITLES = [
 // match counts, the bench reads it for the full breakdown. Two components
 // asking the same question separately would double the traffic and let them
 // disagree on screen, which is worse than either.
-export function useProfilePreview(profile, { titles, kind, targetTitle, sample } = {}) {
+export function useProfilePreview(profile, { titles, kind, targetTitle, originalLanguage, sample } = {}) {
   const [results, setResults] = useState(null)
   const [aggregates, setAggregates] = useState([])
   const [loading, setLoading] = useState(false)
@@ -52,6 +52,7 @@ export function useProfilePreview(profile, { titles, kind, targetTitle, sample }
           profile,
           kind: kind && kind !== "all" ? kind : undefined,
           target_title: targetTitle?.trim() || undefined,
+          original_language: originalLanguage?.trim() || undefined,
           sample: sampleForRequest(sample),
         }),
       })
@@ -76,7 +77,7 @@ export function useProfilePreview(profile, { titles, kind, targetTitle, sample }
     return () => window.clearTimeout(handle)
     // profileKey and titleKey stand in for the objects they serialize.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [profileKey, titleKey, sampleKey, kind, targetTitle])
+  }, [profileKey, titleKey, sampleKey, kind, targetTitle, originalLanguage])
 
   // ruleStats counts, per rule name, how many sampled releases it paid out on
   // and how many it could not be judged against. It is what turns a condition

--- a/frontend/src/lib/profiles.js
+++ b/frontend/src/lib/profiles.js
@@ -415,6 +415,7 @@ export const RULE_ATTRIBUTES = [
       { name: "season", type: "number" },
       { name: "episode", type: "number" },
       { name: "title", type: "text", example: "the title that was searched for" },
+      { name: "originalLanguage", type: "text", example: 'originalLanguage != "" and originalLanguage in languages — ISO 639-1 from metadata, "" when it did not say' },
     ],
   },
 ]

--- a/pkg/search/ranking/service.go
+++ b/pkg/search/ranking/service.go
@@ -237,6 +237,9 @@ type Request struct {
 	Season  int
 	Episode int
 	Title   string
+	// OriginalLanguage is the requested title's original language as an ISO
+	// 639-1 code from metadata, empty when unknown.
+	OriginalLanguage string
 	// Seadex is the SeaDex recommendation resolved for the requested anime,
 	// nil when no lookup ran (not anime, no mapping, or SeaDex unreachable).
 	Seadex *rules.SeadexContext
@@ -456,6 +459,7 @@ func (r Request) ruleContext() rules.Context {
 		Season:           r.Season,
 		Episode:          r.Episode,
 		Title:            r.Title,
+		OriginalLanguage: r.OriginalLanguage,
 		Episodic:         r.Kind == KindSeries || r.Kind == KindAnimeShow,
 		IndexerDataKnown: r.Sample != nil && r.Sample.IndexerData,
 		Seadex:           r.Seadex,
@@ -571,6 +575,7 @@ func (p *Profile) recordVerdicts(req Request, results []Result) {
 		r := &results[i]
 		r.Candidate.Verdict.Kind = req.Kind
 		r.Candidate.Verdict.IsAnime = req.IsAnime
+		r.Candidate.Verdict.OriginalLanguage = req.OriginalLanguage
 		r.Candidate.Verdict.Matched = r.Matched
 		r.Candidate.Verdict.Rejections = r.Torrent.Rejections
 		if req.Seadex != nil {

--- a/pkg/search/rules/env.go
+++ b/pkg/search/rules/env.go
@@ -148,6 +148,11 @@ type Env struct {
 	Season  int
 	Episode int
 	Title   string
+	// OriginalLanguage is the language the requested title was made in, as
+	// an ISO 639-1 code from the metadata provider ("ja", "ko", "fr"), empty
+	// when the provider did not say. It is what lets "prefer the original
+	// audio" be one rule for every language rather than one per language.
+	OriginalLanguage string
 
 	// ---- post-scoring ----
 
@@ -330,6 +335,8 @@ func (e *Env) Lookup(path string) (jhinrules.Value, bool) {
 	// parsed.title. It shadows jhin's core field on purpose.
 	case "title":
 		return jhinrules.StrOf(e.Title), true
+	case "originalLanguage":
+		return jhinrules.StrOf(e.OriginalLanguage), true
 
 	case "finalScore":
 		return jhinrules.NumOf(float64(e.FinalScore)), true
@@ -474,6 +481,9 @@ type Context struct {
 	Season  int
 	Episode int
 	Title   string
+	// OriginalLanguage is the requested title's original language (ISO
+	// 639-1), empty when metadata did not carry one.
+	OriginalLanguage string
 	// Episodic marks a request for episodic content, which is what decides
 	// whether a size is judged whole or per episode.
 	Episodic bool
@@ -508,11 +518,12 @@ type SeadexContext struct {
 // which is the same thing an absent attribute has always meant here.
 func BuildEnv(cand triage.Candidate, parsed *jhinparser.Result, ctx Context) Env {
 	env := Env{
-		Kind:    ctx.Kind,
-		IsAnime: ctx.IsAnime,
-		Season:  ctx.Season,
-		Episode: ctx.Episode,
-		Title:   ctx.Title,
+		Kind:             ctx.Kind,
+		IsAnime:          ctx.IsAnime,
+		Season:           ctx.Season,
+		Episode:          ctx.Episode,
+		Title:            ctx.Title,
+		OriginalLanguage: ctx.OriginalLanguage,
 	}
 
 	if parsed != nil {

--- a/pkg/search/rules/rules.go
+++ b/pkg/search/rules/rules.go
@@ -101,6 +101,10 @@ func buildRegistry() *jhinrules.Registry {
 	reg.Field("isAnime", jhinrules.Bool, "")
 	reg.Field("season", jhinrules.Num, "")
 	reg.Field("episode", jhinrules.Num, "")
+	// The requested title's original language, from metadata. Always
+	// answerable — an empty string when the provider did not say — so it
+	// carries no tier; a rule that needs it can guard on it being non-empty.
+	reg.Field("originalLanguage", jhinrules.Str, "")
 
 	if err := reg.Err(); err != nil {
 		// A registration that fails is a programming error in this file, not

--- a/pkg/search/rules/rules_test.go
+++ b/pkg/search/rules/rules_test.go
@@ -514,6 +514,31 @@ func TestLibraryIsAnsweredWithoutIndexerData(t *testing.T) {
 	}
 }
 
+// originalLanguage is the request's, from metadata, so one rule covers every
+// language: a Japanese anime, a Korean drama and a French film all get "prefer
+// the original audio" from the same line.
+func TestOriginalLanguageIsPerRequest(t *testing.T) {
+	set := compile(t,
+		config.RuleConfig{Name: "Original audio", When: `originalLanguage != "" and originalLanguage in languages`, Points: 500},
+		config.RuleConfig{Name: "Dubbed, not original", When: `originalLanguage != "" and dubbed and not (originalLanguage in languages)`, Points: -300},
+	)
+	envFor := func(title, orig string) rules.Env {
+		cand := triage.Candidate{Release: &release.Release{Title: title}}
+		return rules.BuildEnv(cand, jhin.Parse(title), rules.Context{Kind: "series", OriginalLanguage: orig})
+	}
+
+	if got := set.Evaluate(envFor("Drama.S01E01.1080p.WEB-DL.Korean.H.264-GRP", "ko"), "series"); got.Points != 500 {
+		t.Errorf("Korean audio on a Korean title scored %d, want 500", got.Points)
+	}
+	if got := set.Evaluate(envFor("Drama.S01E01.1080p.WEB-DL.English.Dubbed.H.264-GRP", "ko"), "series"); got.Points != -300 {
+		t.Errorf("English dub of a Korean title scored %d, want -300", got.Points)
+	}
+	// Metadata did not say: both rules are guarded and neither fires.
+	if got := set.Evaluate(envFor("Drama.S01E01.1080p.WEB-DL.English.Dubbed.H.264-GRP", ""), "series"); got.Points != 0 {
+		t.Errorf("unknown original language scored %d, want 0", got.Points)
+	}
+}
+
 // seadexEnvFor builds the environment for one release under a request that
 // resolved a SeaDex answer, the way ranking does for an anime search.
 func seadexEnvFor(title string, seadex *rules.SeadexContext) rules.Env {

--- a/pkg/search/triage/verdict.go
+++ b/pkg/search/triage/verdict.go
@@ -104,6 +104,9 @@ type Verdict struct {
 	// IsAnime is the anime classification behind Kind, kept separately
 	// because it is the half of the decision that custom formats ask for.
 	IsAnime bool
+	// OriginalLanguage is the requested title's original language (ISO
+	// 639-1) as metadata reported it, empty when it did not.
+	OriginalLanguage string
 
 	// Rejections is why a profile turned the release away, empty when it was
 	// kept.

--- a/pkg/server/api/handlers_ranking.go
+++ b/pkg/server/api/handlers_ranking.go
@@ -32,6 +32,9 @@ type explainRequest struct {
 	// tuned per content kind can be previewed as each of them. Empty exercises
 	// the rules that apply everywhere.
 	Kind string `json:"kind,omitempty"`
+	// OriginalLanguage is what to pretend the requested title was made in
+	// (ISO 639-1), for rules that read originalLanguage.
+	OriginalLanguage string `json:"original_language,omitempty"`
 	// Sample is what to pretend about the releases being judged, for the parts
 	// a release name cannot carry. Absent leaves those rules unjudged.
 	Sample *explainSample `json:"sample,omitempty"`
@@ -236,11 +239,12 @@ func (s *Server) handleRankingExplain(w http.ResponseWriter, r *http.Request) {
 	opts := rank.RankOptions{TargetTitle: strings.TrimSpace(req.TargetTitle)}
 	kind := strings.ToLower(strings.TrimSpace(req.Kind))
 	explainReq := ranking.Request{
-		Kind:    kind,
-		IsAnime: kind == ranking.KindAnimeMovie || kind == ranking.KindAnimeShow,
-		Title:   strings.TrimSpace(req.TargetTitle),
-		Seadex:  req.Sample.toSeadex(),
-		Sample:  req.Sample.toSample(),
+		Kind:             kind,
+		IsAnime:          kind == ranking.KindAnimeMovie || kind == ranking.KindAnimeShow,
+		Title:            strings.TrimSpace(req.TargetTitle),
+		OriginalLanguage: strings.ToLower(strings.TrimSpace(req.OriginalLanguage)),
+		Seadex:           req.Sample.toSeadex(),
+		Sample:           req.Sample.toSample(),
 	}
 	results, aggregates := profile.Explain(titles, explainReq, opts)
 

--- a/pkg/server/stremio/formatter.go
+++ b/pkg/server/stremio/formatter.go
@@ -63,6 +63,11 @@ type FormatContext struct {
 	// decision on its own, which is the form templates usually want.
 	Kind    string
 	IsAnime bool
+	// OriginalLanguage is the requested title's original language as an ISO
+	// 639-1 code from metadata ("ja", "ko"), empty when it did not say. Pair
+	// it with .Languages to badge original-audio releases without a
+	// per-language template line.
+	OriginalLanguage string
 
 	// MatchedRules are the profile's named rules that paid out on this
 	// release, in configuration order. Range over them for badges
@@ -638,19 +643,20 @@ func newFormatContext(cand triage.Candidate, index, count, topScore int, service
 		service = DefaultServiceName
 	}
 	ctx := FormatContext{
-		Service:      service,
-		Stream:       streamID,
-		Content:      contentTitle,
-		Index:        index,
-		Count:        count,
-		Score:        cand.Score,
-		TopScore:     topScore,
-		Avail:        avail,
-		Caps:         caps,
-		Kind:         cand.Verdict.Kind,
-		IsAnime:      cand.Verdict.IsAnime,
-		MatchedRules: cand.Verdict.Matched,
-		Availability: availInfo(cand.Verdict.Avail),
+		Service:          service,
+		Stream:           streamID,
+		Content:          contentTitle,
+		Index:            index,
+		Count:            count,
+		Score:            cand.Score,
+		TopScore:         topScore,
+		Avail:            avail,
+		Caps:             caps,
+		Kind:             cand.Verdict.Kind,
+		IsAnime:          cand.Verdict.IsAnime,
+		OriginalLanguage: cand.Verdict.OriginalLanguage,
+		MatchedRules:     cand.Verdict.Matched,
+		Availability:     availInfo(cand.Verdict.Avail),
 		Seadex: SeadexInfo{
 			Checked:     cand.Verdict.Seadex.Checked,
 			Known:       cand.Verdict.Seadex.Known,

--- a/pkg/server/stremio/formatter.go
+++ b/pkg/server/stremio/formatter.go
@@ -961,6 +961,9 @@ type formatPreviewFixture struct {
 	kind             string
 	isAnime          bool
 	originalLanguage string
+	// languages is what the indexer reported, used when the title carries no
+	// language token, so at least one fixture renders the original-audio badge.
+	languages []string
 	// variants are the other indexers holding a copy of this release, so a
 	// preview of {{.Variants}} shows a merged result rather than a lone one.
 	variants []string
@@ -980,6 +983,7 @@ func formatPreviewFixtures() []formatPreviewFixture {
 			duration:         165 * 60,
 			kind:             "movie",
 			originalLanguage: "en",
+			languages:        []string{"en"},
 			variants:         []string{"NZBGeek", "NinjaCentral"},
 		},
 		{
@@ -1070,6 +1074,7 @@ func RenderFormatPreview(nameText, descText string) *FormatPreviewResult {
 			PubDate:   fx.pubDate,
 			Grabs:     fx.grabs,
 			Duration:  fx.duration,
+			Languages: fx.languages,
 		}
 		for _, name := range fx.variants {
 			rel.Variants = append(rel.Variants, &release.Release{Title: fx.title, Size: fx.size, Indexer: name, PubDate: fx.pubDate})

--- a/pkg/server/stremio/formatter.go
+++ b/pkg/server/stremio/formatter.go
@@ -505,6 +505,19 @@ var formatTemplateFuncs = template.FuncMap{
 	"contains": func(sub string, v any) bool {
 		return strings.Contains(templateText(v), sub)
 	},
+	// has is membership on a list, which contains is not: contains is a
+	// substring test over the list's rendered text, so `contains "en"
+	// .Languages` is true for ["French"]. {{if has "en" .Languages}} asks
+	// whether "en" is one of the entries.
+	"has": func(item string, v any) bool {
+		switch list := v.(type) {
+		case stringList:
+			return slices.Contains(list, item)
+		case []string:
+			return slices.Contains(list, item)
+		}
+		return false
+	},
 	"hasPrefix": func(prefix string, v any) bool {
 		return strings.HasPrefix(templateText(v), prefix)
 	},

--- a/pkg/server/stremio/formatter.go
+++ b/pkg/server/stremio/formatter.go
@@ -955,6 +955,12 @@ type formatPreviewFixture struct {
 	// fixtures without an indexer-reported duration still preview {{.Bitrate}}.
 	runtime float64
 	seadex  triage.SeadexState
+	// kind, isAnime and originalLanguage are the request half of the verdict,
+	// so {{.Kind}}, {{.IsAnime}} and {{.OriginalLanguage}} preview as they
+	// render on a live result instead of as their zero values.
+	kind             string
+	isAnime          bool
+	originalLanguage string
 	// variants are the other indexers holding a copy of this release, so a
 	// preview of {{.Variants}} shows a merged result rather than a lone one.
 	variants []string
@@ -963,54 +969,63 @@ type formatPreviewFixture struct {
 func formatPreviewFixtures() []formatPreviewFixture {
 	return []formatPreviewFixture{
 		{
-			label:    "4K movie · fresh indexer hit",
-			content:  "Dune: Part Two",
-			title:    "Dune.Part.Two.2024.2160p.WEB-DL.DV.HDR10.HEVC.DDP5.1.Atmos-FLUX",
-			indexer:  "DrunkenSlug",
-			size:     24_800_000_000,
-			grabs:    154,
-			pubDate:  time.Now().Add(-40 * 24 * time.Hour).Format(time.RFC1123Z),
-			score:    4200,
-			duration: 165 * 60,
-			variants: []string{"NZBGeek", "NinjaCentral"},
+			label:            "4K movie · fresh indexer hit",
+			content:          "Dune: Part Two",
+			title:            "Dune.Part.Two.2024.2160p.WEB-DL.DV.HDR10.HEVC.DDP5.1.Atmos-FLUX",
+			indexer:          "DrunkenSlug",
+			size:             24_800_000_000,
+			grabs:            154,
+			pubDate:          time.Now().Add(-40 * 24 * time.Hour).Format(time.RFC1123Z),
+			score:            4200,
+			duration:         165 * 60,
+			kind:             "movie",
+			originalLanguage: "en",
+			variants:         []string{"NZBGeek", "NinjaCentral"},
 		},
 		{
-			label:   "1080p episode · AvailNZB verified",
-			content: "Ted Lasso",
-			title:   "Ted.Lasso.S04E01.NORDiC.1080p.ATV.WEB-DL.H.265-NORViNE",
-			indexer: "altHUB",
-			size:    1_832_627_684,
-			grabs:   37,
-			pubDate: time.Now().Add(-3 * 24 * time.Hour).Format(time.RFC1123Z),
-			score:   2850,
-			avail:   true,
-			runtime: 34 * 60,
+			label:            "1080p episode · AvailNZB verified",
+			content:          "Ted Lasso",
+			title:            "Ted.Lasso.S04E01.NORDiC.1080p.ATV.WEB-DL.H.265-NORViNE",
+			indexer:          "altHUB",
+			size:             1_832_627_684,
+			grabs:            37,
+			pubDate:          time.Now().Add(-3 * 24 * time.Hour).Format(time.RFC1123Z),
+			score:            2850,
+			avail:            true,
+			runtime:          34 * 60,
+			kind:             "series",
+			originalLanguage: "en",
 		},
 		{
-			label:   "Anime episode · SeaDex best",
-			content: "86: Eighty Six",
-			title:   "86.Eighty.Six.S01E01.REPACK.1080p.Blu-ray.Opus2.0.x265-koala",
-			indexer: "animetosho",
-			size:    2_118_286_545,
-			grabs:   88,
-			pubDate: time.Now().Add(-300 * 24 * time.Hour).Format(time.RFC1123Z),
-			score:   3600,
-			runtime: 24 * 60,
-			seadex:  triage.SeadexState{Checked: true, Known: true, Best: true, DualAudio: true},
+			label:            "Anime episode · SeaDex best",
+			content:          "86: Eighty Six",
+			title:            "86.Eighty.Six.S01E01.REPACK.1080p.Blu-ray.Opus2.0.x265-koala",
+			indexer:          "animetosho",
+			size:             2_118_286_545,
+			grabs:            88,
+			pubDate:          time.Now().Add(-300 * 24 * time.Hour).Format(time.RFC1123Z),
+			score:            3600,
+			runtime:          24 * 60,
+			seadex:           triage.SeadexState{Checked: true, Known: true, Best: true, DualAudio: true},
+			kind:             "anime_show",
+			isAnime:          true,
+			originalLanguage: "ja",
 		},
 		{
-			label:   "Library hit · ffprobe verified",
-			content: "Ted Lasso",
-			title:   "Ted.Lasso.S04E01.NORDiC.1080p.ATV.WEB-DL.H.265-NORViNE",
-			indexer: "StreamNZB Library - altHUB",
-			size:    1_775_983_877,
-			grabs:   37,
-			pubDate: time.Now().Add(-3 * 24 * time.Hour).Format(time.RFC1123Z),
-			score:   3350,
-			avail:   true,
-			library: true,
-			caps:    "hevc Main 10 1080p 10-bit",
-			runtime: 34 * 60,
+			label:            "Library hit · ffprobe verified",
+			content:          "Ted Lasso",
+			title:            "Ted.Lasso.S04E01.NORDiC.1080p.ATV.WEB-DL.H.265-NORViNE",
+			indexer:          "StreamNZB Library - altHUB",
+			size:             1_775_983_877,
+			grabs:            37,
+			pubDate:          time.Now().Add(-3 * 24 * time.Hour).Format(time.RFC1123Z),
+			score:            3350,
+			avail:            true,
+			library:          true,
+			caps:             "hevc Main 10 1080p 10-bit",
+			runtime:          34 * 60,
+			kind:             "series",
+			originalLanguage: "en",
 		},
 	}
 }
@@ -1061,6 +1076,9 @@ func RenderFormatPreview(nameText, descText string) *FormatPreviewResult {
 		}
 		cand := triage.Candidate{Release: rel, Score: fx.score, Metadata: parser.ParseReleaseTitle(fx.title)}
 		cand.Verdict.Seadex = fx.seadex
+		cand.Verdict.Kind = fx.kind
+		cand.Verdict.IsAnime = fx.isAnime
+		cand.Verdict.OriginalLanguage = fx.originalLanguage
 		ctx := newFormatContext(cand, i+1, len(fixtures), topScore, DefaultServiceName, "Standalone", fx.content, fx.caps, fx.avail, fx.runtime)
 
 		builtinName := "StreamNZB\nStandalone"

--- a/pkg/server/stremio/formatter_has_test.go
+++ b/pkg/server/stremio/formatter_has_test.go
@@ -1,0 +1,39 @@
+package stremio
+
+import (
+	"bytes"
+	"testing"
+	"text/template"
+)
+
+// has is membership; contains is a substring test over the rendered list.
+// The documented original-audio badge must use the former: with contains,
+// "en" lit up inside ["French"] and the genuine "ko" in ["Korean"] did not.
+func TestHasIsMembershipNotSubstring(t *testing.T) {
+	render := func(orig string, langs ...string) string {
+		tpl := template.Must(template.New("t").Funcs(formatTemplateFuncs).Parse(
+			`{{if and .OriginalLanguage (has .OriginalLanguage .Languages)}}🎙{{end}}`))
+		var out bytes.Buffer
+		if err := tpl.Execute(&out, FormatContext{OriginalLanguage: orig, Languages: langs}); err != nil {
+			t.Fatal(err)
+		}
+		return out.String()
+	}
+	for _, tc := range []struct {
+		orig  string
+		langs []string
+		want  bool
+	}{
+		{"en", []string{"en"}, true},
+		{"en", []string{"ja", "en"}, true},
+		{"en", []string{"French"}, false},   // contains would say yes
+		{"es", []string{"Japanese"}, false}, // contains would say yes
+		{"ko", []string{"Korean"}, false},   // a word, not a code: honest no
+		{"ko", []string{"ko"}, true},
+		{"", []string{"en"}, false},
+	} {
+		if got := render(tc.orig, tc.langs...) != ""; got != tc.want {
+			t.Errorf("orig=%q langs=%v: badge=%v, want %v", tc.orig, tc.langs, got, tc.want)
+		}
+	}
+}

--- a/pkg/server/stremio/handlers_filtering_test.go
+++ b/pkg/server/stremio/handlers_filtering_test.go
@@ -276,6 +276,25 @@ func TestProfileForKindIgnoresProfileInAIOStreamsMode(t *testing.T) {
 	}
 }
 
+// The original language rides the request from TMDB metadata, lowercased,
+// and is empty for a title that carries none — never guessed.
+func TestRankingRequestCarriesOriginalLanguage(t *testing.T) {
+	tv := &playlistSource{Params: &query.SearchParams{
+		ContentType: "series",
+		Metadata:    &query.ResolvedSearchMetadata{TVDetails: &tmdb.TVDetails{OriginalLanguage: "KO"}},
+	}}
+	if got := rankingRequest(tv).OriginalLanguage; got != "ko" {
+		t.Errorf("rankingRequest().OriginalLanguage = %q, want %q", got, "ko")
+	}
+	kitsuOnly := &playlistSource{Params: &query.SearchParams{
+		ContentType: "series",
+		Metadata:    &query.ResolvedSearchMetadata{KitsuDetails: &kitsu.AnimeDetails{ShowType: "TV"}},
+	}}
+	if got := rankingRequest(kitsuOnly).OriginalLanguage; got != "" {
+		t.Errorf("rankingRequest().OriginalLanguage = %q for Kitsu-only metadata, want empty", got)
+	}
+}
+
 // A Kitsu request stays anime regardless of what the other metadata says.
 func TestRankingRequestPrefersKitsu(t *testing.T) {
 	source := &playlistSource{Params: &query.SearchParams{

--- a/pkg/server/stremio/handlers_playlist.go
+++ b/pkg/server/stremio/handlers_playlist.go
@@ -1414,6 +1414,7 @@ func rankingRequest(source *playlistSource) ranking.Request {
 			} else {
 				isAnime = query.MetadataLooksLikeAnime(meta, contentType)
 			}
+			req.OriginalLanguage = strings.ToLower(query.MetadataOriginalLanguage(meta, contentType))
 		}
 	}
 	req.IsAnime = isAnime


### PR DESCRIPTION
### What

Metadata already knows what language a title was made in — `query.MetadataOriginalLanguage` reads TMDB's `original_language` to pick title variants — but rules and result formats couldn't see it. This carries it through as request context:

- `ranking.Request.OriginalLanguage` → `rules.Context` → `originalLanguage` in the rules env (no tier: always answerable, `""` when metadata didn't say)
- `triage.Verdict.OriginalLanguage`, so the formatter gets `.OriginalLanguage` next to `.Kind` / `.IsAnime`
- `original_language` on the preview request

Set from the playlist path in `rankingRequest()`, lowercased; Kitsu-only requests with no TMDB match report `""` rather than guessing.

### Why

Today "prefer the original audio" needs one rule per language and a guess from `isAnime`. With the request carrying it, one line covers Japanese anime, Korean drama and French film alike:

```
originalLanguage != "" and originalLanguage in languages                  → +500
originalLanguage != "" and dubbed and not (originalLanguage in languages) → -300
```

`TestOriginalLanguageIsPerRequest` pins the three cases: original audio on a Korean title, an English dub of it, and a request whose metadata carried no language (both rules guarded, neither fires).

### Tests

`go test` passes for `pkg/search/rules`, `pkg/search/ranking`, `pkg/server/stremio`. `gofmt` and `go vet` clean. Docs updated in `rules.md` ("About the request") and `result-formatting.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MzJz3CvfuTMMDWn2jnntV3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added original-language support for requests, using ISO 639-1 language codes when metadata is available.
  - Added an optional Original language field to profile previews.
  - Rules can now reward original-language releases or penalize dubbed releases.
  - Added exact language-list matching for formatting templates.

- **Documentation**
  - Documented original-language attributes, rule examples, language matching, and preview formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->