### PR TITLE
feat(metadata): prioritize anime sources

### DIFF
--- a/frontend/src/components/MetadataPage.jsx
+++ b/frontend/src/components/MetadataPage.jsx
@@ -408,7 +408,7 @@ function MetadataProfileEditor({ draft, onChange, registry, registryError, certO
           <CardTitle className="text-base font-semibold">Sources &amp; language</CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
-          <div className="grid gap-3 sm:grid-cols-3">
+          <div className="grid gap-3 sm:grid-cols-4">
             <div className="space-y-1.5">
               <Label htmlFor="metadata-source-movie" className="text-sm">Movies</Label>
               <select id="metadata-source-movie" className={selectClass} value="tmdb" disabled>
@@ -428,15 +428,41 @@ function MetadataProfileEditor({ draft, onChange, registry, registryError, certO
               </select>
             </div>
             <div className="space-y-1.5">
-              <Label htmlFor="metadata-source-anime" className="text-sm">Anime</Label>
-              <select id="metadata-source-anime" className={selectClass} value="kitsu" disabled>
-                <option value="kitsu">Kitsu</option>
+              <Label htmlFor="metadata-source-anime" className="text-sm">Anime primary</Label>
+              <select
+                id="metadata-source-anime"
+                className={selectClass}
+                value={draft.anime_source === "tvdb" ? "tvdb" : "kitsu"}
+                onChange={(e) => {
+                  const primary = e.target.value
+                  const backup = primary === "kitsu" ? "tvdb" : "kitsu"
+                  onChange({ ...draft, anime_source: primary === "kitsu" ? undefined : primary, anime_backup_source: backup === "tvdb" ? undefined : backup })
+                }}
+              >
+                <option value="kitsu">Kitsu (default)</option>
+                <option value="tvdb">TVDB</option>
+              </select>
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="metadata-source-anime-backup" className="text-sm">Anime backup</Label>
+              <select
+                id="metadata-source-anime-backup"
+                className={selectClass}
+                value={draft.anime_source === "tvdb" ? "kitsu" : (draft.anime_backup_source === "kitsu" ? "kitsu" : "tvdb")}
+                onChange={(e) => {
+                  const backup = e.target.value
+                  const primary = backup === "kitsu" ? "tvdb" : "kitsu"
+                  onChange({ ...draft, anime_source: primary === "kitsu" ? undefined : primary, anime_backup_source: backup === "tvdb" ? undefined : backup })
+                }}
+              >
+                <option value={draft.anime_source === "tvdb" ? "kitsu" : "tvdb"}>{draft.anime_source === "tvdb" ? "Kitsu" : "TVDB"}</option>
               </select>
             </div>
           </div>
           <p className="text-xs text-muted-foreground">
-            The source a media type&apos;s name, artwork and episode list come from. When the primary source
-            cannot serve a title, the other one steps in. Movies and anime have a single source today.
+            The primary source supplies a media type&apos;s metadata. Its backup is used only when the primary
+            cannot serve that title. Anime always keeps Kitsu&apos;s stable playback IDs, so switching metadata
+            sources never changes episode matching or stream lookup.
           </p>
           <div className="space-y-1.5">
             <Label htmlFor="metadata-language" className="text-sm">Language</Label>

--- a/pkg/core/config/metadataprofile.go
+++ b/pkg/core/config/metadataprofile.go
@@ -28,9 +28,10 @@ type MetadataProfileConfig struct {
 	// Per-media-type meta sources. Empty means the default; unknown values
 	// normalize to the default read-side. Today only series has a real choice
 	// (TVDB default, TMDB alternative).
-	MovieSource  string `json:"movie_source,omitempty"`
-	SeriesSource string `json:"series_source,omitempty"`
-	AnimeSource  string `json:"anime_source,omitempty"`
+	MovieSource       string `json:"movie_source,omitempty"`
+	SeriesSource      string `json:"series_source,omitempty"`
+	AnimeSource       string `json:"anime_source,omitempty"`
+	AnimeBackupSource string `json:"anime_backup_source,omitempty"`
 
 	// TVMazeAirDates lets TVMaze override episode air dates (and drive the
 	// unaired-episode gate). nil means enabled.
@@ -85,6 +86,31 @@ func (p *MetadataProfileConfig) EffectiveSeriesMetaSource() string {
 		return "tmdb"
 	}
 	return "tvdb"
+}
+
+// EffectiveAnimeMetaSources returns the user-selected ordered metadata
+// providers. Kitsu remains the default primary to preserve existing profiles;
+// TVDB is its fallback. Invalid or duplicate persisted values normalize to a
+// usable pair rather than making an installed profile unopenable.
+func (p *MetadataProfileConfig) EffectiveAnimeMetaSources() (primary, backup string) {
+	primary, backup = "kitsu", "tvdb"
+	if p == nil {
+		return primary, backup
+	}
+	if p.AnimeSource == "tvdb" || p.AnimeSource == "kitsu" {
+		primary = p.AnimeSource
+	}
+	if p.AnimeBackupSource == "tvdb" || p.AnimeBackupSource == "kitsu" {
+		backup = p.AnimeBackupSource
+	}
+	if primary == backup {
+		if primary == "kitsu" {
+			backup = "tvdb"
+		} else {
+			backup = "kitsu"
+		}
+	}
+	return primary, backup
 }
 
 // EffectiveLanguage returns the profile's display language tag, or "" for the

--- a/pkg/core/config/metadataprofile_test.go
+++ b/pkg/core/config/metadataprofile_test.go
@@ -20,6 +20,25 @@ func loadFromJSON(t *testing.T, content string) *Config {
 	return cfg
 }
 
+func TestEffectiveAnimeMetaSourcesAreOrderedAndDistinct(t *testing.T) {
+	tests := []struct {
+		name, primary, backup, wantPrimary, wantBackup string
+	}{
+		{"default", "", "", "kitsu", "tvdb"},
+		{"tvdb primary", "tvdb", "kitsu", "tvdb", "kitsu"},
+		{"duplicate normalizes", "tvdb", "tvdb", "tvdb", "kitsu"},
+		{"invalid normalizes", "invalid", "invalid", "kitsu", "tvdb"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			primary, backup := (&MetadataProfileConfig{AnimeSource: tc.primary, AnimeBackupSource: tc.backup}).EffectiveAnimeMetaSources()
+			if primary != tc.wantPrimary || backup != tc.wantBackup {
+				t.Fatalf("sources = %q, %q; want %q, %q", primary, backup, tc.wantPrimary, tc.wantBackup)
+			}
+		})
+	}
+}
+
 func TestMetadataProfileMigrationSeedsAndBinds(t *testing.T) {
 	cfg := loadFromJSON(t, `{
 		"config_version": 2,

--- a/pkg/core/persistence/anime_mapping_store.go
+++ b/pkg/core/persistence/anime_mapping_store.go
@@ -128,7 +128,10 @@ func (as *AnimeMappingStore) LookupTVDB(tvdbID string) (*AnimeMapping, bool) {
 		return nil, false
 	}
 	return as.lookupOne(`WHERE tvdb_id = ? ORDER BY
-		CASE WHEN entry_type = 'TV' THEN 0 WHEN has_season = 0 THEN 1 ELSE 2 END,
+		CASE WHEN entry_type = 'TV' AND has_season = 0 THEN 0
+			WHEN entry_type = 'TV' THEN 1
+			WHEN has_season = 0 THEN 2
+			ELSE 3 END,
 		kitsu_id ASC`, id)
 }
 

--- a/pkg/core/persistence/anime_mapping_store.go
+++ b/pkg/core/persistence/anime_mapping_store.go
@@ -114,6 +114,20 @@ func (as *AnimeMappingStore) LookupMAL(malID int) (*AnimeMapping, bool) {
 	return as.lookupOne(`WHERE mal_id = ?`, malID)
 }
 
+// LookupTVDB resolves a TVDB series id to the Kitsu entry that owns the
+// playable anime identity. Multiple cours can share one TVDB id; the first
+// entry is the stable series-level choice for a TVDB-originated search result.
+func (as *AnimeMappingStore) LookupTVDB(tvdbID string) (*AnimeMapping, bool) {
+	if as == nil || as.db == nil {
+		return nil, false
+	}
+	id := strings.TrimSpace(tvdbID)
+	if id == "" {
+		return nil, false
+	}
+	return as.lookupOne(`WHERE tvdb_id = ? ORDER BY kitsu_id ASC`, id)
+}
+
 func (as *AnimeMappingStore) lookupOne(where string, arg any) (*AnimeMapping, bool) {
 	var (
 		m         AnimeMapping

--- a/pkg/core/persistence/anime_mapping_store.go
+++ b/pkg/core/persistence/anime_mapping_store.go
@@ -115,8 +115,10 @@ func (as *AnimeMappingStore) LookupMAL(malID int) (*AnimeMapping, bool) {
 }
 
 // LookupTVDB resolves a TVDB series id to the Kitsu entry that owns the
-// playable anime identity. Multiple cours can share one TVDB id; the first
-// entry is the stable series-level choice for a TVDB-originated search result.
+// playable anime identity. Multiple cours can share one TVDB id; prefer the
+// series-level TV entry, then entries with no explicit season, before any
+// season/special row. That prevents an OVA or specials mapping from winning
+// a TVDB-originated discovery result just because it has a smaller Kitsu id.
 func (as *AnimeMappingStore) LookupTVDB(tvdbID string) (*AnimeMapping, bool) {
 	if as == nil || as.db == nil {
 		return nil, false
@@ -125,7 +127,9 @@ func (as *AnimeMappingStore) LookupTVDB(tvdbID string) (*AnimeMapping, bool) {
 	if id == "" {
 		return nil, false
 	}
-	return as.lookupOne(`WHERE tvdb_id = ? ORDER BY kitsu_id ASC`, id)
+	return as.lookupOne(`WHERE tvdb_id = ? ORDER BY
+		CASE WHEN entry_type = 'TV' THEN 0 WHEN has_season = 0 THEN 1 ELSE 2 END,
+		kitsu_id ASC`, id)
 }
 
 func (as *AnimeMappingStore) lookupOne(where string, arg any) (*AnimeMapping, bool) {

--- a/pkg/core/persistence/anime_mapping_store_test.go
+++ b/pkg/core/persistence/anime_mapping_store_test.go
@@ -54,6 +54,9 @@ func TestAnimeMappingStoreReplaceAndLookup(t *testing.T) {
 	if !cour.HasSeason || cour.Season != 3 || cour.EpisodeOffset != 12 {
 		t.Fatalf("season = %d (has=%v) offset = %d", cour.Season, cour.HasSeason, cour.EpisodeOffset)
 	}
+	if byTVDB, ok := store.LookupTVDB("355480"); !ok || byTVDB.KitsuID != 49016 {
+		t.Fatalf("tvdb 355480 = %+v (ok=%v), want Kitsu 49016", byTVDB, ok)
+	}
 
 	// An absent season must not come back looking like season 0, or a
 	// series-spanning entry would be mistaken for specials.

--- a/pkg/core/persistence/anime_mapping_store_test.go
+++ b/pkg/core/persistence/anime_mapping_store_test.go
@@ -57,6 +57,9 @@ func TestAnimeMappingStoreReplaceAndLookup(t *testing.T) {
 	if byTVDB, ok := store.LookupTVDB("355480"); !ok || byTVDB.KitsuID != 49016 {
 		t.Fatalf("tvdb 355480 = %+v (ok=%v), want Kitsu 49016", byTVDB, ok)
 	}
+	if byTVDB, ok := store.LookupTVDB("76703"); !ok || byTVDB.KitsuID != 486 {
+		t.Fatalf("tvdb 76703 = %+v (ok=%v), want series-level Kitsu 486", byTVDB, ok)
+	}
 
 	// An absent season must not come back looking like season 0, or a
 	// series-spanning entry would be mistaken for specials.

--- a/pkg/server/api/config_validation.go
+++ b/pkg/server/api/config_validation.go
@@ -656,6 +656,19 @@ func (s *Server) validateConfigWithPlan(cfg *config.Config, plan configValidatio
 			default:
 				errors[fmt.Sprintf("metadata_profiles.%d.series_source", i)] = "Unknown series source"
 			}
+			switch mp.AnimeSource {
+			case "", "kitsu", "tvdb":
+			default:
+				errors[fmt.Sprintf("metadata_profiles.%d.anime_source", i)] = "Unknown anime primary source"
+			}
+			switch mp.AnimeBackupSource {
+			case "", "kitsu", "tvdb":
+			default:
+				errors[fmt.Sprintf("metadata_profiles.%d.anime_backup_source", i)] = "Unknown anime backup source"
+			}
+			if mp.AnimeSource != "" && mp.AnimeBackupSource != "" && mp.AnimeSource == mp.AnimeBackupSource {
+				errors[fmt.Sprintf("metadata_profiles.%d.anime_backup_source", i)] = "Anime backup must be different from the primary source"
+			}
 			if pattern := strings.TrimSpace(mp.PosterURLPattern); pattern != "" {
 				if !strings.Contains(pattern, "{imdb_id}") {
 					errors[fmt.Sprintf("metadata_profiles.%d.poster_url_pattern", i)] = "Must contain the {imdb_id} placeholder"

--- a/pkg/server/jellyfin/items.go
+++ b/pkg/server/jellyfin/items.go
@@ -34,7 +34,13 @@ const (
 // allCatalogs is every catalog an id may name: the browse registry plus the
 // search carriers.
 func allCatalogs() []stremio.CatalogDef {
-	return append(stremio.CatalogRegistry(), stremio.SearchCatalogs()...)
+	// View ids are decoded before a request's stream/profile is known. Keep
+	// both possible anime search carriers here solely for that reverse lookup;
+	// the profile-aware SearchCatalogs call below decides which one can serve.
+	return append(stremio.CatalogRegistry(),
+		stremio.CatalogDef{ID: "kitsu.search.anime", Type: "anime"},
+		stremio.CatalogDef{ID: "tvdb.search.anime", Type: "anime"},
+	)
 }
 
 func catalogByID(id string) (stremio.CatalogDef, bool) {
@@ -373,7 +379,7 @@ func (s *Server) allItems(rq *request, include []string) []*baseItem {
 
 // search runs the search carriers the filter admits, in parallel.
 func (s *Server) search(rq *request, term string, include []string) []*baseItem {
-	defs := stremio.SearchCatalogs()
+	defs := s.opts.Catalog.SearchCatalogs(rq.stream)
 	var wg sync.WaitGroup
 	rows := make([][]stremio.MetaPreview, len(defs))
 	for i, def := range defs {

--- a/pkg/server/jellyfin/server.go
+++ b/pkg/server/jellyfin/server.go
@@ -57,6 +57,7 @@ type Streams interface {
 // *stremio.Server satisfies it.
 type Catalog interface {
 	EnabledCatalogs(stream *auth.Stream) ([]stremio.CatalogDef, error)
+	SearchCatalogs(stream *auth.Stream) []stremio.CatalogDef
 	Catalog(ctx context.Context, stream *auth.Stream, catalogID, contentType, search string, skip int) ([]stremio.MetaPreview, error)
 	Meta(ctx context.Context, stream *auth.Stream, contentType, id string) (*stremio.MetaObject, error)
 	Playlist(ctx context.Context, stream *auth.Stream, contentType, id string) (*stremio.PlaylistView, error)

--- a/pkg/server/jellyfin/server_test.go
+++ b/pkg/server/jellyfin/server_test.go
@@ -101,6 +101,14 @@ func (f *fakeCatalog) EnabledCatalogs(*auth.Stream) ([]stremio.CatalogDef, error
 	return f.catalogs, nil
 }
 
+func (f *fakeCatalog) SearchCatalogs(*auth.Stream) []stremio.CatalogDef {
+	return []stremio.CatalogDef{
+		{ID: "tmdb.search.movie", Type: "movie", Name: "Search Movies", Provider: "tmdb", Kind: "search", SupportsSearch: true},
+		{ID: "tmdb.search.series", Type: "series", Name: "Search Series", Provider: "tmdb", Kind: "search", SupportsSearch: true},
+		{ID: "kitsu.search.anime", Type: "anime", Name: "Search Anime", Provider: "kitsu", Kind: "search", SupportsSearch: true},
+	}
+}
+
 func (f *fakeCatalog) Catalog(_ context.Context, _ *auth.Stream, catalogID, _, search string, skip int) ([]stremio.MetaPreview, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/pkg/server/stremio/catalog_registry.go
+++ b/pkg/server/stremio/catalog_registry.go
@@ -110,11 +110,26 @@ var catalogRegistry = []CatalogDef{
 var searchCatalogs = []CatalogDef{
 	{ID: "tmdb.search.movie", Type: "movie", Name: "Search Movies", Provider: "tmdb", Kind: "search", SupportsSearch: true},
 	{ID: "tmdb.search.series", Type: "series", Name: "Search Series", Provider: "tmdb", Kind: "search", SupportsSearch: true},
-	{ID: "kitsu.search.anime", Type: "anime", Name: "Search Anime", Provider: "kitsu", Kind: "search", SupportsSearch: true},
 }
 
-func searchCatalogDefByID(id string) (CatalogDef, bool) {
-	for _, def := range searchCatalogs {
+// searchCatalogDefs gives anime exactly one discovery source: the user's
+// primary. Its backup is intentionally not a second result set; it is used
+// only when the primary cannot return a viable match.
+func searchCatalogDefs(profile *config.MetadataProfileConfig) []CatalogDef {
+	defs := make([]CatalogDef, len(searchCatalogs), len(searchCatalogs)+1)
+	copy(defs, searchCatalogs)
+	primary := "kitsu"
+	if profile != nil {
+		primary, _ = profile.EffectiveAnimeMetaSources()
+	}
+	if primary == "tvdb" {
+		return append(defs, CatalogDef{ID: "tvdb.search.anime", Type: "anime", Name: "Search Anime", Provider: "tvdb", Kind: "search", SupportsSearch: true})
+	}
+	return append(defs, CatalogDef{ID: "kitsu.search.anime", Type: "anime", Name: "Search Anime", Provider: "kitsu", Kind: "search", SupportsSearch: true})
+}
+
+func searchCatalogDefByID(profile *config.MetadataProfileConfig, id string) (CatalogDef, bool) {
+	for _, def := range searchCatalogDefs(profile) {
 		if def.ID == id {
 			return def, true
 		}
@@ -252,7 +267,8 @@ func enabledCatalogs(profile *config.MetadataProfileConfig, dropProviders ...str
 		dropped[provider] = true
 	}
 	defs := enabledCatalogDefs(profile)
-	catalogs := make([]Catalog, 0, len(defs)+len(searchCatalogs))
+	searchDefs := searchCatalogDefs(profile)
+	catalogs := make([]Catalog, 0, len(defs)+len(searchDefs))
 	for _, def := range defs {
 		if dropped[def.Provider] {
 			continue
@@ -263,7 +279,7 @@ func enabledCatalogs(profile *config.MetadataProfileConfig, dropProviders ...str
 		}
 		catalogs = append(catalogs, cat)
 	}
-	for _, def := range searchCatalogs {
+	for _, def := range searchDefs {
 		catalogs = append(catalogs, Catalog{
 			Type:  def.Type,
 			ID:    def.ID,

--- a/pkg/server/stremio/facade.go
+++ b/pkg/server/stremio/facade.go
@@ -77,12 +77,11 @@ func (s *Server) EnabledCatalogs(stream *auth.Stream) ([]CatalogDef, error) {
 	return enabledCatalogDefs(profile), nil
 }
 
-// SearchCatalogs lists the hidden search carriers, one per content type. They
-// answer for every profile and only with a query.
-func SearchCatalogs() []CatalogDef {
-	out := make([]CatalogDef, len(searchCatalogs))
-	copy(out, searchCatalogs)
-	return out
+// SearchCatalogs lists the hidden search carriers for a stream's profile.
+// Anime has a single primary carrier, while its configured backup remains a
+// fallback inside that carrier rather than a duplicate result source.
+func (s *Server) SearchCatalogs(stream *auth.Stream) []CatalogDef {
+	return searchCatalogDefs(s.metadataProfileFor(stream))
 }
 
 // Catalog serves one page of a catalog under the same rules as the HTTP

--- a/pkg/server/stremio/handlers_catalog.go
+++ b/pkg/server/stremio/handlers_catalog.go
@@ -627,10 +627,10 @@ func (s *Server) resolveIMDbIDs(mediaType string, results []tmdb.SearchMultiResu
 // hundreds of rows, so board pages slice into the cached first page. tt ids
 // resolve through each row's extended record (bounded fan-out, cached, and
 // reused later by the series meta pages those rows open).
-func (s *Server) tvdbCatalog(_ context.Context, def CatalogDef, req catalogRequest) ([]MetaPreview, error) {
+func (s *Server) tvdbCatalog(ctx context.Context, def CatalogDef, req catalogRequest) ([]MetaPreview, error) {
 	rt := s.runtime()
 	if req.Search != "" {
-		return s.tvdbAnimeSearchCatalog(def, req)
+		return s.tvdbAnimeSearchCatalog(ctx, def, req)
 	}
 	sort := "score"
 	if def.Kind == "new" {
@@ -703,15 +703,15 @@ func (s *Server) tvdbCatalog(_ context.Context, def CatalogDef, req catalogReque
 // to a playable Kitsu entry; unrelated shows and Kitsu's broad fuzzy matches
 // never leak into the result grid. If TVDB has no usable row, Kitsu is the
 // explicit backup.
-func (s *Server) tvdbAnimeSearchCatalog(def CatalogDef, req catalogRequest) ([]MetaPreview, error) {
+func (s *Server) tvdbAnimeSearchCatalog(ctx context.Context, def CatalogDef, req catalogRequest) ([]MetaPreview, error) {
 	rt := s.runtime()
 	if rt.tvdbClient == nil {
-		return s.kitsuCatalog(context.Background(), CatalogDef{ID: "kitsu.search.anime", Type: "anime", Provider: "kitsu", Kind: "search"}, req)
+		return s.kitsuCatalog(ctx, CatalogDef{ID: "kitsu.search.anime", Type: "anime", Provider: "kitsu", Kind: "search"}, req)
 	}
 	results, err := rt.tvdbClient.SearchSeries(req.Search)
 	if err != nil {
 		logger.Debug("TVDB anime search failed; trying Kitsu backup", "search", req.Search, "err", err)
-		return s.kitsuCatalog(context.Background(), CatalogDef{ID: "kitsu.search.anime", Type: "anime", Provider: "kitsu", Kind: "search"}, req)
+		return s.kitsuCatalog(ctx, CatalogDef{ID: "kitsu.search.anime", Type: "anime", Provider: "kitsu", Kind: "search"}, req)
 	}
 	previews := make([]MetaPreview, 0, len(results))
 	seen := map[string]bool{}
@@ -734,9 +734,12 @@ func (s *Server) tvdbAnimeSearchCatalog(def CatalogDef, req catalogRequest) ([]M
 		}
 	}
 	if len(previews) > 0 {
+		if cap, capped := capForProfile(req.Profile); capped {
+			previews = s.filterPreviewsByCertification(ctx, cap, previews, def.Type)
+		}
 		return previews, nil
 	}
-	return s.kitsuCatalog(context.Background(), CatalogDef{ID: "kitsu.search.anime", Type: "anime", Provider: "kitsu", Kind: "search"}, req)
+	return s.kitsuCatalog(ctx, CatalogDef{ID: "kitsu.search.anime", Type: "anime", Provider: "kitsu", Kind: "search"}, req)
 }
 
 func (s *Server) kitsuCatalog(ctx context.Context, def CatalogDef, req catalogRequest) ([]MetaPreview, error) {

--- a/pkg/server/stremio/handlers_catalog.go
+++ b/pkg/server/stremio/handlers_catalog.go
@@ -273,7 +273,7 @@ func parseCatalogPath(path string) (catalogRequest, bool) {
 // a bare listing request is a client ignoring the manifest. Browse catalogs
 // must be enabled on the profile, and only take a query when they support one.
 func resolveCatalogDef(profile *config.MetadataProfileConfig, req catalogRequest) (CatalogDef, bool) {
-	if def, ok := searchCatalogDefByID(req.ID); ok {
+	if def, ok := searchCatalogDefByID(profile, req.ID); ok {
 		return def, def.Type == req.Type && req.Search != ""
 	}
 	for _, d := range enabledCatalogDefs(profile) {
@@ -629,6 +629,9 @@ func (s *Server) resolveIMDbIDs(mediaType string, results []tmdb.SearchMultiResu
 // reused later by the series meta pages those rows open).
 func (s *Server) tvdbCatalog(_ context.Context, def CatalogDef, req catalogRequest) ([]MetaPreview, error) {
 	rt := s.runtime()
+	if req.Search != "" {
+		return s.tvdbAnimeSearchCatalog(def, req)
+	}
 	sort := "score"
 	if def.Kind == "new" {
 		sort = "firstAired"
@@ -693,6 +696,47 @@ func (s *Server) tvdbCatalog(_ context.Context, def CatalogDef, req catalogReque
 		previews = append(previews, preview)
 	}
 	return previews, nil
+}
+
+// tvdbAnimeSearchCatalog keeps the search contract aligned with metadata
+// priority. A TVDB result is accepted only when anime-lists can translate it
+// to a playable Kitsu entry; unrelated shows and Kitsu's broad fuzzy matches
+// never leak into the result grid. If TVDB has no usable row, Kitsu is the
+// explicit backup.
+func (s *Server) tvdbAnimeSearchCatalog(def CatalogDef, req catalogRequest) ([]MetaPreview, error) {
+	rt := s.runtime()
+	if rt.tvdbClient == nil {
+		return s.kitsuCatalog(context.Background(), CatalogDef{ID: "kitsu.search.anime", Type: "anime", Provider: "kitsu", Kind: "search"}, req)
+	}
+	results, err := rt.tvdbClient.SearchSeries(req.Search)
+	if err != nil {
+		logger.Debug("TVDB anime search failed; trying Kitsu backup", "search", req.Search, "err", err)
+		return s.kitsuCatalog(context.Background(), CatalogDef{ID: "kitsu.search.anime", Type: "anime", Provider: "kitsu", Kind: "search"}, req)
+	}
+	previews := make([]MetaPreview, 0, len(results))
+	seen := map[string]bool{}
+	for _, result := range results {
+		if s.animeLists == nil {
+			break
+		}
+		mapping, ok := s.animeLists.LookupTVDB(result.SeriesID())
+		if !ok || mapping.KitsuID <= 0 || result.Title() == "" {
+			continue
+		}
+		id := fmt.Sprintf("kitsu:%d", mapping.KitsuID)
+		if seen[id] {
+			continue
+		}
+		seen[id] = true
+		previews = append(previews, MetaPreview{ID: id, Type: "anime", Name: result.Title(), Poster: result.ImageURL})
+		if len(previews) >= catalogPageSize {
+			break
+		}
+	}
+	if len(previews) > 0 {
+		return previews, nil
+	}
+	return s.kitsuCatalog(context.Background(), CatalogDef{ID: "kitsu.search.anime", Type: "anime", Provider: "kitsu", Kind: "search"}, req)
 }
 
 func (s *Server) kitsuCatalog(ctx context.Context, def CatalogDef, req catalogRequest) ([]MetaPreview, error) {

--- a/pkg/server/stremio/handlers_meta.go
+++ b/pkg/server/stremio/handlers_meta.go
@@ -377,6 +377,13 @@ func (s *Server) resolveTVDBIDForMeta(rid *resolvedMetaID) string {
 }
 
 func (s *Server) buildSeriesMetaFromTVDB(ctx context.Context, profile *config.MetadataProfileConfig, contentType string, rid *resolvedMetaID) (*MetaObject, error) {
+	return s.buildSeriesMetaFromTVDBWithVideos(ctx, profile, contentType, rid, true)
+}
+
+// buildSeriesMetaFromTVDBWithVideos fetches the common TVDB record and, for
+// ordinary series, its episode list. Anime keeps Kitsu episode identities, so
+// its TVDB metadata path deliberately skips TVDB/TVMaze episode work.
+func (s *Server) buildSeriesMetaFromTVDBWithVideos(ctx context.Context, profile *config.MetadataProfileConfig, contentType string, rid *resolvedMetaID, includeVideos bool) (*MetaObject, error) {
 	rt := s.runtime()
 	tvdbID := s.resolveTVDBIDForMeta(rid)
 	if tvdbID == "" {
@@ -439,6 +446,9 @@ func (s *Server) buildSeriesMetaFromTVDB(ctx context.Context, profile *config.Me
 				break
 			}
 		}
+	}
+	if !includeVideos {
+		return meta, nil
 	}
 
 	episodes, err := rt.tvdbClient.GetSeriesEpisodesTranslated(tvdbID, lang3)
@@ -718,16 +728,13 @@ func (s *Server) buildAnimeMetaFromTVDB(ctx context.Context, profile *config.Met
 	if tvdbRID.imdbID == "" {
 		tvdbRID.imdbID = mapping.IMDbID
 	}
-	// The TVDB builder uses this when creating videos; it is reset below and
-	// never exposed to clients, keeping the Kitsu request canonical.
 	tvdbRID.canonicalID = rid.canonicalID
-	meta, err := s.buildSeriesMetaFromTVDB(ctx, profile, contentType, &tvdbRID)
+	meta, err := s.buildSeriesMetaFromTVDBWithVideos(ctx, profile, contentType, &tvdbRID, false)
 	if err != nil {
 		return nil, err
 	}
 	meta.ID = rid.canonicalID
 	meta.Type = seriesMetaType(contentType)
-	meta.Videos = nil
 	if contentType != "movie" {
 		s.appendKitsuAnimeVideos(ctx, meta, rid.kitsuID)
 	}

--- a/pkg/server/stremio/handlers_meta.go
+++ b/pkg/server/stremio/handlers_meta.go
@@ -674,6 +674,56 @@ func (s *Server) applyAnimeArtwork(meta *MetaObject, profile *config.MetadataPro
 }
 
 func (s *Server) buildAnimeMeta(ctx context.Context, profile *config.MetadataProfileConfig, contentType string, rid *resolvedMetaID) (*MetaObject, error) {
+	primary, backup := profile.EffectiveAnimeMetaSources()
+	build := func(source string) (*MetaObject, error) {
+		switch source {
+		case "tvdb":
+			return s.buildAnimeMetaFromTVDB(ctx, profile, contentType, rid)
+		default:
+			return s.buildAnimeMetaFromKitsu(ctx, profile, contentType, rid)
+		}
+	}
+	meta, err := build(primary)
+	if err == nil {
+		return meta, nil
+	}
+	logger.Debug("Primary anime meta source unavailable; falling back",
+		"source", primary, "backup", backup, "kitsu_id", rid.kitsuID, "err", err)
+	return build(backup)
+}
+
+// buildAnimeMetaFromTVDB uses the anime-lists crosswalk to fetch a complete
+// TVDB record while retaining Kitsu as the public/playback identity. TVDB's
+// season rows cannot safely replace entry-local Kitsu episode ids, so videos
+// are rebuilt from Kitsu after the selected provider supplies show metadata.
+func (s *Server) buildAnimeMetaFromTVDB(ctx context.Context, profile *config.MetadataProfileConfig, contentType string, rid *resolvedMetaID) (*MetaObject, error) {
+	if s.animeLists == nil {
+		return nil, fmt.Errorf("anime id mapping unavailable")
+	}
+	mapping, ok := s.animeLists.LookupKitsu(rid.kitsuID)
+	if !ok || mapping.TVDBID == "" {
+		return nil, fmt.Errorf("no TVDB id mapped for kitsu:%s", rid.kitsuID)
+	}
+	tvdbRID := *rid
+	tvdbRID.tvdbID = mapping.TVDBID
+	if tvdbRID.imdbID == "" {
+		tvdbRID.imdbID = mapping.IMDbID
+	}
+	// The TVDB builder uses this when creating videos; it is reset below and
+	// never exposed to clients, keeping the Kitsu request canonical.
+	tvdbRID.canonicalID = rid.canonicalID
+	meta, err := s.buildSeriesMetaFromTVDB(ctx, profile, contentType, &tvdbRID)
+	if err != nil {
+		return nil, err
+	}
+	meta.ID = rid.canonicalID
+	meta.Type = seriesMetaType(contentType)
+	meta.Videos = nil
+	s.appendKitsuAnimeVideos(ctx, meta, rid.kitsuID)
+	return meta, nil
+}
+
+func (s *Server) buildAnimeMetaFromKitsu(ctx context.Context, profile *config.MetadataProfileConfig, contentType string, rid *resolvedMetaID) (*MetaObject, error) {
 	animeMeta, err := s.kitsuClient.GetAnimeMeta(ctx, rid.kitsuID)
 	if err != nil {
 		return nil, err
@@ -701,39 +751,34 @@ func (s *Server) buildAnimeMeta(ctx context.Context, profile *config.MetadataPro
 	if rating, err := strconv.ParseFloat(animeMeta.AverageRating, 64); err == nil && rating > 0 {
 		meta.IMDBRating = fmt.Sprintf("%.1f", rating/10)
 	}
-	s.applyAnimeArtwork(meta, profile, rid.kitsuID)
-
 	// Movies get no episode list; everything else does. Kitsu numbering is
 	// entry-relative, which is exactly what kitsu:<id>:<ep> stream ids carry.
 	if contentType != "movie" && !strings.EqualFold(animeMeta.ShowType, "movie") {
-		episodes, err := s.kitsuClient.GetAnimeEpisodes(ctx, rid.kitsuID)
-		if err != nil {
-			logger.Debug("Kitsu episodes fetch failed; serving meta without videos",
-				"kitsu_id", rid.kitsuID, "err", err)
-		}
-		for _, ep := range episodes {
-			if ep.Number <= 0 {
-				continue
-			}
-			title := ep.CanonicalTitle
-			if title == "" {
-				title = fmt.Sprintf("Episode %d", ep.Number)
-			}
-			video := MetaVideo{
-				ID:        fmt.Sprintf("kitsu:%s:%d", rid.kitsuID, ep.Number),
-				Title:     title,
-				Season:    1,
-				Episode:   ep.Number,
-				Overview:  ep.Synopsis,
-				Thumbnail: ep.Thumbnail,
-			}
-			if ep.Airdate != "" {
-				video.Released = ep.Airdate + "T00:00:00.000Z"
-			}
-			meta.Videos = append(meta.Videos, video)
-		}
+		s.appendKitsuAnimeVideos(ctx, meta, rid.kitsuID)
 	}
 	return meta, nil
+}
+
+func (s *Server) appendKitsuAnimeVideos(ctx context.Context, meta *MetaObject, kitsuID string) {
+	episodes, err := s.kitsuClient.GetAnimeEpisodes(ctx, kitsuID)
+	if err != nil {
+		logger.Debug("Kitsu episodes fetch failed; serving meta without videos", "kitsu_id", kitsuID, "err", err)
+		return
+	}
+	for _, ep := range episodes {
+		if ep.Number <= 0 {
+			continue
+		}
+		title := ep.CanonicalTitle
+		if title == "" {
+			title = fmt.Sprintf("Episode %d", ep.Number)
+		}
+		video := MetaVideo{ID: fmt.Sprintf("kitsu:%s:%d", kitsuID, ep.Number), Title: title, Season: 1, Episode: ep.Number, Overview: ep.Synopsis, Thumbnail: ep.Thumbnail}
+		if ep.Airdate != "" {
+			video.Released = ep.Airdate + "T00:00:00.000Z"
+		}
+		meta.Videos = append(meta.Videos, video)
+	}
 }
 
 // applyTVMazeOverlay makes TVMaze the air-date authority: its airstamp carries

--- a/pkg/server/stremio/handlers_meta.go
+++ b/pkg/server/stremio/handlers_meta.go
@@ -728,7 +728,9 @@ func (s *Server) buildAnimeMetaFromTVDB(ctx context.Context, profile *config.Met
 	meta.ID = rid.canonicalID
 	meta.Type = seriesMetaType(contentType)
 	meta.Videos = nil
-	s.appendKitsuAnimeVideos(ctx, meta, rid.kitsuID)
+	if contentType != "movie" {
+		s.appendKitsuAnimeVideos(ctx, meta, rid.kitsuID)
+	}
 	return meta, nil
 }
 

--- a/pkg/server/stremio/handlers_meta.go
+++ b/pkg/server/stremio/handlers_meta.go
@@ -2,6 +2,7 @@ package stremio
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -685,11 +686,19 @@ func (s *Server) buildAnimeMeta(ctx context.Context, profile *config.MetadataPro
 	}
 	meta, err := build(primary)
 	if err == nil {
+		s.applyAnimeArtwork(meta, profile, rid.kitsuID)
 		return meta, nil
+	}
+	if errors.Is(err, errCertificationBlocked) {
+		return nil, err
 	}
 	logger.Debug("Primary anime meta source unavailable; falling back",
 		"source", primary, "backup", backup, "kitsu_id", rid.kitsuID, "err", err)
-	return build(backup)
+	meta, err = build(backup)
+	if err == nil {
+		s.applyAnimeArtwork(meta, profile, rid.kitsuID)
+	}
+	return meta, err
 }
 
 // buildAnimeMetaFromTVDB uses the anime-lists crosswalk to fetch a complete

--- a/pkg/server/stremio/manifest_test.go
+++ b/pkg/server/stremio/manifest_test.go
@@ -152,10 +152,10 @@ func TestEnabledCatalogDefsRespectstogglesAndOrder(t *testing.T) {
 func TestExternalCatalogSourceLabelsStayHumanFacing(t *testing.T) {
 	profile := &config.MetadataProfileConfig{ExternalCatalogs: []config.ExternalCatalogConfig{
 		{ID: "external.letterboxd", Name: "Essentials", Kind: "letterboxd", ManifestURL: "https://letterboxd.com/example/list/essentials/", RemoteType: "movie", RemoteID: "example/essentials"},
-		{ID: "external.manifest", Name: "Front Row", Kind: "manifest", SourceLabel: "Marquee", ManifestURL: "https://example.com/manifest.json", RemoteType: "movie", RemoteID: "front-row"},
+		{ID: "external.manifest", Name: "Front Row", Kind: "manifest", SourceLabel: "Custom source", ManifestURL: "https://example.com/manifest.json", RemoteType: "movie", RemoteID: "front-row"},
 	}}
 	defs := externalCatalogDefs(profile)
-	if len(defs) != 2 || defs[0].SourceLabel != "Letterboxd" || defs[1].SourceLabel != "Marquee" {
+	if len(defs) != 2 || defs[0].SourceLabel != "Letterboxd" || defs[1].SourceLabel != "Custom source" {
 		t.Fatalf("source labels = %#v", defs)
 	}
 }

--- a/pkg/server/stremio/manifest_test.go
+++ b/pkg/server/stremio/manifest_test.go
@@ -149,6 +149,17 @@ func TestEnabledCatalogDefsRespectstogglesAndOrder(t *testing.T) {
 	}
 }
 
+func TestExternalCatalogSourceLabelsStayHumanFacing(t *testing.T) {
+	profile := &config.MetadataProfileConfig{ExternalCatalogs: []config.ExternalCatalogConfig{
+		{ID: "external.letterboxd", Name: "Essentials", Kind: "letterboxd", ManifestURL: "https://letterboxd.com/example/list/essentials/", RemoteType: "movie", RemoteID: "example/essentials"},
+		{ID: "external.manifest", Name: "Front Row", Kind: "manifest", SourceLabel: "Marquee", ManifestURL: "https://example.com/manifest.json", RemoteType: "movie", RemoteID: "front-row"},
+	}}
+	defs := externalCatalogDefs(profile)
+	if len(defs) != 2 || defs[0].SourceLabel != "Letterboxd" || defs[1].SourceLabel != "Marquee" {
+		t.Fatalf("source labels = %#v", defs)
+	}
+}
+
 // TestDefaultCatalogsAreOneFlagshipPerType pins the suppressed default set: a
 // fresh install gets exactly one trending row per media type; everything else
 // is opt-in from the Metadata page. Search does not ride these — it rides the

--- a/pkg/services/metadata/animelists/animelists.go
+++ b/pkg/services/metadata/animelists/animelists.go
@@ -318,6 +318,20 @@ func (s *Store) LookupMAL(malID string) (*Mapping, bool) {
 	return mappingFromRow(row), true
 }
 
+// LookupTVDB resolves a TVDB series id to its canonical Kitsu entry. It lets
+// TVDB drive discovery and metadata without losing Kitsu's episode-local
+// playback ids.
+func (s *Store) LookupTVDB(tvdbID string) (*Mapping, bool) {
+	if s == nil || s.mappings == nil {
+		return nil, false
+	}
+	row, ok := s.mappings.LookupTVDB(tvdbID)
+	if !ok {
+		return nil, false
+	}
+	return mappingFromRow(row), true
+}
+
 func mappingFromRow(row *persistence.AnimeMapping) *Mapping {
 	return &Mapping{
 		KitsuID:       row.KitsuID,

--- a/pkg/services/metadata/tvdb/client.go
+++ b/pkg/services/metadata/tvdb/client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"strconv"
 	"streamnzb/pkg/core/logger"
@@ -167,6 +168,42 @@ type searchRemoteIDResponse struct {
 			ID int `json:"id"`
 		} `json:"series"`
 	} `json:"data"`
+}
+
+// SearchResult is the series-shaped portion of TVDB's unified search
+// response. The API has changed field casing over time, so decoding keeps the
+// documented tvdb_id alongside the older id/objectID alternatives.
+type SearchResult struct {
+	TVDBID         string `json:"tvdb_id"`
+	ID             string `json:"id"`
+	ObjectID       string `json:"objectID"`
+	Name           string `json:"name"`
+	NameTranslated string `json:"name_translated"`
+	ImageURL       string `json:"image_url"`
+}
+
+type searchResponse struct {
+	Status string         `json:"status"`
+	Data   []SearchResult `json:"data"`
+}
+
+// SeriesID returns the numeric TVDB id regardless of which response spelling
+// the upstream currently uses ("123", "series-123", or tvdb_id).
+func (r SearchResult) SeriesID() string {
+	for _, raw := range []string{r.TVDBID, r.ID, r.ObjectID} {
+		id := strings.TrimPrefix(strings.TrimSpace(raw), "series-")
+		if _, err := strconv.Atoi(id); err == nil && id != "" {
+			return id
+		}
+	}
+	return ""
+}
+
+func (r SearchResult) Title() string {
+	if title := strings.TrimSpace(r.NameTranslated); title != "" {
+		return title
+	}
+	return strings.TrimSpace(r.Name)
 }
 
 type tokenState struct {
@@ -365,6 +402,32 @@ func (c *Client) ResolveTVDBID(remoteID string) (string, error) {
 		}
 	}
 	return "", fmt.Errorf("no TVDB series ID found for remote ID: %s", remoteID)
+}
+
+// SearchSeries returns TVDB's own series results for a title. Keeping this in
+// the TVDB client is important: callers must not substitute a broad Kitsu
+// search when TVDB is the user-selected primary source.
+func (c *Client) SearchSeries(query string) ([]SearchResult, error) {
+	if c == nil || c.apiKey == "" {
+		return nil, fmt.Errorf("TVDB API key not configured")
+	}
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return nil, nil
+	}
+	path := "/search?query=" + url.QueryEscape(query) + "&type=series&limit=20"
+	body, err := c.getBodyCached(path, listingCacheTTL)
+	if err != nil {
+		return nil, err
+	}
+	var out searchResponse
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, fmt.Errorf("failed to decode TVDB series search: %w", err)
+	}
+	if out.Status != successVal {
+		return nil, fmt.Errorf("TVDB series search failed: status=%s", out.Status)
+	}
+	return out.Data, nil
 }
 
 // episodesCacheTTL bounds the episode-list cache: air dates and late episode

--- a/pkg/services/metadata/tvdb/client_test.go
+++ b/pkg/services/metadata/tvdb/client_test.go
@@ -322,6 +322,27 @@ func TestResolveTVDBIDPicksSeriesOverMovie(t *testing.T) {
 	}
 }
 
+func TestSearchSeriesUsesSeriesEndpointAndNormalizesIDs(t *testing.T) {
+	client := newStubClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/search" || r.URL.Query().Get("query") != "Solo Leveling" || r.URL.Query().Get("type") != "series" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte(`{"status":"success","data":[
+			{"objectID":"series-447898","name":"Solo Leveling","image_url":"https://art.test/solo.jpg"},
+			{"tvdb_id":"451793","name_translated":"Solo Leveling: Arise"}
+		]}`))
+	})
+
+	results, err := client.SearchSeries("Solo Leveling")
+	if err != nil {
+		t.Fatalf("SearchSeries: %v", err)
+	}
+	if len(results) != 2 || results[0].SeriesID() != "447898" || results[0].Title() != "Solo Leveling" || results[1].SeriesID() != "451793" || results[1].Title() != "Solo Leveling: Arise" {
+		t.Fatalf("results = %+v", results)
+	}
+}
+
 // A key TVDB will not accept comes back as a bare 401. The message is what the
 // settings UI shows, so it has to say what to do about it.
 func TestLoginRejectedKeyExplains401(t *testing.T) {


### PR DESCRIPTION
## Scope\nLets the user choose the anime metadata primary and backup source (TVDB or Kitsu).\n\n- Only the selected primary supplies anime discovery results\n- The backup is used solely when the primary cannot provide metadata\n- Retains Kitsu playback IDs so source changes do not break episode/stream matching\n- Adds TVDB anime discovery filtered through known anime mappings\n\n## Validation\n- `go test ./pkg/services/metadata/animelists ./pkg/services/metadata/tvdb ./pkg/server/stremio ./pkg/server/jellyfin` passes\n- Tested on the isolated Jellyfin test deployment\n\nDepends on #2 in this review chain.