### PR TITLE
fix(jellyfin): relay artwork instead of redirecting (Infuse ignores 302s)

### DIFF
--- a/docs/jellyfin.md
+++ b/docs/jellyfin.md
@@ -61,8 +61,10 @@ stream never sees another's.
   from the same metadata providers the addon uses.
 - **Search** — the client's search box runs the addon's search carriers
   (TMDB movies, TMDB series, Kitsu anime) in parallel.
-- **Images** — posters and backdrops redirect to the provider's CDN, the same
-  URLs Stremio is given. They are never proxied through StreamNZB.
+- **Images** — posters and backdrops are fetched from the provider's CDN and
+  relayed by StreamNZB, because some clients (Infuse) do not follow redirects
+  for artwork. TMDB images are requested at bounded sizes (backdrops 1280px
+  wide, posters 780px) and sent with a one-day cache header.
 - **Playback** — pressing play searches, ranks and returns every candidate
   release as a *media source*, best first. The client's media-source picker is
   therefore the stream list, and switching source is switching release.

--- a/pkg/server/jellyfin/images.go
+++ b/pkg/server/jellyfin/images.go
@@ -3,19 +3,26 @@ package jellyfin
 import (
 	"crypto/sha1"
 	"encoding/hex"
+	"io"
+	"net"
 	"net/http"
+	"net/url"
+	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"streamnzb/pkg/core/logger"
 )
 
-// Images are never proxied. Jellyfin clients build image URLs from an item's
-// ImageTags and fetch /Items/{id}/Images/{type}?tag=..., and the answer here
-// is a redirect to the provider's CDN — the same URL the Stremio meta hands
-// out. The tag is a hash of that URL, so the layer can answer a tag it has
-// seen without touching metadata, and one it has not by resolving the item
-// again: the map is a fast path, not a source of truth.
+// Images are relayed, not redirected. Jellyfin clients build image URLs from
+// an item's ImageTags and fetch /Items/{id}/Images/{type}?tag=..., and the
+// answer here fetches the provider's CDN — the same URL the Stremio meta
+// hands out — and streams the bytes back, because some clients (Infuse on
+// tvOS/macOS) do not follow redirects for artwork and are left with a blank
+// image on a 302. The tag is a hash of the upstream URL, so the layer can
+// answer a tag it has seen without touching metadata, and one it has not by
+// resolving the item again: the map is a fast path, not a source of truth.
 
 const imageTagCap = 50_000
 
@@ -80,7 +87,7 @@ func (s *Server) serveImages(w http.ResponseWriter, rq *request) bool {
 	}
 	if tag := rq.param("tag"); tag != "" {
 		if url, ok := s.images.urlFor(tag); ok {
-			http.Redirect(w, rq.Request, url, http.StatusFound)
+			s.relayImage(w, rq, url, kind)
 			return true
 		}
 	}
@@ -89,7 +96,7 @@ func (s *Server) serveImages(w http.ResponseWriter, rq *request) bool {
 		http.NotFound(w, rq.Request)
 		return true
 	}
-	http.Redirect(w, rq.Request, url, http.StatusFound)
+	s.relayImage(w, rq, url, kind)
 	return true
 }
 
@@ -126,4 +133,120 @@ func (s *Server) resolveImage(rq *request, rawID, kind string) string {
 		return meta.Logo
 	}
 	return ""
