### PR TITLE
fix(jellyfin): cap PlaybackInfo media sources (SenPlayer picker limit)

### DIFF
--- a/cmd/streamnzb/main.go
+++ b/cmd/streamnzb/main.go
@@ -342,6 +342,12 @@ func main() {
 			}
 			return liveCfg.GetAdminUsername(), liveCfg.AdminPasswordHash, liveCfg.AdminToken
 		},
+		MaxPlaybackSources: func() int {
+			if liveCfg := apiServer.Config(); liveCfg != nil {
+				return liveCfg.JellyfinMaxPlaybackSources
+			}
+			return 0
+		},
 		Streams:   streamManager,
 		Catalog:   stremioServer,
 		Playstate: stateMgr.JellyfinPlaystateStore(),

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -96,6 +96,7 @@ See [Database backends](database.md) for how switching and migration work.
 | Variable | Meaning |
 |---|---|
 | `JELLYFIN_ENABLED` | Enable/disable the Jellyfin endpoint (default off) — see [Jellyfin endpoint](jellyfin.md) |
+| `JELLYFIN_MAX_PLAYBACK_SOURCES` | Cap on media sources offered per play, 1-200 (default 20) |
 
 ### Outbound User-Agent headers
 

--- a/docs/jellyfin.md
+++ b/docs/jellyfin.md
@@ -65,7 +65,9 @@ stream never sees another's.
   URLs Stremio is given. They are never proxied through StreamNZB.
 - **Playback** — pressing play searches, ranks and returns every candidate
   release as a *media source*, best first. The client's media-source picker is
-  therefore the stream list, and switching source is switching release.
+  therefore the stream list, and switching source is switching release. At
+  most 20 sources are offered per play (`JELLYFIN_MAX_PLAYBACK_SOURCES`); some
+  clients' pickers break on longer lists.
 - **Resume** — position and watched state are kept per stream, server-side,
   because Jellyfin clients expect the server to remember rather than keeping
   it locally the way Stremio clients do. 90% in counts as watched.

