### PR TITLE
feat(indexer): present series and film traffic as Sonarr and Radarr (per-media User-Agents)

### DIFF
--- a/cmd/streamnzb/main.go
+++ b/cmd/streamnzb/main.go
@@ -124,6 +124,7 @@ func main() {
 	effectiveTMDBKey := firstNonEmpty(userTMDBKey, TMDBKey)
 	effectiveTVDBKey := firstNonEmpty(userTVDBKey, TVDBKey)
 	env.SetRuntimeHeaders(cfg.IndexerQueryHeader, cfg.IndexerGrabHeader, cfg.ProviderHeader)
+	env.SetRuntimeMediaHeaders(cfg.IndexerSeriesHeader, cfg.IndexerMovieHeader)
 
 	dataDir := filepath.Dir(cfg.LoadedPath)
 	if dataDir == "" || dataDir == "." {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -95,6 +95,8 @@ See [Database backends](database.md) for how switching and migration work.
 |---|---|
 | `STREAMNZB_INDEXER_QUERY_HEADER` (legacy `INDEXER_QUERY_HEADER`) | User-Agent sent on indexer search requests |
 | `STREAMNZB_INDEXER_GRAB_HEADER` (legacy `INDEXER_GRAB_HEADER`) | User-Agent sent on NZB downloads |
+| `STREAMNZB_INDEXER_SERIES_HEADER` | Optional. User-Agent for series and anime — searches **and** NZB downloads — e.g. `Sonarr/4.0.15.2941`. Empty: the query/grab pair applies |
+| `STREAMNZB_INDEXER_MOVIE_HEADER` | Optional. Same for films, e.g. `Radarr/5.26.2.10099` |
 | `STREAMNZB_PROVIDER_HEADER` (legacy `PROVIDER_HEADER`) | Identification sent to Usenet providers |
 
 Indexers increasingly gate content on the client version, so a header pinned to
@@ -111,7 +113,20 @@ each of these tools is on today and lifts the headers to it:
 Whichever tool a header already names is kept, only its version moves; an empty
 header is seeded with the default for its slot (Prowlarr for queries, SABnzbd
 for grabs, VLC for providers), and a header naming a tool that is not in that
-list is left untouched. Headers set from the environment are never rewritten —
+list is left untouched. The two per-media headers are opt-in and are never
+seeded while empty; once they name Sonarr or Radarr they are lifted like the
+others.
+
+**Per-media identity.** A Prowlarr search followed by a SABnzbd download is not
+how an automation stack looks to an indexer: Sonarr and Radarr search under
+their own names and fetch the NZB themselves, and SABnzbd never contacts the
+indexer at all. Setting the series header to a Sonarr User-Agent and the movie
+header to a Radarr one makes StreamNZB present that same split — the class of
+the request (series, anime, film) picks the header for both the search and the
+later grab, including grabs served through the [Newznab endpoint](newznab.md),
+whose links remember the class of the search that produced them. A per-indexer
+override still wins over both. Direct-play NZB URLs carry no class and use the
+plain grab header. Headers set from the environment are never rewritten —
 the process value wins over config regardless. Results are cached for an hour,
 since GitHub allows 60 unauthenticated requests per hour per IP.
 

--- a/frontend/src/components/GeneralSettingsSection.jsx
+++ b/frontend/src/components/GeneralSettingsSection.jsx
@@ -16,7 +16,7 @@ import { cn, selectClass } from "@/lib/utils"
 // The TMDB/TVDB API keys live on the Metadata page, next to what they power.
 const CARD_FIELDS = {
   addon: ['addon_base_url', 'addon_port'],
-  useragent: ['indexer_query_header', 'indexer_grab_header', 'provider_header'],
+  useragent: ['indexer_query_header', 'indexer_grab_header', 'indexer_series_header', 'indexer_movie_header', 'provider_header'],
   database: ['database_driver', 'database_url', 'nzb_history_retention_days'],
 }
 
@@ -30,6 +30,8 @@ const FIELD_CARD = Object.fromEntries(
 const USER_AGENT_ROLES = {
   indexer_query_header: 'query',
   indexer_grab_header: 'grab',
+  indexer_series_header: 'series',
+  indexer_movie_header: 'movie',
   provider_header: 'provider',
 }
 
@@ -56,6 +58,8 @@ function pickInitialValues(values = {}) {
     addon_base_url: values.addon_base_url ?? '',
     indexer_query_header: values.indexer_query_header ?? '',
     indexer_grab_header: values.indexer_grab_header ?? '',
+    indexer_series_header: values.indexer_series_header ?? '',
+    indexer_movie_header: values.indexer_movie_header ?? '',
     provider_header: values.provider_header ?? '',
     database_driver: values.database_driver || 'sqlite',
     database_url: values.database_url ?? '',
@@ -141,6 +145,10 @@ export const GeneralSettingsSection = React.memo(function GeneralSettingsSection
       Object.entries(USER_AGENT_ROLES).forEach(([name, role]) => {
         if (envOverrides.includes(name)) return
         const current = form.getValues(name) || ''
+        // The per-media pair is opt-in: an empty one stays empty, so
+        // "Update to latest" only moves a Sonarr/Radarr header the user
+        // already typed.
+        if (!current && (role === 'series' || role === 'movie')) return
         const token = productToken(current)
         const match = token
           ? agents.find((agent) => agent.product.toLowerCase() === token.toLowerCase())
@@ -320,6 +328,28 @@ export const GeneralSettingsSection = React.memo(function GeneralSettingsSection
                     <FormControl><Input className={`h-9 ${controlWideClass}`} {...field} value={field.value || ''} placeholder="SABnzbd/4.5.5" onBlur={blurCommit(field, 'indexer_grab_header')} /></FormControl>
                   </div>
                   <FormDescription className="mt-3">Used when grabbing NZBs from indexers.</FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )} />
+              <FormField control={control} name="indexer_series_header" render={({ field }) => (
+                <FormItem className="relative rounded-none border-0 p-3">
+                  <div className="absolute left-3 right-3 top-0 border-t border-border/60" />
+                  <div className={stackedFieldRowClass}>
+                    <FormLabel className={cn(labelClass, 'flex items-center gap-1.5 sm:flex-1')}>Series Header <EnvOverrideIndicator show={envOverrides.includes('indexer_series_header')} /></FormLabel>
+                    <FormControl><Input className={`h-9 ${controlWideClass}`} {...field} value={field.value || ''} placeholder="Sonarr/4.0.15.2941" onBlur={blurCommit(field, 'indexer_series_header')} /></FormControl>
+                  </div>
+                  <FormDescription className="mt-3">Optional. Used for both searches and grabs of series and anime, the way Sonarr itself talks to an indexer. Leave empty to use the query and grab headers above.</FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )} />
+              <FormField control={control} name="indexer_movie_header" render={({ field }) => (
+                <FormItem className="relative rounded-none border-0 p-3">
+                  <div className="absolute left-3 right-3 top-0 border-t border-border/60" />
+                  <div className={stackedFieldRowClass}>
+                    <FormLabel className={cn(labelClass, 'flex items-center gap-1.5 sm:flex-1')}>Movie Header <EnvOverrideIndicator show={envOverrides.includes('indexer_movie_header')} /></FormLabel>
+                    <FormControl><Input className={`h-9 ${controlWideClass}`} {...field} value={field.value || ''} placeholder="Radarr/5.26.2.10099" onBlur={blurCommit(field, 'indexer_movie_header')} /></FormControl>
+                  </div>
+                  <FormDescription className="mt-3">Optional. Used for both searches and grabs of films, the way Radarr itself talks to an indexer. Leave empty to use the query and grab headers above.</FormDescription>
                   <FormMessage />
                 </FormItem>
               )} />

--- a/frontend/src/hooks/useSettingsState.js
+++ b/frontend/src/hooks/useSettingsState.js
@@ -7,6 +7,8 @@ const GENERAL_TAB_FIELDS = [
   'addon_base_url',
   'indexer_query_header',
   'indexer_grab_header',
+  'indexer_series_header',
+  'indexer_movie_header',
   'provider_header',
   'database_driver',
   'database_url',

--- a/pkg/core/app/app.go
+++ b/pkg/core/app/app.go
@@ -154,6 +154,7 @@ func prefetchAvailNZBBackbones(cfg *config.Config, client *availnzb.Client) {
 
 func (a *App) buildFull(cfg *config.Config, opts BuildOpts) (*Components, error) {
 	env.SetRuntimeHeaders(cfg.IndexerQueryHeader, cfg.IndexerGrabHeader, cfg.ProviderHeader)
+	env.SetRuntimeMediaHeaders(cfg.IndexerSeriesHeader, cfg.IndexerMovieHeader)
 	base, err := initialization.BuildComponents(cfg)
 	if err != nil {
 		return nil, err
@@ -285,6 +286,7 @@ func (a *App) Reload(newCfg *config.Config) (*Components, ReloadScope, error) {
 	a.opts.TVDBAPIKey = strings.TrimSpace(newCfg.TVDBAPIKey)
 	a.opts.SimklClientID = strings.TrimSpace(newCfg.SimklClientID)
 	env.SetRuntimeHeaders(newCfg.IndexerQueryHeader, newCfg.IndexerGrabHeader, newCfg.ProviderHeader)
+	env.SetRuntimeMediaHeaders(newCfg.IndexerSeriesHeader, newCfg.IndexerMovieHeader)
 
 	old := a.components
 	scope := ConfigChanged(old.Config, newCfg)

--- a/pkg/core/config/config.go
+++ b/pkg/core/config/config.go
@@ -748,8 +748,15 @@ type Config struct {
 	TMDBAPIKey         string `json:"tmdb_api_key,omitempty"`
 	IndexerQueryHeader string `json:"indexer_query_header,omitempty"`
 	IndexerGrabHeader  string `json:"indexer_grab_header,omitempty"`
-	ProviderHeader     string `json:"provider_header,omitempty"`
-	IndexerProxyURL    string `json:"indexer_proxy_url,omitempty"`
+	// IndexerSeriesHeader and IndexerMovieHeader present series and film
+	// traffic as two different programs — Sonarr and Radarr in a typical
+	// setup — for both the search and the NZB download, the way those tools
+	// actually behave. Empty means that kind of content uses the plain
+	// query/grab headers above. Per-indexer overrides still win.
+	IndexerSeriesHeader string `json:"indexer_series_header,omitempty"`
+	IndexerMovieHeader  string `json:"indexer_movie_header,omitempty"`
+	ProviderHeader      string `json:"provider_header,omitempty"`
+	IndexerProxyURL     string `json:"indexer_proxy_url,omitempty"`
 
 	TVDBAPIKey string `json:"tvdb_api_key,omitempty"`
 
@@ -1661,31 +1668,33 @@ func keySet(list []string, s string) bool {
 // so a new override is one entry instead of two hand-maintained mirrors that
 // can (and did) drift apart.
 var envFieldCopiers = map[string]func(dst, src *Config){
-	env.KeyAddonPort:          func(d, s *Config) { d.AddonPort = s.AddonPort },
-	env.KeyAddonBaseURL:       func(d, s *Config) { d.AddonBaseURL = s.AddonBaseURL },
-	env.KeyLogLevel:           func(d, s *Config) { d.LogLevel = s.LogLevel },
-	env.KeyKeepLogFiles:       func(d, s *Config) { d.KeepLogFiles = s.KeepLogFiles },
-	env.KeyAvailNZBAPIKey:     func(d, s *Config) { d.AvailNZBAPIKey = s.AvailNZBAPIKey },
-	env.KeyTMDBAPIKey:         func(d, s *Config) { d.TMDBAPIKey = s.TMDBAPIKey },
-	env.KeyTVDBAPIKey:         func(d, s *Config) { d.TVDBAPIKey = s.TVDBAPIKey },
-	env.KeySimklClientID:      func(d, s *Config) { d.SimklClientID = s.SimklClientID },
-	env.KeyIndexerQueryHeader: func(d, s *Config) { d.IndexerQueryHeader = s.IndexerQueryHeader },
-	env.KeyIndexerGrabHeader:  func(d, s *Config) { d.IndexerGrabHeader = s.IndexerGrabHeader },
-	env.KeyProviderHeader:     func(d, s *Config) { d.ProviderHeader = s.ProviderHeader },
-	env.KeyProxyPort:          func(d, s *Config) { d.ProxyPort = s.ProxyPort },
-	env.KeyProxyHost:          func(d, s *Config) { d.ProxyHost = s.ProxyHost },
-	env.KeyProxyEnabled:       func(d, s *Config) { d.ProxyEnabled = s.ProxyEnabled },
-	env.KeyProxyAuthUser:      func(d, s *Config) { d.ProxyAuthUser = s.ProxyAuthUser },
-	env.KeyProxyAuthPass:      func(d, s *Config) { d.ProxyAuthPass = s.ProxyAuthPass },
-	env.KeyNewznabEnabled:     func(d, s *Config) { d.NewznabEnabled = s.NewznabEnabled },
-	env.KeyNewznabAPIKey:      func(d, s *Config) { d.NewznabAPIKey = s.NewznabAPIKey },
-	env.KeyAdminUsername:      func(d, s *Config) { d.AdminUsername = s.AdminUsername },
-	env.KeyAdminMustChangePwd: func(d, s *Config) { d.AdminMustChangePassword = s.AdminMustChangePassword },
-	env.KeyProviders:          func(d, s *Config) { d.Providers = cloneProviders(s.Providers) },
-	env.KeyIndexers:           func(d, s *Config) { d.Indexers = cloneIndexers(s.Indexers) },
-	env.KeyDatabaseDriver:     func(d, s *Config) { d.DatabaseDriver = s.DatabaseDriver },
-	env.KeyDatabaseURL:        func(d, s *Config) { d.DatabaseURL = s.DatabaseURL },
-	env.KeyMetadataEnabled:    func(d, s *Config) { d.Metadata.Enabled = s.Metadata.Enabled },
+	env.KeyAddonPort:           func(d, s *Config) { d.AddonPort = s.AddonPort },
+	env.KeyAddonBaseURL:        func(d, s *Config) { d.AddonBaseURL = s.AddonBaseURL },
+	env.KeyLogLevel:            func(d, s *Config) { d.LogLevel = s.LogLevel },
+	env.KeyKeepLogFiles:        func(d, s *Config) { d.KeepLogFiles = s.KeepLogFiles },
+	env.KeyAvailNZBAPIKey:      func(d, s *Config) { d.AvailNZBAPIKey = s.AvailNZBAPIKey },
+	env.KeyTMDBAPIKey:          func(d, s *Config) { d.TMDBAPIKey = s.TMDBAPIKey },
+	env.KeyTVDBAPIKey:          func(d, s *Config) { d.TVDBAPIKey = s.TVDBAPIKey },
+	env.KeySimklClientID:       func(d, s *Config) { d.SimklClientID = s.SimklClientID },
+	env.KeyIndexerQueryHeader:  func(d, s *Config) { d.IndexerQueryHeader = s.IndexerQueryHeader },
+	env.KeyIndexerGrabHeader:   func(d, s *Config) { d.IndexerGrabHeader = s.IndexerGrabHeader },
+	env.KeyIndexerSeriesHeader: func(d, s *Config) { d.IndexerSeriesHeader = s.IndexerSeriesHeader },
+	env.KeyIndexerMovieHeader:  func(d, s *Config) { d.IndexerMovieHeader = s.IndexerMovieHeader },
+	env.KeyProviderHeader:      func(d, s *Config) { d.ProviderHeader = s.ProviderHeader },
+	env.KeyProxyPort:           func(d, s *Config) { d.ProxyPort = s.ProxyPort },
+	env.KeyProxyHost:           func(d, s *Config) { d.ProxyHost = s.ProxyHost },
+	env.KeyProxyEnabled:        func(d, s *Config) { d.ProxyEnabled = s.ProxyEnabled },
+	env.KeyProxyAuthUser:       func(d, s *Config) { d.ProxyAuthUser = s.ProxyAuthUser },
+	env.KeyProxyAuthPass:       func(d, s *Config) { d.ProxyAuthPass = s.ProxyAuthPass },
+	env.KeyNewznabEnabled:      func(d, s *Config) { d.NewznabEnabled = s.NewznabEnabled },
+	env.KeyNewznabAPIKey:       func(d, s *Config) { d.NewznabAPIKey = s.NewznabAPIKey },
+	env.KeyAdminUsername:       func(d, s *Config) { d.AdminUsername = s.AdminUsername },
+	env.KeyAdminMustChangePwd:  func(d, s *Config) { d.AdminMustChangePassword = s.AdminMustChangePassword },
+	env.KeyProviders:           func(d, s *Config) { d.Providers = cloneProviders(s.Providers) },
+	env.KeyIndexers:            func(d, s *Config) { d.Indexers = cloneIndexers(s.Indexers) },
+	env.KeyDatabaseDriver:      func(d, s *Config) { d.DatabaseDriver = s.DatabaseDriver },
+	env.KeyDatabaseURL:         func(d, s *Config) { d.DatabaseURL = s.DatabaseURL },
+	env.KeyMetadataEnabled:     func(d, s *Config) { d.Metadata.Enabled = s.Metadata.Enabled },
 }
 
 // cloneProviders deep-copies the pointer fields so the two configs never share
@@ -1750,6 +1759,8 @@ func envOverridesAsConfig(o env.ConfigOverrides) *Config {
 		SimklClientID:           o.SimklClientID,
 		IndexerQueryHeader:      o.IndexerQueryHeader,
 		IndexerGrabHeader:       o.IndexerGrabHeader,
+		IndexerSeriesHeader:     o.IndexerSeriesHeader,
+		IndexerMovieHeader:      o.IndexerMovieHeader,
 		ProviderHeader:          o.ProviderHeader,
 		ProxyPort:               o.ProxyPort,
 		ProxyHost:               o.ProxyHost,
@@ -1839,6 +1850,8 @@ func (c *Config) RedactForAPI() Config {
 	out.ProxyAuthPass = ""
 	out.IndexerQueryHeader = ""
 	out.IndexerGrabHeader = ""
+	out.IndexerSeriesHeader = ""
+	out.IndexerMovieHeader = ""
 	out.ProviderHeader = ""
 	out.IndexerProxyURL = RedactProxyURLForAPI(c.IndexerProxyURL)
 	out.AvailNZBAPIKey = ""

--- a/pkg/core/config/config_test.go
+++ b/pkg/core/config/config_test.go
@@ -835,6 +835,7 @@ func TestEnvFieldCopiersCoverEveryKey(t *testing.T) {
 		env.KeyProviders, env.KeyIndexers, env.KeyAvailNZBURL,
 		env.KeyAvailNZBAPIKey, env.KeyTMDBAPIKey, env.KeyTVDBAPIKey, env.KeySimklClientID,
 		env.KeyIndexerQueryHeader, env.KeyIndexerGrabHeader, env.KeyProviderHeader,
+		env.KeyIndexerSeriesHeader, env.KeyIndexerMovieHeader,
 		env.KeyAdminUsername, env.KeyAdminMustChangePwd,
 		env.KeyDatabaseDriver, env.KeyDatabaseURL, env.KeyMetadataEnabled,
 	}

--- a/pkg/core/env/env.go
+++ b/pkg/core/env/env.go
@@ -36,6 +36,8 @@ const (
 	ProviderHeaderEnv                  = "PROVIDER_HEADER"
 	StreamNZBIndexerQueryHeaderEnv     = "STREAMNZB_INDEXER_QUERY_HEADER"
 	StreamNZBIndexerGrabHeaderEnv      = "STREAMNZB_INDEXER_GRAB_HEADER"
+	StreamNZBIndexerSeriesHeaderEnv    = "STREAMNZB_INDEXER_SERIES_HEADER"
+	StreamNZBIndexerMovieHeaderEnv     = "STREAMNZB_INDEXER_MOVIE_HEADER"
 	StreamNZBProviderHeaderEnv         = "STREAMNZB_PROVIDER_HEADER"
 	ConfigPath                         = "CONFIG_PATH"
 	DatabaseDriverEnv                  = "DATABASE_DRIVER"
@@ -56,32 +58,34 @@ const (
 )
 
 const (
-	KeyAddonPort          = "addon_port"
-	KeyAddonBaseURL       = "addon_base_url"
-	KeyLogLevel           = "log_level"
-	KeyKeepLogFiles       = "keep_log_files"
-	KeyProxyPort          = "proxy_port"
-	KeyProxyHost          = "proxy_host"
-	KeyProxyEnabled       = "proxy_enabled"
-	KeyProxyAuthUser      = "proxy_auth_user"
-	KeyProxyAuthPass      = "proxy_auth_pass"
-	KeyNewznabEnabled     = "newznab_enabled"
-	KeyNewznabAPIKey      = "newznab_api_key"
-	KeyProviders          = "providers"
-	KeyIndexers           = "indexers"
-	KeyAvailNZBURL        = "availnzb_url"
-	KeyAvailNZBAPIKey     = "availnzb_api_key"
-	KeyTMDBAPIKey         = "tmdb_api_key"
-	KeyTVDBAPIKey         = "tvdb_api_key"
-	KeySimklClientID      = "simkl_client_id"
-	KeyMetadataEnabled    = "metadata_enabled"
-	KeyIndexerQueryHeader = "indexer_query_header"
-	KeyIndexerGrabHeader  = "indexer_grab_header"
-	KeyProviderHeader     = "provider_header"
-	KeyAdminUsername      = "admin_username"
-	KeyAdminMustChangePwd = "admin_must_change_password"
-	KeyDatabaseDriver     = "database_driver"
-	KeyDatabaseURL        = "database_url"
+	KeyAddonPort           = "addon_port"
+	KeyAddonBaseURL        = "addon_base_url"
+	KeyLogLevel            = "log_level"
+	KeyKeepLogFiles        = "keep_log_files"
+	KeyProxyPort           = "proxy_port"
+	KeyProxyHost           = "proxy_host"
+	KeyProxyEnabled        = "proxy_enabled"
+	KeyProxyAuthUser       = "proxy_auth_user"
+	KeyProxyAuthPass       = "proxy_auth_pass"
+	KeyNewznabEnabled      = "newznab_enabled"
+	KeyNewznabAPIKey       = "newznab_api_key"
+	KeyProviders           = "providers"
+	KeyIndexers            = "indexers"
+	KeyAvailNZBURL         = "availnzb_url"
+	KeyAvailNZBAPIKey      = "availnzb_api_key"
+	KeyTMDBAPIKey          = "tmdb_api_key"
+	KeyTVDBAPIKey          = "tvdb_api_key"
+	KeySimklClientID       = "simkl_client_id"
+	KeyMetadataEnabled     = "metadata_enabled"
+	KeyIndexerQueryHeader  = "indexer_query_header"
+	KeyIndexerGrabHeader   = "indexer_grab_header"
+	KeyIndexerSeriesHeader = "indexer_series_header"
+	KeyIndexerMovieHeader  = "indexer_movie_header"
+	KeyProviderHeader      = "provider_header"
+	KeyAdminUsername       = "admin_username"
+	KeyAdminMustChangePwd  = "admin_must_change_password"
+	KeyDatabaseDriver      = "database_driver"
+	KeyDatabaseURL         = "database_url"
 )
 
 const AdminUsernameEnv = "ADMIN_USERNAME"
@@ -91,6 +95,8 @@ var DefaultIndexerUserAgent = "StreamNZB/dev"
 var runtimeHeadersMu sync.RWMutex
 var runtimeIndexerQueryHeader = ""
 var runtimeIndexerGrabHeader = ""
+var runtimeIndexerSeriesHeader = ""
+var runtimeIndexerMovieHeader = ""
 var runtimeProviderHeader = ""
 
 func TZ() string {
@@ -148,6 +154,59 @@ func SetRuntimeHeaders(indexerQueryHeader, indexerGrabHeader, providerHeader str
 	runtimeIndexerQueryHeader = strings.TrimSpace(indexerQueryHeader)
 	runtimeIndexerGrabHeader = strings.TrimSpace(indexerGrabHeader)
 	runtimeProviderHeader = strings.TrimSpace(providerHeader)
+}
+
+// SetRuntimeMediaHeaders stores the per-media User-Agents from config. Either
+// may be empty, which means that kind of content keeps using the plain
+// query/grab headers.
+func SetRuntimeMediaHeaders(seriesHeader, movieHeader string) {
+	runtimeHeadersMu.Lock()
+	defer runtimeHeadersMu.Unlock()
+	runtimeIndexerSeriesHeader = strings.TrimSpace(seriesHeader)
+	runtimeIndexerMovieHeader = strings.TrimSpace(movieHeader)
+}
+
+// IndexerSeriesHeader and IndexerMovieHeader are the User-Agents presented
+// for series and film traffic respectively, environment first, then config.
+// Empty means unset.
+func IndexerSeriesHeader() string {
+	if v := os.Getenv(StreamNZBIndexerSeriesHeaderEnv); v != "" {
+		return v
+	}
+	runtimeHeadersMu.RLock()
+	defer runtimeHeadersMu.RUnlock()
+	return runtimeIndexerSeriesHeader
+}
+
+func IndexerMovieHeader() string {
+	if v := os.Getenv(StreamNZBIndexerMovieHeaderEnv); v != "" {
+		return v
+	}
+	runtimeHeadersMu.RLock()
+	defer runtimeHeadersMu.RUnlock()
+	return runtimeIndexerMovieHeader
+}
+
+// IndexerHeaderFor is the User-Agent for one request to an indexer. A
+// per-media header, when set for the request's class, is used for both the
+// search and the NZB download — that is how Sonarr and Radarr behave, each
+// searching and fetching under its own name. Without one, the plain query or
+// grab header applies as before.
+func IndexerHeaderFor(mediaClass string, grab bool) string {
+	switch mediaClass {
+	case "series":
+		if h := IndexerSeriesHeader(); h != "" {
+			return h
+		}
+	case "movie":
+		if h := IndexerMovieHeader(); h != "" {
+			return h
+		}
+	}
+	if grab {
+		return IndexerGrabHeader()
+	}
+	return IndexerQueryHeader()
 }
 
 func LogLevel() string {
@@ -391,32 +450,34 @@ type Indexer struct {
 }
 
 type ConfigOverrides struct {
-	AddonPort          int
-	AddonBaseURL       string
-	LogLevel           string
-	KeepLogFiles       int
-	AvailNZBURL        string
-	AvailNZBAPIKey     string
-	TMDBAPIKey         string
-	TVDBAPIKey         string
-	SimklClientID      string
-	IndexerQueryHeader string
-	IndexerGrabHeader  string
-	ProviderHeader     string
-	ProxyPort          int
-	ProxyHost          string
-	ProxyEnabled       bool
-	ProxyAuthUser      string
-	ProxyAuthPass      string
-	NewznabEnabled     bool
-	NewznabAPIKey      string
-	AdminUsername      string
-	AdminMustChangePwd bool
-	DatabaseDriver     string
-	DatabaseURL        string
-	MetadataEnabled    bool
-	Providers          []Provider
-	Indexers           []Indexer
+	AddonPort           int
+	AddonBaseURL        string
+	LogLevel            string
+	KeepLogFiles        int
+	AvailNZBURL         string
+	AvailNZBAPIKey      string
+	TMDBAPIKey          string
+	TVDBAPIKey          string
+	SimklClientID       string
+	IndexerQueryHeader  string
+	IndexerGrabHeader   string
+	IndexerSeriesHeader string
+	IndexerMovieHeader  string
+	ProviderHeader      string
+	ProxyPort           int
+	ProxyHost           string
+	ProxyEnabled        bool
+	ProxyAuthUser       string
+	ProxyAuthPass       string
+	NewznabEnabled      bool
+	NewznabAPIKey       string
+	AdminUsername       string
+	AdminMustChangePwd  bool
+	DatabaseDriver      string
+	DatabaseURL         string
+	MetadataEnabled     bool
+	Providers           []Provider
+	Indexers            []Indexer
 }
 
 // envReader accumulates config overrides read from the environment, tracking
@@ -471,6 +532,8 @@ func ReadConfigOverrides() (ConfigOverrides, []string) {
 	}
 	r.str(&o.IndexerQueryHeader, KeyIndexerQueryHeader, StreamNZBIndexerQueryHeaderEnv, IndexerQueryHeaderEnv)
 	r.str(&o.IndexerGrabHeader, KeyIndexerGrabHeader, StreamNZBIndexerGrabHeaderEnv, IndexerGrabHeaderEnv)
+	r.str(&o.IndexerSeriesHeader, KeyIndexerSeriesHeader, StreamNZBIndexerSeriesHeaderEnv)
+	r.str(&o.IndexerMovieHeader, KeyIndexerMovieHeader, StreamNZBIndexerMovieHeaderEnv)
 	r.str(&o.ProviderHeader, KeyProviderHeader, StreamNZBProviderHeaderEnv, ProviderHeaderEnv)
 	r.intVal(&o.ProxyPort, KeyProxyPort, NNTPProxyPort, nil)
 	r.str(&o.ProxyHost, KeyProxyHost, NNTPProxyHost)

--- a/pkg/core/env/env_test.go
+++ b/pkg/core/env/env_test.go
@@ -571,3 +571,43 @@ func TestBooleanEnvNamesCoversEveryFixedName(t *testing.T) {
 		})
 	}
 }
+
+// The per-media headers win for their class, for search and grab alike, and
+// an unset one falls back to the plain query/grab pair.
+func TestIndexerHeaderForPicksByMediaClass(t *testing.T) {
+	clear(t, StreamNZBIndexerSeriesHeaderEnv, StreamNZBIndexerMovieHeaderEnv, StreamNZBIndexerQueryHeaderEnv, StreamNZBIndexerGrabHeaderEnv, IndexerQueryHeaderEnv, IndexerGrabHeaderEnv)
+	SetRuntimeHeaders("Prowlarr/2.0", "SABnzbd/4.5", "")
+	SetRuntimeMediaHeaders("Sonarr/4.0", "")
+	t.Cleanup(func() { SetRuntimeHeaders("", "", ""); SetRuntimeMediaHeaders("", "") })
+
+	if got := IndexerHeaderFor("series", false); got != "Sonarr/4.0" {
+		t.Fatalf("series search = %q", got)
+	}
+	if got := IndexerHeaderFor("series", true); got != "Sonarr/4.0" {
+		t.Fatalf("series grab = %q", got)
+	}
+	if got := IndexerHeaderFor("movie", false); got != "Prowlarr/2.0" {
+		t.Fatalf("movie search without a movie header = %q", got)
+	}
+	if got := IndexerHeaderFor("movie", true); got != "SABnzbd/4.5" {
+		t.Fatalf("movie grab without a movie header = %q", got)
+	}
+	if got := IndexerHeaderFor("", true); got != "SABnzbd/4.5" {
+		t.Fatalf("classless grab = %q", got)
+	}
+
+	t.Setenv(StreamNZBIndexerMovieHeaderEnv, "Radarr/5.0")
+	if got := IndexerHeaderFor("movie", false); got != "Radarr/5.0" {
+		t.Fatalf("environment movie header must win: %q", got)
+	}
+}
+
+func TestMediaHeaderOverrides(t *testing.T) {
+	clearNumberedBlocks(t)
+	clear(t, StreamNZBIndexerSeriesHeaderEnv, StreamNZBIndexerMovieHeaderEnv)
+	t.Setenv(StreamNZBIndexerSeriesHeaderEnv, "Sonarr/4.0.15")
+	o, keys := ReadConfigOverrides()
+	if o.IndexerSeriesHeader != "Sonarr/4.0.15" || !contains(keys, KeyIndexerSeriesHeader) || contains(keys, KeyIndexerMovieHeader) {
+		t.Fatalf("series header override not read: %+v %v", o, keys)
+	}
+}

--- a/pkg/indexer/easynews/client.go
+++ b/pkg/indexer/easynews/client.go
@@ -166,18 +166,18 @@ func (c *Client) reauthenticateRedirect(req *http.Request, via []*http.Request) 
 	return nil
 }
 
-func (c *Client) effectiveQueryHeader() string {
+func (c *Client) effectiveQueryHeader(ctx context.Context) string {
 	if h := strings.TrimSpace(c.queryHeader); h != "" {
 		return h
 	}
-	return env.IndexerQueryHeader()
+	return env.IndexerHeaderFor(indexer.MediaClassFromContext(ctx), false)
 }
 
-func (c *Client) effectiveGrabHeader() string {
+func (c *Client) effectiveGrabHeader(ctx context.Context) string {
 	if h := strings.TrimSpace(c.grabHeader); h != "" {
 		return h
 	}
-	return env.IndexerGrabHeader()
+	return env.IndexerHeaderFor(indexer.MediaClassFromContext(ctx), true)
 }
 
 func (c *Client) Name() string {
@@ -214,6 +214,7 @@ func (c *Client) Ping(ctx context.Context) error {
 }
 
 func (c *Client) Search(ctx context.Context, req indexer.SearchRequest) (*indexer.SearchResponse, error) {
+	ctx = indexer.WithMediaClass(ctx, req.Class)
 	if strings.TrimSpace(req.Query) == "" {
 		// Easynews answers text queries only. An empty one is not an id search
 		// it could still serve — it asks for the whole index, which is never
@@ -473,7 +474,7 @@ func (c *Client) fetchSearchPage(ctx context.Context, query, season, episode, sc
 
 	req.SetBasicAuth(c.username, c.password)
 	req.Header.Set("Accept", "application/json")
-	req.Header.Set("User-Agent", c.effectiveQueryHeader())
+	req.Header.Set("User-Agent", c.effectiveQueryHeader(ctx))
 	resp, err := c.client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("easynews search request failed: %w", err)
@@ -593,7 +594,7 @@ func (c *Client) downloadNZBInternal(ctx context.Context, payload map[string]int
 
 	req.SetBasicAuth(c.username, c.password)
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Set("User-Agent", c.effectiveGrabHeader())
+	req.Header.Set("User-Agent", c.effectiveGrabHeader(ctx))
 	resp, err := c.downloadClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("easynews NZB download request failed: %w", err)

--- a/pkg/indexer/media_class.go
+++ b/pkg/indexer/media_class.go
@@ -1,0 +1,52 @@
+package indexer
+
+import (
+	"context"
+	"strings"
+)
+
+// Media header classes. An *arr stack talks to an indexer as two different
+// programs: Sonarr for series, Radarr for films, and each of them both
+// searches and fetches the NZB itself. StreamNZB can present the same split,
+// so the class a request is about has to travel with it down to the HTTP
+// call, including the NZB download that happens long after the search.
+const (
+	MediaClassSeries = "series"
+	MediaClassMovie  = "movie"
+)
+
+type mediaClassKey struct{}
+
+// WithMediaClass records which kind of content a request is about, for the
+// indexer clients to pick the matching User-Agent. Anything that is not a
+// film or a series (direct-play NZB URLs, unknown content) leaves the
+// context untouched and the clients fall back to the plain headers.
+func WithMediaClass(ctx context.Context, class string) context.Context {
+	if c := MediaClassOf(class); c != "" {
+		return context.WithValue(ctx, mediaClassKey{}, c)
+	}
+	return ctx
+}
+
+// MediaClassFromContext returns the class stored by WithMediaClass, or "".
+func MediaClassFromContext(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	c, _ := ctx.Value(mediaClassKey{}).(string)
+	return c
+}
+
+// MediaClassOf folds the vocabularies in use across the code base — search
+// classes ("movie", "tv", "tv_anime"), Stremio content types ("movie",
+// "series"), profile kinds ("anime_show", "anime_movie") — into the two the
+// headers distinguish. Unknown words map to "".
+func MediaClassOf(class string) string {
+	switch strings.ToLower(strings.TrimSpace(class)) {
+	case "movie", "movies", "anime_movie", "film":
+		return MediaClassMovie
+	case "series", "tv", "tv_anime", "show", "anime_show", "episode", "anime":
+		return MediaClassSeries
+	}
+	return ""
+}

--- a/pkg/indexer/media_class_test.go
+++ b/pkg/indexer/media_class_test.go
@@ -1,0 +1,34 @@
+package indexer
+
+import (
+	"context"
+	"testing"
+)
+
+func TestMediaClassOfFoldsEveryVocabulary(t *testing.T) {
+	cases := map[string]string{
+		"movie": MediaClassMovie, "Movies": MediaClassMovie, "anime_movie": MediaClassMovie,
+		"series": MediaClassSeries, "tv": MediaClassSeries, "tv_anime": MediaClassSeries, "anime_show": MediaClassSeries,
+		"direct": "", "": "", "  ": "", "music": "",
+	}
+	for in, want := range cases {
+		if got := MediaClassOf(in); got != want {
+			t.Errorf("MediaClassOf(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestWithMediaClassRoundTrip(t *testing.T) {
+	ctx := WithMediaClass(context.Background(), "tv_anime")
+	if got := MediaClassFromContext(ctx); got != MediaClassSeries {
+		t.Fatalf("got %q, want %q", got, MediaClassSeries)
+	}
+	// An unknown class leaves the context alone rather than storing "".
+	plain := WithMediaClass(context.Background(), "direct")
+	if got := MediaClassFromContext(plain); got != "" {
+		t.Fatalf("direct must not set a class, got %q", got)
+	}
+	if got := MediaClassFromContext(context.TODO()); got != "" {
+		t.Fatalf("empty context must answer \"\", got %q", got)
+	}
+}

--- a/pkg/indexer/newznab/client.go
+++ b/pkg/indexer/newznab/client.go
@@ -208,18 +208,22 @@ func (c *Client) buildAPIURL(params url.Values) string {
 	return fmt.Sprintf("%s%s?%s", c.baseURL, c.apiPath, encodeOrderedQuery(params, orderedSearchQueryKeys))
 }
 
-func (c *Client) effectiveQueryHeader() string {
+// effectiveQueryHeader and effectiveGrabHeader pick the User-Agent for one
+// request: this indexer's own override first, then the per-media header for
+// the class the context carries (see indexer.WithMediaClass), then the plain
+// global header.
+func (c *Client) effectiveQueryHeader(ctx context.Context) string {
 	if h := strings.TrimSpace(c.cfg.QueryHeader); h != "" {
 		return h
 	}
-	return env.IndexerQueryHeader()
+	return env.IndexerHeaderFor(indexer.MediaClassFromContext(ctx), false)
 }
 
-func (c *Client) effectiveGrabHeader() string {
+func (c *Client) effectiveGrabHeader(ctx context.Context) string {
 	if h := strings.TrimSpace(c.cfg.GrabHeader); h != "" {
 		return h
 	}
-	return env.IndexerGrabHeader()
+	return env.IndexerHeaderFor(indexer.MediaClassFromContext(ctx), true)
 }
 
 func (c *Client) checkAPILimit() error {
@@ -299,7 +303,7 @@ func (c *Client) Ping(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	req.Header.Set("User-Agent", c.effectiveQueryHeader())
+	req.Header.Set("User-Agent", c.effectiveQueryHeader(ctx))
 	resp, err := c.client.Do(req)
 	if err != nil {
 		return err
@@ -342,7 +346,7 @@ func (c *Client) GetCaps() (*indexer.Caps, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create caps request: %w", err)
 	}
-	req.Header.Set("User-Agent", c.effectiveQueryHeader())
+	req.Header.Set("User-Agent", c.effectiveQueryHeader(ctx))
 
 	resp, err := c.client.Do(req)
 	if err != nil {
@@ -500,6 +504,9 @@ func selectTVIDSearchParam(caps *indexer.Caps, req indexer.SearchRequest) (strin
 }
 
 func (c *Client) Search(ctx context.Context, req indexer.SearchRequest) (*indexer.SearchResponse, error) {
+	// The class rides the context so the HTTP layer picks the matching
+	// User-Agent without every helper growing a parameter.
+	ctx = indexer.WithMediaClass(ctx, req.Class)
 	if err := c.checkAPILimit(); err != nil {
 		return nil, err
 	}
@@ -792,7 +799,7 @@ func (c *Client) executeSearch(ctx context.Context, req indexer.SearchRequest, p
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
-	httpReq.Header.Set("User-Agent", c.effectiveQueryHeader())
+	httpReq.Header.Set("User-Agent", c.effectiveQueryHeader(ctx))
 	startedAt := time.Now()
 	resp, err := c.client.Do(httpReq)
 	if err != nil {
@@ -900,7 +907,7 @@ func (c *Client) DownloadNZB(ctx context.Context, nzbURL string) ([]byte, error)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
-	req.Header.Set("User-Agent", c.effectiveGrabHeader())
+	req.Header.Set("User-Agent", c.effectiveGrabHeader(ctx))
 	startedAt := time.Now()
 	resp, err := c.client.Do(req)
 	if err != nil {

--- a/pkg/indexer/newznab/client_test.go
+++ b/pkg/indexer/newznab/client_test.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"streamnzb/pkg/core/config"
+	"streamnzb/pkg/core/env"
 	"streamnzb/pkg/core/logger"
 	"streamnzb/pkg/core/persistence"
 	"streamnzb/pkg/indexer"
@@ -1219,5 +1220,80 @@ func TestCategoriesForResolvesTheClassInOneOrderOfAuthority(t *testing.T) {
 	client.cfg.TVCategories = ""
 	if got := client.categoriesFor(indexer.SearchRequest{Cat: "5030"}, false, true); got != "5030" {
 		t.Fatalf("classless request = %q, want the cat it arrived with", got)
+	}
+}
+
+// With per-media headers set, a series search and its grab both present the
+// series identity, a film presents the film identity, and an indexer's own
+// override still wins over either.
+func TestNewznabMediaHeaders(t *testing.T) {
+	logger.Init("DEBUG")
+	env.SetRuntimeHeaders("Prowlarr/2.3.0", "SABnzbd/4.5.5", "")
+	env.SetRuntimeMediaHeaders("Sonarr/4.0.15.2941", "Radarr/5.26.2.10099")
+	t.Cleanup(func() { env.SetRuntimeHeaders("", "", ""); env.SetRuntimeMediaHeaders("", "") })
+
+	var mu sync.Mutex
+	seen := map[string]string{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		seen[r.URL.Path+"?t="+r.URL.Query().Get("t")] = r.Header.Get("User-Agent")
+		mu.Unlock()
+		if r.URL.Path == "/nzb" {
+			w.Header().Set("Content-Type", "application/x-nzb")
+			fmt.Fprint(w, `<?xml version="1.0"?><nzb xmlns="http://www.newzbin.com/DTD/2003/nzb"></nzb>`)
+			return
+		}
+		w.Header().Set("Content-Type", "application/xml")
+		fmt.Fprint(w, `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:newznab="http://www.newznab.com/DTD/2010/feeds/attributes/"><channel><newznab:response offset="0" total="0"/></channel></rss>`)
+	}))
+	defer server.Close()
+
+	client := NewClient(config.IndexerConfig{Name: "MockIndexer", URL: server.URL, APIKey: "k"}, nil)
+
+	if _, err := client.Search(context.Background(), indexer.SearchRequest{Query: "show", Class: config.SearchClassTV, Season: "1", Episode: "2"}); err != nil {
+		t.Fatalf("series search: %v", err)
+	}
+	if _, err := client.Search(context.Background(), indexer.SearchRequest{Query: "film", Class: config.SearchClassMovie}); err != nil {
+		t.Fatalf("movie search: %v", err)
+	}
+	if _, err := client.DownloadNZB(indexer.WithMediaClass(context.Background(), config.SearchClassTVAnime), server.URL+"/nzb"); err != nil {
+		t.Fatalf("series grab: %v", err)
+	}
+
+	snapshot := func() map[string]string {
+		mu.Lock()
+		defer mu.Unlock()
+		out := make(map[string]string, len(seen))
+		for k, v := range seen {
+			out[k] = v
+		}
+		return out
+	}
+	first := snapshot()
+	presented := map[string]bool{}
+	for _, ua := range first {
+		presented[ua] = true
+	}
+	if !presented["Sonarr/4.0.15.2941"] || !presented["Radarr/5.26.2.10099"] {
+		t.Fatalf("expected both identities to be presented, saw %v", first)
+	}
+	if ua := first["/nzb?t="]; ua != "Sonarr/4.0.15.2941" {
+		t.Fatalf("series grab must carry the series identity, got %q (%v)", ua, first)
+	}
+
+	// The indexer's own override beats the per-media header.
+	override := NewClient(config.IndexerConfig{Name: "Scene", URL: server.URL, APIKey: "k", QueryHeader: "Prowlarr/1.0"}, nil)
+	if _, err := override.Search(context.Background(), indexer.SearchRequest{Query: "film", Class: config.SearchClassMovie}); err != nil {
+		t.Fatalf("override search: %v", err)
+	}
+	found := false
+	for _, ua := range snapshot() {
+		if ua == "Prowlarr/1.0" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("per-indexer override must win, saw %v", seen)
 	}
 }

--- a/pkg/server/newznab/feed.go
+++ b/pkg/server/newznab/feed.go
@@ -260,7 +260,7 @@ func downloadURL(baseURL, apiKey, id string) string {
 
 // linkerFor returns the itemLinker that seals each result's origin under
 // secret and points it back at baseURL.
-func linkerFor(secret, baseURL, apiKey string) itemLinker {
+func linkerFor(secret, baseURL, apiKey, class string) itemLinker {
 	return func(item *indexer.Item) string {
 		source := strings.TrimSpace(item.Link)
 		if source == "" {
@@ -274,7 +274,7 @@ func linkerFor(secret, baseURL, apiKey string) itemLinker {
 			logger.Debug("Newznab result dropped", "reason", "no resolvable download source", "title", item.Title, "indexer", name)
 			return ""
 		}
-		id, err := sealGrabRef(secret, grabRef{Indexer: name, URL: source, Title: item.Title})
+		id, err := sealGrabRef(secret, grabRef{Indexer: name, URL: source, Title: item.Title, Class: class})
 		if err != nil {
 			logger.Warn("Newznab result dropped", "reason", "failed to seal download reference", "title", item.Title, "err", err)
 			return ""

--- a/pkg/server/newznab/grab.go
+++ b/pkg/server/newznab/grab.go
@@ -22,6 +22,9 @@ type grabRef struct {
 	Indexer string `json:"i"`
 	URL     string `json:"u"`
 	Title   string `json:"t,omitempty"`
+	// Class is what the search that produced this link was after ("movie",
+	// "tv", "tv_anime"), so the grab can present the same identity.
+	Class string `json:"c,omitempty"`
 }
 
 var errBadGrabRef = errors.New("newznab: malformed download reference")
@@ -111,7 +114,7 @@ func (s *Server) handleGet(w http.ResponseWriter, r *http.Request, idx indexer.I
 		return
 	}
 
-	data, err := source.DownloadNZB(r.Context(), ref.URL)
+	data, err := source.DownloadNZB(indexer.WithMediaClass(r.Context(), ref.Class), ref.URL)
 	if err != nil {
 		logger.Warn("Newznab grab failed", "indexer", ref.Indexer, "title", ref.Title, "err", err)
 		s.writeError(w, r, http.StatusBadGateway, errUnknownError, "NZB download failed")

--- a/pkg/server/newznab/search.go
+++ b/pkg/server/newznab/search.go
@@ -111,7 +111,7 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request, function s
 
 	base := s.baseURL(r)
 	result := newFeed(s.selfURL(r), base, offset)
-	result.Channel.Items = buildFeedItems(items, linkerFor(s.grabSecret(), base, s.apiKey()))
+	result.Channel.Items = buildFeedItems(items, linkerFor(s.grabSecret(), base, s.apiKey(), req.Class))
 	// Newznab's total is the size of the whole result set. A fan-out cannot
 	// know that, and overstating it makes clients page into nothing, so it
 	// reports what has actually been served up to this page.

--- a/pkg/services/useragent/useragent.go
+++ b/pkg/services/useragent/useragent.go
@@ -24,6 +24,10 @@ const (
 	RoleQuery    = "query"
 	RoleGrab     = "grab"
 	RoleProvider = "provider"
+	// RoleSeries and RoleMovie seed the per-media headers: Sonarr for
+	// series, Radarr for films, each used for both search and grab.
+	RoleSeries = "series"
+	RoleMovie  = "movie"
 )
 
 const (
@@ -93,8 +97,8 @@ type source struct {
 // "nzbget/{version}").
 var catalog = []source{
 	{id: "prowlarr", product: "Prowlarr", role: RoleQuery, repo: "Prowlarr/Prowlarr"},
-	{id: "sonarr", product: "Sonarr", role: RoleQuery, repo: "Sonarr/Sonarr"},
-	{id: "radarr", product: "Radarr", role: RoleQuery, repo: "Radarr/Radarr"},
+	{id: "sonarr", product: "Sonarr", role: RoleSeries, repo: "Sonarr/Sonarr"},
+	{id: "radarr", product: "Radarr", role: RoleMovie, repo: "Radarr/Radarr"},
 	{id: "sabnzbd", product: "SABnzbd", role: RoleGrab, repo: "sabnzbd/sabnzbd"},
 	{id: "nzbget", product: "nzbget", role: RoleGrab, repo: "nzbgetcom/nzbget"},
 	{id: "vlc", product: "VLC", role: RoleProvider, statusURL: vlcStatusURL},

--- a/pkg/session/manager.go
+++ b/pkg/session/manager.go
@@ -1298,6 +1298,7 @@ func (s *Session) GetOrDownloadNZBWithContext(ctx context.Context, manager *Mana
 		segmentFetcher := s.segmentFetcher
 		itemTitle := ""
 		indexerName := ""
+		contentType := s.ContentType
 		if s.rel != nil {
 			itemTitle = s.rel.Title
 			indexerName = s.rel.Indexer
@@ -1313,7 +1314,9 @@ func (s *Session) GetOrDownloadNZBWithContext(ctx context.Context, manager *Mana
 		s.mu.Unlock()
 
 		go func() {
-			downloadCtx, cancel := context.WithTimeout(sessionFileCtx, 60*time.Second)
+			// The class the play is about, so the download presents the same
+			// identity the search did (Sonarr for a series, Radarr for a film).
+			downloadCtx, cancel := context.WithTimeout(indexer.WithMediaClass(sessionFileCtx, contentType), 60*time.Second)
 			defer cancel()
 
 			var data []byte


### PR DESCRIPTION
## Why

Today every search goes out as Prowlarr and every NZB download as SABnzbd. That pair is a tell: in a real automation stack Sonarr and Radarr search under their own names and fetch the NZB themselves, and SABnzbd never talks to an indexer. Indexers that look at the client name can pick StreamNZB out by that mismatch alone.

## What

Two optional headers, empty by default:

| Field | Env | Used for |
|---|---|---|
| `indexer_series_header` | `STREAMNZB_INDEXER_SERIES_HEADER` | series and anime: search **and** grab |
| `indexer_movie_header` | `STREAMNZB_INDEXER_MOVIE_HEADER` | films: search **and** grab |

Set them to a Sonarr and a Radarr User-Agent and the request's class picks the identity for the whole exchange. Unset, nothing changes. A per-indexer `query_header` / `grab_header` override still wins over both.

## How

- `pkg/indexer/media_class.go` — `WithMediaClass` / `MediaClassFromContext`, plus `MediaClassOf` folding the vocabularies already in use (`movie`/`tv`/`tv_anime`, Stremio `movie`/`series`, profile kinds) into `series` / `movie`. Unknown words (direct play) leave the context untouched.
- `env.IndexerHeaderFor(class, grab)` — per-media header for the class, else the existing query/grab header. Environment wins over config as for the other headers.
- Newznab and Easynews clients: `effectiveQueryHeader`/`effectiveGrabHeader` take the request context. `Search` stores `req.Class` in the context; caps and ping requests carry no class and use the plain query header.
- Grab sites: the session's lazy NZB download uses the session's content type; the Newznab re-serve endpoint seals the class of the originating search into the grab reference (`grabRef.Class`, `json:"c"`), so a grab minutes or hours later still matches the search that produced the link. Direct play sets nothing.
- Config/env wiring follows `envFieldCopiers`; both fields are redacted from the API like the other headers; `SetRuntimeMediaHeaders` sits beside `SetRuntimeHeaders` at all three call sites.
- User-Agent catalog: Sonarr and Radarr move to their own roles (`series`, `movie`). The settings card shows the two fields; **Update to latest** lifts a Sonarr/Radarr header it finds there but never seeds an empty one, so the split stays opt-in.
- Docs: env table and a "Per-media identity" paragraph in `configuration.md`.

## Tests

- `pkg/indexer/media_class_test.go` — vocabulary folding, context round trip, unknown class leaves the context alone.
- `pkg/core/env/env_test.go` — `IndexerHeaderFor` picks by class for search and grab, falls back per class, environment wins; override reading.
- `pkg/indexer/newznab/client_test.go` — `TestNewznabMediaHeaders`: a series search and its grab present the series identity, a film search presents the film identity, a per-indexer override still wins.
- `config_test.go` coverage pin updated for the two keys.

`go build ./...`, `gofmt -l`, `go vet ./...`, and `go test ./pkg/... ./cmd/...` pass except the two pre-existing failures on main (`TestHandleDownloadLogsReturnsNotFoundWhenMissing`, `TestSetLogPathHonorsCustomFileAndDirectory`). `npm run lint` and `vite build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MzJz3CvfuTMMDWn2jnntV3