+}
+
+// imageClient fetches provider images to relay. The dial, handshake and
+// response-header timeouts are short so a dead CDN fails fast; the overall
+// timeout is longer to cover a large backdrop over a slow upstream.
+var imageClient = &http.Client{
+	Timeout: 30 * time.Second,
+	Transport: &http.Transport{
+		DialContext:           (&net.Dialer{Timeout: 5 * time.Second}).DialContext,
+		TLSHandshakeTimeout:   5 * time.Second,
+		ResponseHeaderTimeout: 10 * time.Second,
+		MaxIdleConnsPerHost:   8,
+	},
+}
+
+// maxImageBody caps a relayed image, upstream Content-Length and all: this
+// layer never has to hold more than a poster in flight, and a CDN promising
+// more is answered with a 502 rather than trusted to actually send that much.
+const maxImageBody = 20 << 20 // 20 MiB
+
+// relayImage fetches url and streams it back as the response, instead of
+// redirecting the client to it: Infuse and some other clients ignore a 302
+// on an artwork request and are left with a blank image.
+func (s *Server) relayImage(w http.ResponseWriter, rq *request, rawURL, kind string) {
+	u, err := url.Parse(rawURL)
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
+		// Nothing here to fetch on the client's behalf; the redirect is the
+		// only path left for a scheme this layer cannot relay.
+		http.Redirect(w, rq.Request, rawURL, http.StatusFound)
+		return
+	}
+	target := rewriteImageSize(rawURL, kind)
+	// A GET is sent even for a HEAD request: some CDNs answer HEAD with the
+	// wrong content type, or refuse it outright.
+	req, err := http.NewRequestWithContext(rq.Context(), http.MethodGet, target, nil)
+	if err != nil {
+		logger.Debug("Jellyfin image relay failed", "url", target, "err", err)
+		http.Error(w, "bad gateway", http.StatusBadGateway)
+		return
+	}
+	resp, err := imageClient.Do(req)
+	if err != nil {
+		// Including a request the client abandoned: its context is what was
+		// passed above, so the fetch dies with it instead of running to
+		// completion for no one.
+		logger.Debug("Jellyfin image relay failed", "url", target, "err", err)
+		http.Error(w, "bad gateway", http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		logger.Debug("Jellyfin image relay failed", "url", target, "status", resp.StatusCode)
+		http.Error(w, "bad gateway", http.StatusBadGateway)
+		return
+	}
+	if cl := resp.Header.Get("Content-Length"); cl != "" {
+		if n, err := strconv.ParseInt(cl, 10, 64); err == nil && n > maxImageBody {
+			// Refused before a header is written: a Content-Length promising
+			// more than the cap would otherwise reach the client alongside a
+			// body truncated well short of it.
+			logger.Debug("Jellyfin image relay refused", "url", target, "length", n)
+			http.Error(w, "bad gateway", http.StatusBadGateway)
+			return
+		}
+	}
+	ct := resp.Header.Get("Content-Type")
+	if ct == "" {
+		ct = "image/jpeg"
+	}
+	w.Header().Set("Content-Type", ct)
+	if cl := resp.Header.Get("Content-Length"); cl != "" {
+		w.Header().Set("Content-Length", cl)
+	}
+	if etag := resp.Header.Get("ETag"); etag != "" {
+		w.Header().Set("ETag", etag)
+	}
+	if lm := resp.Header.Get("Last-Modified"); lm != "" {
+		w.Header().Set("Last-Modified", lm)
+	}
+	w.Header().Set("Cache-Control", "public, max-age=86400")
+	w.WriteHeader(http.StatusOK)
+	if rq.Method == http.MethodHead {
+		return
+	}
+	written, _ := io.Copy(w, io.LimitReader(resp.Body, maxImageBody)) // write errors ignored: the client went away
+	if written == maxImageBody {
+		logger.Debug("Jellyfin image relay body truncated", "url", target, "limit", maxImageBody)
+	}
+}
+
+// rewriteImageSize points a TMDB image at a size proportional to how large
+// clients render it, rather than the "original" full-resolution file the
+// catalog hands out: relaying a multi-megabyte poster for a thumbnail wastes
+// bandwidth neither side needs. Any other host is passed through unchanged.
+// There are no person items in this layer, so no people size.
+func rewriteImageSize(rawURL, kind string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Host != "image.tmdb.org" {
+		return rawURL
+	}
+	segs := strings.Split(strings.TrimPrefix(u.Path, "/"), "/")
+	if len(segs) != 4 || segs[0] != "t" || segs[1] != "p" {
+		return rawURL
+	}
+	var size string
+	switch kind {
+	case "backdrop":
+		size = "w1280"
+	case "primary", "thumb":
+		size = "w780"
+	default:
+		return rawURL
+	}
+	segs[2] = size
+	u.Path = "/" + strings.Join(segs, "/")
+	return u.String()
 }

--- a/pkg/server/jellyfin/server_test.go
+++ b/pkg/server/jellyfin/server_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"reflect"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -218,19 +219,44 @@ func previews(contentType, prefix string, n int) []stremio.MetaPreview {
 	return out
 }
 