--- a/pkg/core/config/config.go
+++ b/pkg/core/config/config.go
@@ -523,6 +523,9 @@ const (
 	DefaultVariantAttempts = 1
 	// VariantAttemptsUnlimited asks for every copy the merge kept.
 	VariantAttemptsUnlimited = -1
+	// DefaultJellyfinMaxPlaybackSources is how many ranked candidates
+	// PlaybackInfo offers when the operator has not set a limit.
+	DefaultJellyfinMaxPlaybackSources = 20
 )
 
 func (c *Config) EffectiveLibrarySearchMode() string {
@@ -760,6 +763,11 @@ type Config struct {
 	// servers and per-server state by. Generated when empty and never
 	// rotated afterwards: changing it makes every client forget its login.
 	JellyfinServerID string `json:"jellyfin_server_id"`
+	// JellyfinMaxPlaybackSources caps how many ranked candidates PlaybackInfo
+	// hands a client as media sources. Some pickers (SenPlayer's) break on a
+	// long list; the candidates are already ranked best-first, so capping
+	// only drops the tail. Defaulted to 20 when zero.
+	JellyfinMaxPlaybackSources int `json:"jellyfin_max_playback_sources,omitempty"`
 
 	AvailNZBURL    string `json:"-"`
 	AvailNZBAPIKey string `json:"-"`
@@ -1389,6 +1397,11 @@ func LoadWithPath(explicitPath string) (*Config, error) {
 			needSave = true
 		}
 	}
+	// Unlike the server id this default is not persisted: it is a computed
+	// fallback, not a value the operator needs to see written to disk.
+	if cfg.JellyfinMaxPlaybackSources <= 0 || cfg.JellyfinMaxPlaybackSources > 200 {
+		cfg.JellyfinMaxPlaybackSources = DefaultJellyfinMaxPlaybackSources
+	}
 	if cfg.AdminPasswordHash == "" {
 		cfg.AdminPasswordHash = defaultAdminPasswordHash
 		cfg.AdminMustChangePassword = true
@@ -1691,34 +1704,35 @@ func keySet(list []string, s string) bool {
 // so a new override is one entry instead of two hand-maintained mirrors that
 // can (and did) drift apart.
 var envFieldCopiers = map[string]func(dst, src *Config){
-	env.KeyAddonPort:              func(d, s *Config) { d.AddonPort = s.AddonPort },
-	env.KeyAddonBaseURL:           func(d, s *Config) { d.AddonBaseURL = s.AddonBaseURL },
-	env.KeyLogLevel:               func(d, s *Config) { d.LogLevel = s.LogLevel },
-	env.KeyKeepLogFiles:           func(d, s *Config) { d.KeepLogFiles = s.KeepLogFiles },
-	env.KeyAvailNZBAPIKey:         func(d, s *Config) { d.AvailNZBAPIKey = s.AvailNZBAPIKey },
-	env.KeyTMDBAPIKey:             func(d, s *Config) { d.TMDBAPIKey = s.TMDBAPIKey },
-	env.KeyTVDBAPIKey:             func(d, s *Config) { d.TVDBAPIKey = s.TVDBAPIKey },
-	env.KeySimklClientID:          func(d, s *Config) { d.SimklClientID = s.SimklClientID },
-	env.KeyIndexerQueryHeader:     func(d, s *Config) { d.IndexerQueryHeader = s.IndexerQueryHeader },
-	env.KeyIndexerGrabHeader:      func(d, s *Config) { d.IndexerGrabHeader = s.IndexerGrabHeader },
-	env.KeyProviderHeader:         func(d, s *Config) { d.ProviderHeader = s.ProviderHeader },
-	env.KeyProxyPort:              func(d, s *Config) { d.ProxyPort = s.ProxyPort },
-	env.KeyProxyHost:              func(d, s *Config) { d.ProxyHost = s.ProxyHost },
-	env.KeyProxyEnabled:           func(d, s *Config) { d.ProxyEnabled = s.ProxyEnabled },
-	env.KeyProxyAuthUser:          func(d, s *Config) { d.ProxyAuthUser = s.ProxyAuthUser },
-	env.KeyProxyAuthPass:          func(d, s *Config) { d.ProxyAuthPass = s.ProxyAuthPass },
-	env.KeyNewznabEnabled:         func(d, s *Config) { d.NewznabEnabled = s.NewznabEnabled },
-	env.KeyNewznabAPIKey:          func(d, s *Config) { d.NewznabAPIKey = s.NewznabAPIKey },
-	env.KeyJellyfinEnabled:        func(d, s *Config) { d.JellyfinEnabled = s.JellyfinEnabled },
-	env.KeyAdminUsername:          func(d, s *Config) { d.AdminUsername = s.AdminUsername },
-	env.KeyAdminMustChangePwd:     func(d, s *Config) { d.AdminMustChangePassword = s.AdminMustChangePassword },
-	env.KeyTrustedProxyAuthHeader: func(d, s *Config) { d.TrustedProxyAuthHeader = s.TrustedProxyAuthHeader },
-	env.KeyTrustedProxies:         func(d, s *Config) { d.TrustedProxies = append([]string(nil), s.TrustedProxies...) },
-	env.KeyProviders:              func(d, s *Config) { d.Providers = cloneProviders(s.Providers) },
-	env.KeyIndexers:               func(d, s *Config) { d.Indexers = cloneIndexers(s.Indexers) },
-	env.KeyDatabaseDriver:         func(d, s *Config) { d.DatabaseDriver = s.DatabaseDriver },
-	env.KeyDatabaseURL:            func(d, s *Config) { d.DatabaseURL = s.DatabaseURL },
-	env.KeyMetadataEnabled:        func(d, s *Config) { d.Metadata.Enabled = s.Metadata.Enabled },
+	env.KeyAddonPort:                  func(d, s *Config) { d.AddonPort = s.AddonPort },
+	env.KeyAddonBaseURL:               func(d, s *Config) { d.AddonBaseURL = s.AddonBaseURL },
+	env.KeyLogLevel:                   func(d, s *Config) { d.LogLevel = s.LogLevel },
+	env.KeyKeepLogFiles:               func(d, s *Config) { d.KeepLogFiles = s.KeepLogFiles },
+	env.KeyAvailNZBAPIKey:             func(d, s *Config) { d.AvailNZBAPIKey = s.AvailNZBAPIKey },
+	env.KeyTMDBAPIKey:                 func(d, s *Config) { d.TMDBAPIKey = s.TMDBAPIKey },
+	env.KeyTVDBAPIKey:                 func(d, s *Config) { d.TVDBAPIKey = s.TVDBAPIKey },
+	env.KeySimklClientID:              func(d, s *Config) { d.SimklClientID = s.SimklClientID },
+	env.KeyIndexerQueryHeader:         func(d, s *Config) { d.IndexerQueryHeader = s.IndexerQueryHeader },
+	env.KeyIndexerGrabHeader:          func(d, s *Config) { d.IndexerGrabHeader = s.IndexerGrabHeader },
+	env.KeyProviderHeader:             func(d, s *Config) { d.ProviderHeader = s.ProviderHeader },
+	env.KeyProxyPort:                  func(d, s *Config) { d.ProxyPort = s.ProxyPort },
+	env.KeyProxyHost:                  func(d, s *Config) { d.ProxyHost = s.ProxyHost },
+	env.KeyProxyEnabled:               func(d, s *Config) { d.ProxyEnabled = s.ProxyEnabled },
+	env.KeyProxyAuthUser:              func(d, s *Config) { d.ProxyAuthUser = s.ProxyAuthUser },
+	env.KeyProxyAuthPass:              func(d, s *Config) { d.ProxyAuthPass = s.ProxyAuthPass },
+	env.KeyNewznabEnabled:             func(d, s *Config) { d.NewznabEnabled = s.NewznabEnabled },
+	env.KeyNewznabAPIKey:              func(d, s *Config) { d.NewznabAPIKey = s.NewznabAPIKey },
+	env.KeyJellyfinEnabled:            func(d, s *Config) { d.JellyfinEnabled = s.JellyfinEnabled },
+	env.KeyJellyfinMaxPlaybackSources: func(d, s *Config) { d.JellyfinMaxPlaybackSources = s.JellyfinMaxPlaybackSources },
+	env.KeyAdminUsername:              func(d, s *Config) { d.AdminUsername = s.AdminUsername },
+	env.KeyAdminMustChangePwd:         func(d, s *Config) { d.AdminMustChangePassword = s.AdminMustChangePassword },
+	env.KeyTrustedProxyAuthHeader:     func(d, s *Config) { d.TrustedProxyAuthHeader = s.TrustedProxyAuthHeader },
+	env.KeyTrustedProxies:             func(d, s *Config) { d.TrustedProxies = append([]string(nil), s.TrustedProxies...) },
+	env.KeyProviders:                  func(d, s *Config) { d.Providers = cloneProviders(s.Providers) },
+	env.KeyIndexers:                   func(d, s *Config) { d.Indexers = cloneIndexers(s.Indexers) },
+	env.KeyDatabaseDriver:             func(d, s *Config) { d.DatabaseDriver = s.DatabaseDriver },
+	env.KeyDatabaseURL:                func(d, s *Config) { d.DatabaseURL = s.DatabaseURL },
+	env.KeyMetadataEnabled:            func(d, s *Config) { d.Metadata.Enabled = s.Metadata.Enabled },
 }
 
 // cloneProviders deep-copies the pointer fields so the two configs never share
@@ -1773,32 +1787,33 @@ func copyEnvKeys(dst, src *Config, keys []string) {
 // declared via env are always newznab and default to enabled).
 func envOverridesAsConfig(o env.ConfigOverrides) *Config {
 	cfg := &Config{
-		AddonPort:               o.AddonPort,
-		AddonBaseURL:            o.AddonBaseURL,
-		LogLevel:                o.LogLevel,
-		KeepLogFiles:            o.KeepLogFiles,
-		AvailNZBAPIKey:          o.AvailNZBAPIKey,
-		TMDBAPIKey:              o.TMDBAPIKey,
-		TVDBAPIKey:              o.TVDBAPIKey,
-		SimklClientID:           o.SimklClientID,
-		IndexerQueryHeader:      o.IndexerQueryHeader,
-		IndexerGrabHeader:       o.IndexerGrabHeader,
-		ProviderHeader:          o.ProviderHeader,
-		ProxyPort:               o.ProxyPort,
-		ProxyHost:               o.ProxyHost,
-		ProxyEnabled:            o.ProxyEnabled,
-		ProxyAuthUser:           o.ProxyAuthUser,
-		ProxyAuthPass:           o.ProxyAuthPass,
-		NewznabEnabled:          o.NewznabEnabled,
-		NewznabAPIKey:           o.NewznabAPIKey,
-		JellyfinEnabled:         o.JellyfinEnabled,
-		AdminUsername:           o.AdminUsername,
-		AdminMustChangePassword: o.AdminMustChangePwd,
-		TrustedProxyAuthHeader:  o.TrustedProxyAuthHeader,
-		TrustedProxies:          append([]string(nil), o.TrustedProxies...),
-		DatabaseDriver:          o.DatabaseDriver,
-		DatabaseURL:             o.DatabaseURL,
-		Metadata:                MetadataConfig{Enabled: &o.MetadataEnabled},
+		AddonPort:                  o.AddonPort,
+		AddonBaseURL:               o.AddonBaseURL,
+		LogLevel:                   o.LogLevel,
+		KeepLogFiles:               o.KeepLogFiles,
+		AvailNZBAPIKey:             o.AvailNZBAPIKey,
+		TMDBAPIKey:                 o.TMDBAPIKey,
+		TVDBAPIKey:                 o.TVDBAPIKey,
+		SimklClientID:              o.SimklClientID,
+		IndexerQueryHeader:         o.IndexerQueryHeader,
+		IndexerGrabHeader:          o.IndexerGrabHeader,
+		ProviderHeader:             o.ProviderHeader,
+		ProxyPort:                  o.ProxyPort,
+		ProxyHost:                  o.ProxyHost,
+		ProxyEnabled:               o.ProxyEnabled,
+		ProxyAuthUser:              o.ProxyAuthUser,
+		ProxyAuthPass:              o.ProxyAuthPass,
+		NewznabEnabled:             o.NewznabEnabled,
+		NewznabAPIKey:              o.NewznabAPIKey,
+		JellyfinEnabled:            o.JellyfinEnabled,
+		JellyfinMaxPlaybackSources: o.JellyfinMaxPlaybackSources,
+		AdminUsername:              o.AdminUsername,
+		AdminMustChangePassword:    o.AdminMustChangePwd,
+		TrustedProxyAuthHeader:     o.TrustedProxyAuthHeader,
+		TrustedProxies:             append([]string(nil), o.TrustedProxies...),
+		DatabaseDriver:             o.DatabaseDriver,
+		DatabaseURL:                o.DatabaseURL,
+		Metadata:                   MetadataConfig{Enabled: &o.MetadataEnabled},
 	}
 	cfg.Providers = make([]Provider, len(o.Providers))
 	for i, p := range o.Providers {

--- a/pkg/core/config/config_test.go
+++ b/pkg/core/config/config_test.go
@@ -832,6 +832,7 @@ func TestEnvFieldCopiersCoverEveryKey(t *testing.T) {
 		env.KeyAddonPort, env.KeyAddonBaseURL, env.KeyLogLevel, env.KeyKeepLogFiles,
 		env.KeyProxyPort, env.KeyProxyHost, env.KeyProxyEnabled, env.KeyProxyAuthUser,
 		env.KeyProxyAuthPass, env.KeyNewznabEnabled, env.KeyNewznabAPIKey, env.KeyJellyfinEnabled,
+		env.KeyJellyfinMaxPlaybackSources,
 		env.KeyProviders, env.KeyIndexers, env.KeyAvailNZBURL,
 		env.KeyAvailNZBAPIKey, env.KeyTMDBAPIKey, env.KeyTVDBAPIKey, env.KeySimklClientID,
 		env.KeyIndexerQueryHeader, env.KeyIndexerGrabHeader, env.KeyProviderHeader,

--- a/pkg/core/env/env.go
+++ b/pkg/core/env/env.go
@@ -29,6 +29,7 @@ const (
 	NewznabEnabledEnv                  = "NEWZNAB_ENABLED"
 	NewznabAPIKeyEnv                   = "NEWZNAB_API_KEY"
 	JellyfinEnabledEnv                 = "JELLYFIN_ENABLED"
+	JellyfinMaxPlaybackSourcesEnv      = "JELLYFIN_MAX_PLAYBACK_SOURCES"
 	TZVar                              = "TZ"
 	ProviderPrefix                     = "PROVIDER_"
 	IndexerPrefix                      = "INDEXER_"
@@ -57,35 +58,36 @@ const (
 )
 
 const (
-	KeyAddonPort              = "addon_port"
-	KeyAddonBaseURL           = "addon_base_url"
-	KeyLogLevel               = "log_level"
-	KeyKeepLogFiles           = "keep_log_files"
-	KeyProxyPort              = "proxy_port"
-	KeyProxyHost              = "proxy_host"
-	KeyProxyEnabled           = "proxy_enabled"
-	KeyProxyAuthUser          = "proxy_auth_user"
-	KeyProxyAuthPass          = "proxy_auth_pass"
-	KeyNewznabEnabled         = "newznab_enabled"
-	KeyNewznabAPIKey          = "newznab_api_key"
-	KeyJellyfinEnabled        = "jellyfin_enabled"
-	KeyProviders              = "providers"
-	KeyIndexers               = "indexers"
-	KeyAvailNZBURL            = "availnzb_url"
-	KeyAvailNZBAPIKey         = "availnzb_api_key"
-	KeyTMDBAPIKey             = "tmdb_api_key"
-	KeyTVDBAPIKey             = "tvdb_api_key"
-	KeySimklClientID          = "simkl_client_id"
-	KeyMetadataEnabled        = "metadata_enabled"
-	KeyIndexerQueryHeader     = "indexer_query_header"
-	KeyIndexerGrabHeader      = "indexer_grab_header"
-	KeyProviderHeader         = "provider_header"
-	KeyAdminUsername          = "admin_username"
-	KeyAdminMustChangePwd     = "admin_must_change_password"
-	KeyTrustedProxyAuthHeader = "trusted_proxy_auth_header"
-	KeyTrustedProxies         = "trusted_proxies"
-	KeyDatabaseDriver         = "database_driver"
-	KeyDatabaseURL            = "database_url"
+	KeyAddonPort                  = "addon_port"
+	KeyAddonBaseURL               = "addon_base_url"
+	KeyLogLevel                   = "log_level"
+	KeyKeepLogFiles               = "keep_log_files"
+	KeyProxyPort                  = "proxy_port"
+	KeyProxyHost                  = "proxy_host"
+	KeyProxyEnabled               = "proxy_enabled"
+	KeyProxyAuthUser              = "proxy_auth_user"
+	KeyProxyAuthPass              = "proxy_auth_pass"
+	KeyNewznabEnabled             = "newznab_enabled"
+	KeyNewznabAPIKey              = "newznab_api_key"
+	KeyJellyfinEnabled            = "jellyfin_enabled"
+	KeyJellyfinMaxPlaybackSources = "jellyfin_max_playback_sources"
+	KeyProviders                  = "providers"
+	KeyIndexers                   = "indexers"
+	KeyAvailNZBURL                = "availnzb_url"
+	KeyAvailNZBAPIKey             = "availnzb_api_key"
+	KeyTMDBAPIKey                 = "tmdb_api_key"
+	KeyTVDBAPIKey                 = "tvdb_api_key"
+	KeySimklClientID              = "simkl_client_id"
+	KeyMetadataEnabled            = "metadata_enabled"
+	KeyIndexerQueryHeader         = "indexer_query_header"
+	KeyIndexerGrabHeader          = "indexer_grab_header"
+	KeyProviderHeader             = "provider_header"
+	KeyAdminUsername              = "admin_username"
+	KeyAdminMustChangePwd         = "admin_must_change_password"
+	KeyTrustedProxyAuthHeader     = "trusted_proxy_auth_header"
+	KeyTrustedProxies             = "trusted_proxies"
+	KeyDatabaseDriver             = "database_driver"
+	KeyDatabaseURL                = "database_url"
 )
 
 const AdminUsernameEnv = "ADMIN_USERNAME"
@@ -398,35 +400,36 @@ type Indexer struct {
 }
 
 type ConfigOverrides struct {
-	AddonPort              int
-	AddonBaseURL           string
-	LogLevel               string
-	KeepLogFiles           int
-	AvailNZBURL            string
-	AvailNZBAPIKey         string
-	TMDBAPIKey             string
-	TVDBAPIKey             string
-	SimklClientID          string
-	IndexerQueryHeader     string
-	IndexerGrabHeader      string
-	ProviderHeader         string
-	ProxyPort              int
-	ProxyHost              string
-	ProxyEnabled           bool
-	ProxyAuthUser          string
-	ProxyAuthPass          string
-	NewznabEnabled         bool
-	NewznabAPIKey          string
-	JellyfinEnabled        bool
-	AdminUsername          string
-	AdminMustChangePwd     bool
-	TrustedProxyAuthHeader string
-	TrustedProxies         []string
-	DatabaseDriver         string
-	DatabaseURL            string
-	MetadataEnabled        bool
-	Providers              []Provider
-	Indexers               []Indexer
+	AddonPort                  int
+	AddonBaseURL               string
+	LogLevel                   string
+	KeepLogFiles               int
+	AvailNZBURL                string
+	AvailNZBAPIKey             string
+	TMDBAPIKey                 string
+	TVDBAPIKey                 string
+	SimklClientID              string
+	IndexerQueryHeader         string
+	IndexerGrabHeader          string
+	ProviderHeader             string
+	ProxyPort                  int
+	ProxyHost                  string
+	ProxyEnabled               bool
+	ProxyAuthUser              string
+	ProxyAuthPass              string
+	NewznabEnabled             bool
+	NewznabAPIKey              string
+	JellyfinEnabled            bool
+	JellyfinMaxPlaybackSources int
+	AdminUsername              string
+	AdminMustChangePwd         bool
+	TrustedProxyAuthHeader     string
+	TrustedProxies             []string
+	DatabaseDriver             string
+	DatabaseURL                string
+	MetadataEnabled            bool
+	Providers                  []Provider
+	Indexers                   []Indexer
 }
 
 // envReader accumulates config overrides read from the environment, tracking
@@ -499,6 +502,7 @@ func ReadConfigOverrides() (ConfigOverrides, []string) {
 		o.JellyfinEnabled = getEnvBool(JellyfinEnabledEnv, true)
 		r.keys = append(r.keys, KeyJellyfinEnabled)
 	}
+	r.intVal(&o.JellyfinMaxPlaybackSources, KeyJellyfinMaxPlaybackSources, JellyfinMaxPlaybackSourcesEnv, func(n int) bool { return n >= 1 && n <= 200 })
 	r.str(&o.AdminUsername, KeyAdminUsername, AdminUsernameEnv)
 	r.str(&o.DatabaseDriver, KeyDatabaseDriver, StreamNZBDatabaseDriverEnv, DatabaseDriverEnv)
 	r.str(&o.DatabaseURL, KeyDatabaseURL, StreamNZBDatabaseURLEnv, DatabaseURLEnv)

--- a/pkg/core/env/env_test.go
+++ b/pkg/core/env/env_test.go
@@ -361,7 +361,7 @@ func TestProviderBlockDefaults(t *testing.T) {
 func TestOverrideKeysAreReportedOnlyForVariablesThatAreSet(t *testing.T) {
 	clearNumberedBlocks(t)
 	clear(t, ADDONPort, ADDONBaseURL, LOGLevel, KeepLogFiles, AdminUsernameEnv,
-		MetadataEnabledEnv, NNTPProxyEnabled, NewznabEnabledEnv, JellyfinEnabledEnv, AdminForcePasswordResetEnv,
+		MetadataEnabledEnv, NNTPProxyEnabled, NewznabEnabledEnv, JellyfinEnabledEnv, JellyfinMaxPlaybackSourcesEnv, AdminForcePasswordResetEnv,
 		AvailNZBAPIKey, TMDBAPIKey, TVDBAPIKey, SimklClientID, NNTPProxyPort, NNTPProxyHost,
 		NNTPProxyAuthUser, NNTPProxyAuthPass, NewznabAPIKeyEnv,
 		StreamNZBDatabaseDriverEnv, DatabaseDriverEnv, StreamNZBDatabaseURLEnv, DatabaseURLEnv,
@@ -409,6 +409,28 @@ func TestUnparsableIntegersOverrideNothing(t *testing.T) {
 	o, keys := ReadConfigOverrides()
 	if o.KeepLogFiles != 0 || contains(keys, KeyKeepLogFiles) {
 		t.Fatalf("KEEP_LOG_FILES=0 gave %d, keys %v", o.KeepLogFiles, keys)
+	}
+}
+
+// JELLYFIN_MAX_PLAYBACK_SOURCES follows the same intVal path as KeepLogFiles:
+// it parses and range-checks together, so a value outside 1-200 is treated as
+// unset rather than silently clamped.
+func TestJellyfinMaxPlaybackSourcesEnv(t *testing.T) {
+	clearNumberedBlocks(t)
+	clear(t, JellyfinMaxPlaybackSourcesEnv)
+
+	t.Setenv(JellyfinMaxPlaybackSourcesEnv, "5")
+	o, keys := ReadConfigOverrides()
+	if o.JellyfinMaxPlaybackSources != 5 || !contains(keys, KeyJellyfinMaxPlaybackSources) {
+		t.Fatalf("JELLYFIN_MAX_PLAYBACK_SOURCES=5 gave %d, keys %v", o.JellyfinMaxPlaybackSources, keys)
+	}
+
+	for _, bad := range []string{"0", "201", "-1", "many"} {
+		t.Setenv(JellyfinMaxPlaybackSourcesEnv, bad)
+		o, keys := ReadConfigOverrides()
+		if o.JellyfinMaxPlaybackSources != 0 || contains(keys, KeyJellyfinMaxPlaybackSources) {
+			t.Fatalf("JELLYFIN_MAX_PLAYBACK_SOURCES=%q gave %d, keys %v", bad, o.JellyfinMaxPlaybackSources, keys)
+		}
 	}
 }
 

--- a/pkg/server/api/config_validation.go
+++ b/pkg/server/api/config_validation.go
@@ -114,6 +114,7 @@ var patchKeysNoCacheImpact = map[string]bool{
 	"newznab_enabled":                     true,
 	"newznab_api_key":                     true,
 	"jellyfin_enabled":                    true,
+	"jellyfin_max_playback_sources":       true,
 	"indexer_query_header":                true,
 	"indexer_grab_header":                 true,
 	"provider_header":                     true,

--- a/pkg/server/jellyfin/playback.go
+++ b/pkg/server/jellyfin/playback.go
@@ -196,6 +196,17 @@ func playSessionID(streamName, itemID string) string {
 	return hex.EncodeToString(h[:16])
 }
 
+// cappedEntries trims a ranked playlist down to maxSources, keeping the best
+// candidates: entries arrive best-first, so truncation only ever drops the tail.
+func (s *Server) cappedEntries(rq *request, id itemID, entries []stremio.PlaylistEntry) []stremio.PlaylistEntry {
+	limit := s.maxSources()
+	if len(entries) <= limit {
+		return entries
+	}
+	logger.Debug("Jellyfin media sources truncated", "stream", rq.streamName(), "content", id.playStremioID(), "total", len(entries), "sent", limit)
+	return entries[:limit]
+}
+
 func (s *Server) handlePlaybackInfo(w http.ResponseWriter, rq *request, raw string) {
 	id, _, ok := playableID(raw)
 	if !ok {
@@ -214,7 +225,7 @@ func (s *Server) handlePlaybackInfo(w http.ResponseWriter, rq *request, raw stri
 		writeJSON(w, http.StatusOK, resp)
 		return
 	}
-	for _, entry := range view.Entries {
+	for _, entry := range s.cappedEntries(rq, id, view.Entries) {
 		resp.MediaSources = append(resp.MediaSources, s.mediaSourceOf(rq, id, entry, view.RuntimeSeconds))
 	}
 	if len(resp.MediaSources) == 0 {
@@ -241,7 +252,7 @@ func (s *Server) attachMediaSources(rq *request, id itemID, item *baseItem) {
 		return
 	}
 	if view, ok := s.opts.Catalog.PlaylistCached(rq.stream, id.ContentType, id.playStremioID()); ok && view != nil && len(view.Entries) > 0 {
-		for _, entry := range view.Entries {
+		for _, entry := range s.cappedEntries(rq, id, view.Entries) {
 			item.MediaSources = append(item.MediaSources, s.mediaSourceOf(rq, id, entry, view.RuntimeSeconds))
 		}
 		return

--- a/pkg/server/jellyfin/server.go
+++ b/pkg/server/jellyfin/server.go
@@ -86,6 +86,10 @@ type Options struct {
 	// The admin signs in with the dashboard credentials and is served as the
 	// admin stream, the same as in the Stremio addon.
 	Admin func() (username, passwordHash, token string)
+	// MaxPlaybackSources caps how many ranked candidates a media-source list
+	// carries; read per request. A nil or non-positive value falls back to
+	// defaultMaxPlaybackSources.
+	MaxPlaybackSources func() int
 
 	Streams   Streams
 	Catalog   Catalog
@@ -111,6 +115,29 @@ func (s *Server) Handler() http.Handler {
 
 func (s *Server) enabled() bool {
 	return s.opts.Enabled == nil || s.opts.Enabled()
+}
+
+// defaultMaxPlaybackSources is applied when the operator has not set a
+// limit, or has set one out of range.
+const defaultMaxPlaybackSources = 20
+
+// maxSources reads the configured cap, clamped to a sane range so a bad
+// config value cannot empty the list or make it unbounded again.
+func (s *Server) maxSources() int {
+	n := defaultMaxPlaybackSources
+	if s.opts.MaxPlaybackSources != nil {
+		if v := s.opts.MaxPlaybackSources(); v > 0 {
+			n = v
+		}
+	}
+	switch {
+	case n < 1:
+		return 1
+	case n > 200:
+		return 200
+	default:
+		return n
+	}
 }
 
 func (s *Server) serverID() string {

--- a/pkg/server/jellyfin/server_test.go
+++ b/pkg/server/jellyfin/server_test.go
@@ -260,23 +260,25 @@ func testCatalog() *fakeCatalog {
 }
 
 type fixture struct {
-	server   *Server
-	catalog  *fakeCatalog
-	play     *fakePlaystate
-	enabled  bool
-	serverID string
+	server     *Server
+	catalog    *fakeCatalog
+	play       *fakePlaystate
+	enabled    bool
+	serverID   string
+	maxSources int
 }
 
 func newFixture() *fixture {
 	f := &fixture{catalog: testCatalog(), play: newFakePlaystate(), enabled: true, serverID: "srv-0001"}
 	f.server = New(Options{
-		Enabled:   func() bool { return f.enabled },
-		ServerID:  func() string { return f.serverID },
-		Admin:     func() (string, string, string) { return "admin", "$argon2id$hash", testAdminToken },
-		Streams:   fakeStreams{},
-		Catalog:   f.catalog,
-		Playstate: f.play,
-		Version:   "test",
+		Enabled:            func() bool { return f.enabled },
+		ServerID:           func() string { return f.serverID },
+		Admin:              func() (string, string, string) { return "admin", "$argon2id$hash", testAdminToken },
+		MaxPlaybackSources: func() int { return f.maxSources },
+		Streams:            fakeStreams{},
+		Catalog:            f.catalog,
+		Playstate:          f.play,
+		Version:            "test",
 	})
 	return f
 }
@@ -707,6 +709,37 @@ func TestPlaybackInfo(t *testing.T) {
 	}
 	if rec := f.do(http.MethodGet, "/jellyfin/Items/"+viewID("tmdb.trending.movie")+"/PlaybackInfo", ""); rec.Code != http.StatusNotFound {
 		t.Fatalf("playback info for a folder: %d", rec.Code)
+	}
+}
+
+// TestPlaybackInfoCapsSources checks that a playlist longer than the
+// configured limit is truncated to the limit, keeping the best-ranked
+// entries (the playlist already arrives ranked best-first).
+func TestPlaybackInfoCapsSources(t *testing.T) {
+	f := newFixture()
+	movie, _ := itemIDFor("movie", "tt0111161")
+	entries := make([]stremio.PlaylistEntry, 25)
+	for i := range entries {
+		entries[i] = stremio.PlaylistEntry{Index: i, Title: fmt.Sprintf("Release.%02d.mkv", i)}
+	}
+	f.catalog.playlist = &stremio.PlaylistView{Entries: entries}
+
+	var info playbackInfoResponse
+	decodeInto(t, f.do(http.MethodGet, "/jellyfin/Items/"+movie.encode()+"/PlaybackInfo", ""), &info)
+	if len(info.MediaSources) != 20 {
+		t.Fatalf("want 20 sources capped from 25, got %d", len(info.MediaSources))
+	}
+	for i, src := range info.MediaSources {
+		if src.Name != fmt.Sprintf("Release.%02d.mkv", i) {
+			t.Fatalf("source %d out of order: %+v", i, src)
+		}
+	}
+
+	// A configured limit is honoured too.
+	f.maxSources = 3
+	decodeInto(t, f.do(http.MethodGet, "/jellyfin/Items/"+movie.encode()+"/PlaybackInfo", ""), &info)
+	if len(info.MediaSources) != 3 {
+		t.Fatalf("want 3 sources with a configured limit, got %d", len(info.MediaSources))
 	}
 }
 


### PR DESCRIPTION
SenPlayer's version picker breaks on long `MediaSources` lists (we saw it above ~50 entries on the AIOStreams Jellyfin layer and capped there at 20). StreamNZB playlists can be dozens of releases, and they are already ranked best-first, so a cap only ever drops the tail.

What changes:
- New config `jellyfin_max_playback_sources` (default 20, range 1–200) with env override `JELLYFIN_MAX_PLAYBACK_SOURCES`, plumbed exactly like `jellyfin_enabled` (env key, overrides map, `envOverridesAsConfig`, no-cache-impact patch key). No dashboard field added; happy to add one if you want it visible.
- `jellyfin.Options.MaxPlaybackSources func() int`, read per request from live config like `Enabled`.
- `cappedEntries` applies the cap in `handlePlaybackInfo` and in the cached-playlist branch of `attachMediaSources`, with a debug log when it truncates.
- Tests: 25 candidates → 20 in order; configured limit of 3 honoured; env parse table entry.
- Docs: row in `docs/configuration.md`, sentence in the Playback bullet of `docs/jellyfin.md`.

Most of the diff in `config.go`/`env.go` is gofmt realignment from the longer identifier.
