### PR TITLE
fix(catalogs): warn when a library is served empty

### DIFF
--- a/cmd/streamnzb/main.go
+++ b/cmd/streamnzb/main.go
@@ -124,6 +124,9 @@ func main() {
 	userSimklID := firstNonEmpty(os.Getenv(env.SimklClientID), strings.TrimSpace(cfg.SimklClientID))
 	effectiveTMDBKey := firstNonEmpty(userTMDBKey, TMDBKey)
 	effectiveTVDBKey := firstNonEmpty(userTVDBKey, TVDBKey)
+	if effectiveTMDBKey == "" && cfg.EffectiveMetadataEnabled() {
+		logger.Warn("TMDB Read Access Token missing: TMDB catalogs and movie metadata will be empty until one is set")
+	}
 	env.SetRuntimeHeaders(cfg.IndexerQueryHeader, cfg.IndexerGrabHeader, cfg.ProviderHeader)
 
 	dataDir := filepath.Dir(cfg.LoadedPath)

--- a/cmd/streamnzb/main.go
+++ b/cmd/streamnzb/main.go
@@ -122,7 +122,7 @@ func main() {
 	userTMDBKey := firstNonEmpty(os.Getenv(env.TMDBAPIKey), strings.TrimSpace(cfg.TMDBAPIKey))
 	userTVDBKey := firstNonEmpty(os.Getenv(env.TVDBAPIKey), strings.TrimSpace(cfg.TVDBAPIKey))
 	userSimklID := firstNonEmpty(os.Getenv(env.SimklClientID), strings.TrimSpace(cfg.SimklClientID))
-	effectiveTMDBKey := firstNonEmpty(userTMDBKey, TMDBKey)
+	effectiveTMDBKey := firstNonEmpty(strings.TrimSpace(userTMDBKey), strings.TrimSpace(TMDBKey))
 	effectiveTVDBKey := firstNonEmpty(userTVDBKey, TVDBKey)
 	if effectiveTMDBKey == "" && cfg.EffectiveMetadataEnabled() {
 		logger.Warn("TMDB Read Access Token missing: TMDB catalogs and movie metadata will be empty until one is set")

--- a/pkg/core/logger/throttle.go
+++ b/pkg/core/logger/throttle.go
@@ -5,7 +5,18 @@ import (
 	"time"
 )
 
-var throttleSeen sync.Map // key → time.Time of the last permitted log
+var (
+	throttleMu   sync.Mutex
+	throttleSeen = map[string]time.Time{} // key → time of the last permitted log
+)
+
+// throttleMaxKeys bounds throttleSeen. Keys are never evicted individually —
+// every distinct id a catalog rejects mints one — so without a bound a
+// long-running process serving many different bad ids would grow the map
+// forever. Past the bound the whole table is cleared: the next call for any
+// key just passes again, which is the same behavior as a key seen for the
+// first time.
+const throttleMaxKeys = 10000
 
 // Throttle reports whether a log line keyed by key may be written now: the
 // first call for a key always passes, later calls pass once every interval.
@@ -13,13 +24,14 @@ var throttleSeen sync.Map // key → time.Time of the last permitted log
 // on every request while still surfacing it.
 func Throttle(key string, every time.Duration) bool {
 	now := time.Now()
-	last, loaded := throttleSeen.LoadOrStore(key, now)
-	if !loaded {
-		return true
-	}
-	if now.Sub(last.(time.Time)) < every {
+	throttleMu.Lock()
+	defer throttleMu.Unlock()
+	if last, ok := throttleSeen[key]; ok && now.Sub(last) < every {
 		return false
 	}
-	throttleSeen.Store(key, now)
+	if len(throttleSeen) >= throttleMaxKeys {
+		clear(throttleSeen)
+	}
+	throttleSeen[key] = now
 	return true
 }

--- a/pkg/core/logger/throttle.go
+++ b/pkg/core/logger/throttle.go
@@ -1,0 +1,25 @@
+package logger
+
+import (
+	"sync"
+	"time"
+)
+
+var throttleSeen sync.Map // key → time.Time of the last permitted log
+
+// Throttle reports whether a log line keyed by key may be written now: the
+// first call for a key always passes, later calls pass once every interval.
+// It keeps a dead provider or a stale profile from repeating the same warning
+// on every request while still surfacing it.
+func Throttle(key string, every time.Duration) bool {
+	now := time.Now()
+	last, loaded := throttleSeen.LoadOrStore(key, now)
+	if !loaded {
+		return true
+	}
+	if now.Sub(last.(time.Time)) < every {
+		return false
+	}
+	throttleSeen.Store(key, now)
+	return true
+}

--- a/pkg/core/logger/throttle_test.go
+++ b/pkg/core/logger/throttle_test.go
@@ -1,6 +1,7 @@
 package logger
 
 import (
+	"fmt"
 	"testing"
 	"time"
 )
@@ -13,11 +14,31 @@ func TestThrottleFirstPassesThenHolds(t *testing.T) {
 	if Throttle(key, time.Hour) {
 		t.Fatal("second call inside the interval must be held")
 	}
-	throttleSeen.Store(key, time.Now().Add(-2*time.Hour))
+	throttleMu.Lock()
+	throttleSeen[key] = time.Now().Add(-2 * time.Hour)
+	throttleMu.Unlock()
 	if !Throttle(key, time.Hour) {
 		t.Fatal("call after the interval must pass")
 	}
 	if Throttle("other-"+key, time.Hour) != true {
 		t.Fatal("a different key is independent")
+	}
+}
+
+// Past the bound, the whole table clears rather than growing forever: a
+// long-running process serving many distinct rejected ids must not leak
+// memory one key at a time with no eviction.
+func TestThrottleClearsPastKeyBound(t *testing.T) {
+	throttleMu.Lock()
+	clear(throttleSeen)
+	throttleMu.Unlock()
+	for i := 0; i < throttleMaxKeys+10; i++ {
+		Throttle(fmt.Sprintf("bound-test-%d", i), time.Hour)
+	}
+	throttleMu.Lock()
+	n := len(throttleSeen)
+	throttleMu.Unlock()
+	if n >= throttleMaxKeys {
+		t.Fatalf("throttleSeen has %d entries, want it cleared well before %d", n, throttleMaxKeys)
 	}
 }

--- a/pkg/core/logger/throttle_test.go
+++ b/pkg/core/logger/throttle_test.go
@@ -1,0 +1,23 @@
+package logger
+
+import (
+	"testing"
+	"time"
+)
+
+func TestThrottleFirstPassesThenHolds(t *testing.T) {
+	key := "throttle-test-" + t.Name()
+	if !Throttle(key, time.Hour) {
+		t.Fatal("first call must pass")
+	}
+	if Throttle(key, time.Hour) {
+		t.Fatal("second call inside the interval must be held")
+	}
+	throttleSeen.Store(key, time.Now().Add(-2*time.Hour))
+	if !Throttle(key, time.Hour) {
+		t.Fatal("call after the interval must pass")
+	}
+	if Throttle("other-"+key, time.Hour) != true {
+		t.Fatal("a different key is independent")
+	}
+}

--- a/pkg/server/jellyfin/dto.go
+++ b/pkg/server/jellyfin/dto.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"streamnzb/pkg/core/logger"
 	"streamnzb/pkg/core/persistence"
 	"streamnzb/pkg/server/stremio"
 )
@@ -296,6 +297,12 @@ func (s *Server) viewItem(def stremio.CatalogDef) *baseItem {
 func (s *Server) previewItem(preview stremio.MetaPreview, parentID string) (*baseItem, bool) {
 	id, err := itemIDFor(preview.Type, preview.ID)
 	if err != nil {
+		// The row is dropped from the grid; say why once per id so a
+		// catalog that thins out is not mistaken for a provider miss.
+		if logger.Throttle("jellyfin-row-dropped:"+preview.Type+":"+preview.ID, time.Hour) {
+			logger.Debug("Jellyfin row dropped: id not representable",
+				"type", preview.Type, "id", preview.ID, "err", err)
+		}
 		return nil, false
 	}
 	item := s.newItem(id, preview.Name)

--- a/pkg/server/jellyfin/items.go
+++ b/pkg/server/jellyfin/items.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"streamnzb/pkg/core/logger"
 	"streamnzb/pkg/core/persistence"
@@ -327,6 +328,11 @@ func (s *Server) allItems(rq *request, include []string) []*baseItem {
 			defer wg.Done()
 			metas, err := s.opts.Catalog.Catalog(rq.Context(), rq.stream, def.ID, def.Type, "", 0)
 			if err != nil {
+				if !errors.Is(err, stremio.ErrMetadataDisabled) &&
+					logger.Throttle("jellyfin-all-items:"+def.ID, 5*time.Minute) {
+					logger.Warn("Jellyfin catalog failed; library omitted from listing",
+						"catalog", def.ID, "stream", rq.streamName(), "err", err)
+				}
 				return
 			}
 			mu.Lock()
@@ -365,7 +371,7 @@ func (s *Server) search(rq *request, term string, include []string) []*baseItem 
 			defer wg.Done()
 			metas, err := s.opts.Catalog.Catalog(rq.Context(), rq.stream, def.ID, def.Type, term, 0)
 			if err != nil && !errors.Is(err, stremio.ErrMetadataDisabled) {
-				logger.Debug("Jellyfin search failed", "catalog", def.ID, "err", err)
+				logger.Debug("Jellyfin search failed", "catalog", def.ID, "stream", rq.streamName(), "err", err)
 			}
 			rows[i] = metas
 		}(i, def)
@@ -430,8 +436,17 @@ func (s *Server) handleLatest(w http.ResponseWriter, rq *request) {
 	include := rq.listParam("includeItemTypes")
 	items := []*baseItem{}
 	if parent := rq.param("parentId"); parent != "" {
-		if id, err := decodeItemID(parent); err == nil && id.Kind == kindView {
-			if def, ok := catalogByID(id.CatalogID); ok && wantsType(include, def.Type) {
+		id, err := decodeItemID(parent)
+		switch {
+		case err != nil || id.Kind != kindView:
+			logger.Debug("Jellyfin latest: parent is not a library; serving empty",
+				"parent", parent, "stream", rq.streamName(), "err", err)
+		default:
+			def, ok := catalogByID(id.CatalogID)
+			if !ok {
+				logger.Debug("Jellyfin latest: unknown catalog; serving empty",
+					"catalog", id.CatalogID, "stream", rq.streamName())
+			} else if wantsType(include, def.Type) {
 				items = s.catalogPage(rq, def, 0, limit).Items
 			}
 		}

--- a/pkg/server/stremio/catalog_registry.go
+++ b/pkg/server/stremio/catalog_registry.go
@@ -1,6 +1,11 @@
 package stremio
 
-import "streamnzb/pkg/core/config"
+import (
+	"time"
+
+	"streamnzb/pkg/core/config"
+	"streamnzb/pkg/core/logger"
+)
 
 // CatalogDef is one catalog the addon can serve. The registry is the single
 // source of truth for which catalogs exist: the manifest, the catalog handler,
@@ -166,10 +171,19 @@ func enabledCatalogDefs(profile *config.MetadataProfileConfig) []CatalogDef {
 		if !t.Enabled || seen[t.ID] {
 			continue
 		}
-		if def, ok := catalogDefByID(t.ID); ok {
-			seen[t.ID] = true
-			defs = append(defs, def)
+		def, ok := catalogDefByID(t.ID)
+		if !ok {
+			// A saved toggle the registry no longer knows (removed catalog,
+			// or one from a build this binary is not) is skipped silently
+			// by design; say so once so the missing library is explainable.
+			if logger.Throttle("unknown-catalog-toggle:"+t.ID, 24*time.Hour) {
+				logger.Warn("Metadata profile references an unknown catalog id; ignored",
+					"profile", profile.Name, "catalog", t.ID)
+			}
+			continue
 		}
+		seen[t.ID] = true
+		defs = append(defs, def)
 	}
 	return defs
 }

--- a/pkg/server/stremio/handlers_catalog.go
+++ b/pkg/server/stremio/handlers_catalog.go
@@ -151,8 +151,15 @@ func resolveCatalogDef(profile *config.MetadataProfileConfig, req catalogRequest
 func (s *Server) serveCatalog(ctx context.Context, def CatalogDef, req catalogRequest) []MetaPreview {
 	metas, err := s.buildCatalog(ctx, def, req)
 	if err != nil {
-		logger.Debug("Catalog build failed; serving empty page",
-			"catalog", def.ID, "search", req.Search, "skip", req.Skip, "err", err)
+		// Warn, throttled per catalog: a library that renders empty with
+		// nothing above DEBUG in the log is indistinguishable from "no rows".
+		if logger.Throttle("catalog-build-failed:"+def.ID, 5*time.Minute) {
+			logger.Warn("Catalog build failed; serving empty page",
+				"catalog", def.ID, "provider", def.Provider, "search", req.Search, "skip", req.Skip, "err", err)
+		} else {
+			logger.Debug("Catalog build failed; serving empty page",
+				"catalog", def.ID, "search", req.Search, "skip", req.Skip, "err", err)
+		}
 		metas = nil
 	}
 	if req.Search == "" && len(metas) > 0 {

--- a/pkg/server/stremio/handlers_catalog.go
+++ b/pkg/server/stremio/handlers_catalog.go
@@ -155,7 +155,7 @@ func (s *Server) serveCatalog(ctx context.Context, def CatalogDef, req catalogRe
 		// nothing above DEBUG in the log is indistinguishable from "no rows".
 		if logger.Throttle("catalog-build-failed:"+def.ID, 5*time.Minute) {
 			logger.Warn("Catalog build failed; serving empty page",
-				"catalog", def.ID, "provider", def.Provider, "search", req.Search, "skip", req.Skip, "err", err)
+				"catalog", def.ID, "provider", def.Provider, "searched", req.Search != "", "skip", req.Skip, "err", err)
 		} else {
 			logger.Debug("Catalog build failed; serving empty page",
 				"catalog", def.ID, "search", req.Search, "skip", req.Skip, "err", err)


### PR DESCRIPTION
## Why

Users report Jellyfin libraries that appear in Infuse but stay empty. On 53144c6 every path that produces that outcome is silent above DEBUG:

- `serveCatalog` logs a provider failure at DEBUG and serves an empty page (`handlers_catalog.go`)
- `allItems` drops a failing catalog from the "everything" listing with no log at all (`jellyfin/items.go`)
- `enabledCatalogDefs` skips profile toggles the registry does not know (removed catalogs, or ids saved by another build) with no log; config validation only catches them on save
- `handleLatest` answers an unknown parent with `[]` and no log
- `previewItem` drops rows whose id it cannot encode, unlogged
- a missing TMDB Read Access Token empties the two default libraries (`tmdb/client.go` "not configured") and nothing says so at startup

So a library that is empty because of a dead provider, a missing token or a stale profile looks identical to one with no rows.

## What

- New `logger.Throttle(key, interval)` helper (first call passes, then once per interval per key) so a dead provider does not repeat the line on every request.
- `serveCatalog`: throttled Warn (5 min per catalog) with catalog id, provider, skip, error; DEBUG otherwise.
- `allItems`: throttled Warn when a catalog is omitted (excluding metadata-disabled).
- `enabledCatalogDefs`: Warn once per day per unknown toggle id, with the profile name.
- `handleLatest`: DEBUG when the parent is not a library or the catalog is unknown.
- `previewItem`: DEBUG once per hour per dropped id.
- Startup: one Warn when metadata is enabled and no TMDB token is available from env, config or the build.

No behaviour change: every path returns exactly what it returned before.

## Tests

- `pkg/core/logger/throttle_test.go` covers first-pass, hold, expiry and key independence.
- Existing `TestEnabledCatalogDefsRespectstogglesAndOrder` already exercises the unknown-toggle path; output unchanged.
- `go vet` and `go test -count=1 ./pkg/core/logger/ ./pkg/server/jellyfin/ ./pkg/server/stremio/` pass, run three times.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ECZkfe3SPiUjSEtqS28AHf


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a startup warning when metadata is enabled without a TMDB Read Access Token, clarifying that TMDB catalogs and movie metadata will be unavailable.

- **Diagnostics**
  - Improved warnings and debug logs for catalog, search, latest-item, and metadata-related issues.
  - Added clearer stream, provider, catalog, and item context to relevant log messages.
  - Reduced repetitive warnings by rate-limiting recurring diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->