+// testCDNServer stands in for a provider's image CDN: it answers any path
+// with 200 and the path itself as the body, so a test can tell which URL
+// the relay actually fetched, and answers a path containing "missing" with
+// 404. One instance covers the whole test binary; there is nothing to
+// serve differently per test that a distinct path can't already express.
+var testCDNServer = sync.OnceValue(func() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "missing") {
+			http.NotFound(w, r)
+			return
+		}
+		if strings.Contains(r.URL.Path, "huge") {
+			// Announces a body far past the relay cap; a well-behaved client
+			// gets refused before either header reaches it.
+			w.Header().Set("Content-Length", strconv.Itoa(maxImageBody+1))
+			w.Header().Set("Content-Type", "image/jpeg")
+			w.Write([]byte("not the whole thing"))
+			return
+		}
+		w.Header().Set("Content-Type", "image/jpeg")
+		w.Write([]byte(r.URL.Path))
+	}))
+})
+
 func testCatalog() *fakeCatalog {
+	cdn := testCDNServer().URL
 	movie := &stremio.MetaObject{
 		ID: "tt0111161", Type: "movie", Name: "The Shawshank Redemption",
-		Poster: "https://img.test/shawshank.jpg", Background: "https://img.test/shawshank-bg.jpg", Logo: "https://img.test/shawshank-logo.png",
+		Poster: cdn + "/shawshank.jpg", Background: cdn + "/shawshank-bg.jpg", Logo: cdn + "/shawshank-logo.png",
 		Description: "Two imprisoned men bond.", ReleaseInfo: "1994", Released: "1994-09-23T00:00:00.000Z",
 		IMDBRating: "9.3", Runtime: "142 min", Genres: []string{"Drama"}, Cast: []string{"Tim Robbins"}, Director: []string{"Frank Darabont"},
 		Trailers: []stremio.MetaTrailer{{Source: "6hB3S9bIaco", Type: "Trailer"}},
 	}
 	series := &stremio.MetaObject{
-		ID: "tt0903747", Type: "series", Name: "Breaking Bad", Poster: "https://img.test/bb.jpg", Background: "https://img.test/bb-bg.jpg",
+		ID: "tt0903747", Type: "series", Name: "Breaking Bad", Poster: "https://img.test/bb.jpg", Background: cdn + "/bb-bg.jpg",
 		ReleaseInfo: "2008-2013", Runtime: "49 min",
 		Videos: []stremio.MetaVideo{
-			{ID: "tt0903747:1:1", Title: "Pilot", Season: 1, Episode: 1, Released: "2008-01-20T00:00:00.000Z", Thumbnail: "https://img.test/bb-s1e1.jpg"},
+			{ID: "tt0903747:1:1", Title: "Pilot", Season: 1, Episode: 1, Released: "2008-01-20T00:00:00.000Z", Thumbnail: cdn + "/bb-s1e1.jpg"},
 			{ID: "tt0903747:1:2", Title: "Cat's in the Bag...", Season: 1, Episode: 2},
 			{ID: "tt0903747:2:1", Title: "Seven Thirty-Seven", Season: 2, Episode: 1},
 			{ID: "tt0903747:0:1", Title: "Minisode", Season: 0, Episode: 1},
@@ -484,23 +510,24 @@ func TestMovieDetail(t *testing.T) {
 	if item.ImageTags["Primary"] == "" || item.ImageTags["Logo"] == "" || len(item.BackdropImageTags) != 1 {
 		t.Fatalf("image tags: %+v %+v", item.ImageTags, item.BackdropImageTags)
 	}
-	// Images redirect to the provider URL the tag hashes.
+	// Images are relayed from the provider URL the tag hashes, not redirected
+	// to it: Infuse ignores a 302 on artwork and is left with nothing.
 	rec := f.do(http.MethodGet, "/jellyfin/Items/"+item.ID+"/Images/Primary?tag="+item.ImageTags["Primary"], "")
-	if rec.Code != http.StatusFound || rec.Header().Get("Location") != "https://img.test/shawshank.jpg" {
-		t.Fatalf("primary image: %d %s", rec.Code, rec.Header().Get("Location"))
+	if rec.Code != http.StatusOK || rec.Body.String() != "/shawshank.jpg" || rec.Header().Get("Cache-Control") != "public, max-age=86400" {
+		t.Fatalf("primary image: %d %q %q", rec.Code, rec.Body.String(), rec.Header().Get("Cache-Control"))
 	}
 	// A client's image loader carries no token; the tag alone must serve it,
 	// and an image it cannot resolve is a missing image, never a 401.
 	anon := f.do(http.MethodGet, "/jellyfin/Items/"+item.ID+"/Images/Primary?tag="+item.ImageTags["Primary"], "", "X-Nothing", "x")
-	if anon.Code != http.StatusFound || anon.Header().Get("Location") != rec.Header().Get("Location") {
-		t.Fatalf("anonymous image by tag: %d %s", anon.Code, anon.Header().Get("Location"))
+	if anon.Code != http.StatusOK || anon.Body.String() != rec.Body.String() {
+		t.Fatalf("anonymous image by tag: %d %s", anon.Code, anon.Body.String())
 	}
 	if anon := f.do(http.MethodGet, "/jellyfin/Items/"+item.ID+"/Images/Primary", "", "X-Nothing", "x"); anon.Code != http.StatusNotFound {
 		t.Fatalf("anonymous image without a tag: %d", anon.Code)
 	}
 	rec = f.do(http.MethodGet, "/jellyfin/Items/"+item.ID+"/Images/Backdrop/0?tag="+item.BackdropImageTags[0], "")
-	if rec.Code != http.StatusFound || rec.Header().Get("Location") != "https://img.test/shawshank-bg.jpg" {
-		t.Fatalf("backdrop image: %d %s", rec.Code, rec.Header().Get("Location"))
+	if rec.Code != http.StatusOK || rec.Body.String() != "/shawshank-bg.jpg" {
+		t.Fatalf("backdrop image: %d %s", rec.Code, rec.Body.String())
 	}
 	// Item lookup by ids.
 	var result queryResult
@@ -516,18 +543,90 @@ func TestImageMissResolvesFromMetadata(t *testing.T) {
 	ep := series.episode(1, 1)
 	// A fresh server has no tag map; the id alone must be enough.
 	rec := f.do(http.MethodGet, "/jellyfin/Items/"+ep.encode()+"/Images/Primary?tag=stale", "")
-	if rec.Code != http.StatusFound || rec.Header().Get("Location") != "https://img.test/bb-s1e1.jpg" {
-		t.Fatalf("episode primary on a miss: %d %s", rec.Code, rec.Header().Get("Location"))
+	if rec.Code != http.StatusOK || rec.Body.String() != "/bb-s1e1.jpg" {
+		t.Fatalf("episode primary on a miss: %d %s", rec.Code, rec.Body.String())
 	}
 	rec = f.do(http.MethodGet, "/jellyfin/Items/"+series.season(2).encode()+"/Images/Backdrop", "")
-	if rec.Code != http.StatusFound || rec.Header().Get("Location") != "https://img.test/bb-bg.jpg" {
-		t.Fatalf("season backdrop: %d %s", rec.Code, rec.Header().Get("Location"))
+	if rec.Code != http.StatusOK || rec.Body.String() != "/bb-bg.jpg" {
+		t.Fatalf("season backdrop: %d %s", rec.Code, rec.Body.String())
 	}
 	if rec := f.do(http.MethodGet, "/jellyfin/Items/"+series.encode()+"/Images/Logo", ""); rec.Code != http.StatusNotFound {
 		t.Fatalf("missing logo: %d", rec.Code)
 	}
 	if rec := f.do(http.MethodGet, "/jellyfin/Items/"+userID("person:Tim Robbins")+"/Images/Primary", ""); rec.Code != http.StatusNotFound {
 		t.Fatalf("person image: %d", rec.Code)
+	}
+}
+
+func TestImageRelayHEADHasHeadersButNoBody(t *testing.T) {
+	f := newFixture()
+	movie, _ := itemIDFor("movie", "tt0111161")
+	rec := f.do(http.MethodHead, "/jellyfin/Items/"+movie.encode()+"/Images/Primary", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("HEAD relay: %d", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "image/jpeg" {
+		t.Fatalf("HEAD content-type: %q", ct)
+	}
+	if cc := rec.Header().Get("Cache-Control"); cc != "public, max-age=86400" {
+		t.Fatalf("HEAD cache-control: %q", cc)
+	}
+	if rec.Body.Len() != 0 {
+		t.Fatalf("HEAD body: %q", rec.Body.String())
+	}
+}
+
+func TestImageRelayUpstream404(t *testing.T) {
+	f := newFixture()
+	f.catalog.metas["movie/tt0111161"].Poster = testCDNServer().URL + "/missing.jpg"
+	movie, _ := itemIDFor("movie", "tt0111161")
+	if rec := f.do(http.MethodGet, "/jellyfin/Items/"+movie.encode()+"/Images/Primary", ""); rec.Code != http.StatusBadGateway {
+		t.Fatalf("upstream 404: %d", rec.Code)
+	}
+}
+
+func TestImageRelayRefusesOversizedContentLength(t *testing.T) {
+	f := newFixture()
+	f.catalog.metas["movie/tt0111161"].Poster = testCDNServer().URL + "/huge.jpg"
+	movie, _ := itemIDFor("movie", "tt0111161")
+	rec := f.do(http.MethodGet, "/jellyfin/Items/"+movie.encode()+"/Images/Primary", "")
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("oversized content-length: %d", rec.Code)
+	}
+	// Refused before any of the CDN's response reaches the client.
+	if rec.Header().Get("Content-Type") == "image/jpeg" || strings.Contains(rec.Body.String(), "not the whole thing") {
+		t.Fatalf("oversized content-length leaked upstream headers/body: %+v %q", rec.Header(), rec.Body.String())
+	}
+}
+
+func TestImageRelayUpstreamUnreachable(t *testing.T) {
+	dead := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	deadURL := dead.URL + "/gone.jpg"
+	dead.Close() // closed before use: nothing answers this address any more.
+	f := newFixture()
+	f.catalog.metas["movie/tt0111161"].Poster = deadURL
+	movie, _ := itemIDFor("movie", "tt0111161")
+	if rec := f.do(http.MethodGet, "/jellyfin/Items/"+movie.encode()+"/Images/Primary", ""); rec.Code != http.StatusBadGateway {
+		t.Fatalf("upstream unreachable: %d", rec.Code)
+	}
+}
+
+func TestRewriteImageSize(t *testing.T) {
+	base := "https://image.tmdb.org/t/p/original/abc.jpg"
+	if got := rewriteImageSize(base, "backdrop"); got != "https://image.tmdb.org/t/p/w1280/abc.jpg" {
+		t.Fatalf("backdrop: %q", got)
+	}
+	if got := rewriteImageSize(base, "primary"); got != "https://image.tmdb.org/t/p/w780/abc.jpg" {
+		t.Fatalf("primary: %q", got)
+	}
+	if got := rewriteImageSize(base, "thumb"); got != "https://image.tmdb.org/t/p/w780/abc.jpg" {
+		t.Fatalf("thumb: %q", got)
+	}
+	if got := rewriteImageSize(base, "logo"); got != base {
+		t.Fatalf("logo passthrough: %q", got)
+	}
+	if got := rewriteImageSize("https://img.test/abc.jpg", "backdrop"); got != "https://img.test/abc.jpg" {
+		t.Fatalf("non-tmdb passthrough: %q", got)
 	}
 }
 


### PR DESCRIPTION
Infuse (tvOS and macOS) does not follow HTTP redirects when it fetches artwork. With the current `302` to the provider CDN, every poster, backdrop, episode thumbnail and cast photo is blank in Infuse. Findroid and Swiftfin follow the redirect, which is why it did not show up in testing. We hit exactly this on the AIOStreams Jellyfin layer and relaying was the only thing that fixed it.

What changes:
- `serveImages` fetches the upstream image and streams the bytes back, for both the tag fast path and the metadata-resolved path. A redirect is kept only for non-http(s) URLs.
- TMDB images are requested at bounded sizes (backdrops `w1280`, posters/thumbs `w780`) so relaying does not pay for `original`.
- `Content-Type`, `Content-Length`, `ETag`, `Last-Modified` are passed through; `Cache-Control: public, max-age=86400` is set. HEAD sends a GET upstream (some CDNs answer HEAD badly) and returns headers only.
- 5s dial/TLS, 10s response-header, 30s total timeouts; the fetch is bound to the client's request context. Upstream failure or non-2xx → 502. Bodies above 20 MiB (announced or actual) are refused/truncated with a debug log.
- Tests use an `httptest` CDN: relay, HEAD, TMDB size rewrite, 404 → 502, unreachable → 502, oversized `Content-Length` → 502. Existing image tests updated from 302 to 200.
- `docs/jellyfin.md` image bullet updated.

One thing worth your call: the layer now fetches whatever URL the metadata provider hands out, where before it only redirected to it. Providers are already trusted for everything else, so I left it as-is, but say if you want an allowlist of image hosts.

Tested locally with `go vet` + the jellyfin/core suites (three runs). Not yet verified on a device; I will run Infuse tvOS/macOS, SenPlayer and Swiftfin against a build of this branch and report back.
