### PR TITLE
fix(jellyfin): keep two list-level media sources for Infuse Direct Mode

### DIFF
--- a/docs/jellyfin.md
+++ b/docs/jellyfin.md
@@ -77,6 +77,12 @@ stream never sees another's.
   opened, and the alternative is a picker with nothing real in it. Set it to
   `false` if you would rather not spend the search — a title then offers the
   one best release until you press play.
+- **List rows** — Infuse's Direct Mode never asks PlaybackInfo: it plays from
+  the row's media sources and reads the version count from the list
+  document. Every movie and episode row therefore carries two placeholder
+  sources (slots 0 and 1), or the resolved list when it is already cached.
+  Nothing is searched to build a row; playing a slot the search did not
+  fill falls back to the first playable release.
 - **Resume** — position and watched state are kept per stream, server-side,
   because Jellyfin clients expect the server to remember rather than keeping
   it locally the way Stremio clients do. 90% in counts as watched.

--- a/pkg/server/jellyfin/dto.go
+++ b/pkg/server/jellyfin/dto.go
@@ -293,7 +293,7 @@ func (s *Server) viewItem(def stremio.CatalogDef) *baseItem {
 
 // previewItem renders a catalog row. Rows carry no runtime or year, which is
 // what a Jellyfin library grid shows anyway: poster and title.
-func (s *Server) previewItem(preview stremio.MetaPreview, parentID string) (*baseItem, bool) {
+func (s *Server) previewItem(rq *request, preview stremio.MetaPreview, parentID string) (*baseItem, bool) {
 	id, err := itemIDFor(preview.Type, preview.ID)
 	if err != nil {
 		return nil, false
@@ -302,6 +302,7 @@ func (s *Server) previewItem(preview stremio.MetaPreview, parentID string) (*bas
 	item.ParentID = parentID
 	item.Overview = preview.Description
 	s.setImages(item, id, preview.Poster, preview.Background, "")
+	s.attachListSources(rq, id, item)
 	return item, true
 }
 

--- a/pkg/server/jellyfin/items.go
+++ b/pkg/server/jellyfin/items.go
@@ -295,7 +295,7 @@ func (s *Server) catalogPage(rq *request, def stremio.CatalogDef, start, limit i
 	offset := start - firstPage*bucket
 	parent := viewID(def.ID)
 	for i := offset; i < len(rows) && len(result.Items) < limit; i++ {
-		if item, ok := s.previewItem(rows[i], parent); ok {
+		if item, ok := s.previewItem(rq, rows[i], parent); ok {
 			result.Items = append(result.Items, item)
 		}
 	}
@@ -340,7 +340,7 @@ func (s *Server) allItems(rq *request, include []string) []*baseItem {
 	for i, def := range defs {
 		parent := viewID(def.ID)
 		for _, preview := range rows[i] {
-			item, ok := s.previewItem(preview, parent)
+			item, ok := s.previewItem(rq, preview, parent)
 			if !ok || seen[item.ID] {
 				continue
 			}
@@ -375,7 +375,7 @@ func (s *Server) search(rq *request, term string, include []string) []*baseItem 
 	seen := map[string]bool{}
 	for _, metas := range rows {
 		for _, preview := range metas {
-			item, ok := s.previewItem(preview, "")
+			item, ok := s.previewItem(rq, preview, "")
 			if !ok || seen[item.ID] {
 				continue
 			}
@@ -644,6 +644,8 @@ func (s *Server) childrenOf(rq *request, id itemID, include []string, recursive 
 		item := s.episodeItem(series, meta, v)
 		st, ok := states[item.ID]
 		item.UserData = userDataFor(item.ID, st, ok)
+		// Episodes are list rows too in Infuse's Direct Mode.
+		s.attachListSources(rq, series.episode(v.Season, v.Episode), item)
 		items = append(items, item)
 	}
 	return items, nil

--- a/pkg/server/jellyfin/playback.go
+++ b/pkg/server/jellyfin/playback.go
@@ -389,6 +389,41 @@ func (s *Server) handlePlaybackInfo(w http.ResponseWriter, rq *request, raw stri
 // and the real ranked list arrives when the client asks for PlaybackInfo on
 // play. Playing the stand-in is correct either way: the slot resolves and
 // fails over exactly as it does for a Stremio client.
+// attachListSources gives a browse or episode row the version signal
+// Infuse's Direct Mode reads from the list document: it never asks
+// PlaybackInfo, plays from the row's MediaSources, and decides whether a
+// title has selectable versions from MediaSourceCount on that row. A
+// playlist already in cache is rendered as is; otherwise two placeholders
+// name slots 0 and 1. Nothing here searches — PlaylistCached is a map read.
+//
+// Slot 1 may outnumber the releases found at play time. That is safe: a play
+// request for a slot the list does not hold is recovered by the addon's
+// slot recovery, which wraps around to the first playable candidate and
+// redirects the client there.
+func (s *Server) attachListSources(rq *request, id itemID, item *baseItem) {
+	if item == nil || (id.Kind != kindMovie && id.Kind != kindEpisode) {
+		return
+	}
+	if view, ok := s.opts.Catalog.PlaylistCached(rq.stream, id.ContentType, id.playStremioID()); ok && view != nil && len(view.Entries) > 0 {
+		setItemMediaSources(item, s.renderedSources(rq, id, view))
+		return
+	}
+	setItemMediaSources(item, s.placeholderSources(rq, id, item))
+}
+
+// placeholderSources are the two stand-ins a list row carries before any
+// search has run: slot 0 is the best release once resolved, slot 1 the next.
+func (s *Server) placeholderSources(rq *request, id itemID, item *baseItem) []mediaSource {
+	runtime := float64(0)
+	if item.RunTimeTicks != nil {
+		runtime = float64(*item.RunTimeTicks) / float64(ticksPerSecond)
+	}
+	return []mediaSource{
+		s.mediaSourceOf(rq, id, stremio.PlaylistEntry{Index: 0, Title: item.Name}, runtime),
+		s.mediaSourceOf(rq, id, stremio.PlaylistEntry{Index: 1, Title: item.Name + " (alternate release)"}, runtime),
+	}
+}
+
 func (s *Server) attachMediaSources(rq *request, id itemID, item *baseItem) {
 	if item == nil || (id.Kind != kindMovie && id.Kind != kindEpisode) {
 		return

--- a/pkg/server/jellyfin/server_test.go
+++ b/pkg/server/jellyfin/server_test.go
@@ -467,11 +467,11 @@ func TestViewsPageThroughCatalogs(t *testing.T) {
 	if result.Items[0].Type != "Movie" || result.Items[0].ParentID != view || result.Items[0].ImageTags["Primary"] == "" || len(result.Items[0].BackdropImageTags) != 1 {
 		t.Fatalf("row shape: %+v", result.Items[0])
 	}
-	// A browse row carries no media sources. Nobody opens a version picker
-	// from a grid thumbnail, and the sources are not free: each one is an
-	// absolute stream URL carrying the stream token, on every row of the page.
-	if len(result.Items[0].MediaSources) != 0 || len(result.Items[0].AlternateMediaSources) != 0 || result.Items[0].MediaSourceCount != nil {
-		t.Fatalf("browse row must stay free of media sources: %+v", result.Items[0])
+	// A browse row carries the two-slot version signal Infuse's Direct Mode
+	// reads from the list document (it never asks PlaybackInfo): two
+	// placeholders, a count of two, and the display flag.
+	if row := result.Items[0]; len(row.MediaSources) != 2 || len(row.AlternateMediaSources) != 2 || row.MediaSourceCount == nil || *row.MediaSourceCount != 2 || row.EnableMediaSourceDisplay == nil || !*row.EnableMediaSourceDisplay {
+		t.Fatalf("browse row must carry two placeholder media sources: %+v", row)
 	}
 	decodeInto(t, f.do(http.MethodGet, "/jellyfin/Items?ParentId="+view+"&StartIndex=40&Limit=20", ""), &result)
 	if len(result.Items) != 5 || result.TotalRecordCount != 45 {
@@ -1543,5 +1543,84 @@ func TestFladderImageURLShapes(t *testing.T) {
 	dashed := item.ID[:8] + "-" + item.ID[8:12] + "-" + item.ID[12:16] + "-" + item.ID[16:20] + "-" + item.ID[20:]
 	if rec := anon("/jellyfin/Items/" + dashed + "/Images/Primary" + sized); rec.Code != http.StatusOK {
 		t.Fatalf("hyphenated item id: %d", rec.Code)
+	}
+}
+
+// TestListRowsCarryVersionSignal pins the list-document contract Infuse's
+// Direct Mode depends on: movie rows, Latest rows and episode rows carry two
+// placeholder sources naming slots 0 and 1, a cached playlist is rendered in
+// their place, and none of it runs a search.
+func TestListRowsCarryVersionSignal(t *testing.T) {
+	f := newFixture()
+	f.resolveOnOpen = true
+	stream := &auth.Stream{Username: "living-room", Token: testToken}
+	requireTwo := func(row *baseItem, at string) {
+		t.Helper()
+		if len(row.MediaSources) != 2 || row.MediaSourceCount == nil || *row.MediaSourceCount != 2 || row.EnableMediaSourceDisplay == nil || !*row.EnableMediaSourceDisplay {
+			t.Fatalf("%s: want two placeholder sources with count and display, got %+v", at, row)
+		}
+		id, err := decodeItemID(row.ID)
+		if err != nil {
+			t.Fatalf("%s: row id: %v", at, err)
+		}
+		for i, src := range row.MediaSources {
+			if src.ID != mediaSourceIDFor(id, i) || src.Path != f.server.streamURLFor(id, i, stream) || !src.SupportsDirectPlay {
+				t.Fatalf("%s: slot %d is not a playable stand-in: %+v", at, i, src)
+			}
+		}
+		if row.MediaSources[0].Name != row.Name || row.MediaSources[1].Name == row.MediaSources[0].Name {
+			t.Fatalf("%s: placeholder names: %q %q", at, row.MediaSources[0].Name, row.MediaSources[1].Name)
+		}
+	}
+
+	var page queryResult
+	decodeInto(t, f.do(http.MethodGet, "/jellyfin/Users/u/Items?ParentId="+viewID("tmdb.trending.movie")+"&Limit=5", ""), &page)
+	requireTwo(page.Items[0], "movie row")
+
+	var latest []*baseItem
+	decodeInto(t, f.do(http.MethodGet, "/jellyfin/Users/u/Items/Latest?ParentId="+viewID("tmdb.trending.movie")+"&Limit=3", ""), &latest)
+	requireTwo(latest[0], "latest row")
+
+	series, _ := itemIDFor("series", "tt0903747")
+	var episodes queryResult
+	decodeInto(t, f.do(http.MethodGet, "/jellyfin/Shows/"+series.encode()+"/Episodes?SeasonId="+series.season(1).encode(), ""), &episodes)
+	if len(episodes.Items) == 0 {
+		t.Fatalf("no episodes")
+	}
+	requireTwo(episodes.Items[0], "episode row")
+
+	// Series rows are folders and carry nothing. (Fresh result: decoding
+	// into a reused slice of pointers keeps fields the JSON omits.)
+	var seriesPage queryResult
+	decodeInto(t, f.do(http.MethodGet, "/jellyfin/Users/u/Items?ParentId="+viewID("tmdb.trending.series"), ""), &seriesPage)
+	if len(seriesPage.Items[0].MediaSources) != 0 || seriesPage.Items[0].MediaSourceCount != nil {
+		t.Fatalf("series row carries media sources: %+v", seriesPage.Items[0])
+	}
+
+	// A playlist already in cache is rendered instead of the placeholders.
+	entries := make([]stremio.PlaylistEntry, 3)
+	for i := range entries {
+		entries[i] = stremio.PlaylistEntry{Index: i, Title: fmt.Sprintf("Release.%02d.mkv", i)}
+	}
+	f.catalog.cached = &stremio.PlaylistView{Entries: entries}
+	var cachedPage queryResult
+	decodeInto(t, f.do(http.MethodGet, "/jellyfin/Users/u/Items?ParentId="+viewID("tmdb.trending.movie")+"&Limit=5", ""), &cachedPage)
+	if row := cachedPage.Items[0]; len(row.MediaSources) != 3 || row.MediaSources[0].Name != "Release.00.mkv" || *row.MediaSourceCount != 3 {
+		t.Fatalf("cached playlist not rendered on the row: %+v", row)
+	}
+
+	// None of the above searched: the list document is built from cache and
+	// placeholders only, whatever resolve-on-open is set to.
+	if calls := f.catalog.playlistCalls; calls != 0 {
+		t.Fatalf("list rows ran %d searches, want 0", calls)
+	}
+
+	// Playing placeholder slot 1 goes to the addon as slot 1; when the list
+	// turns out shorter the addon's slot recovery wraps to the first
+	// playable candidate, so nothing here has to know how many were found.
+	movie, _ := itemIDFor("movie", "tt0111161")
+	rec := f.do(http.MethodGet, "/jellyfin/Videos/"+movie.encode()+"/stream?Static=true&MediaSourceId="+movie.source(1).encode(), "")
+	if rec.Code != http.StatusOK || f.catalog.served[len(f.catalog.served)-1].slotPath != stremio.SlotPathFor(stream, "movie", "tt0111161", 1) {
+		t.Fatalf("slot 1 play: %d served %+v", rec.Code, f.catalog.served)
 	}
 }


### PR DESCRIPTION
## Why

Infuse's **Direct Mode** (the default for a Jellyfin server in Infuse 8.5) never calls `PlaybackInfo`. It plays from the item document's `MediaSources` and reads `MediaSourceCount` from the **list** row to decide whether a title has versions. Since 53144c6 removed `attachMediaSourceStubs`, browse rows, `Items/Latest` rows and `Shows/{id}/Episodes` rows carry no sources at all, so Direct Mode users see titles they cannot play and no picker.

Evidence from a live instance on 53144c6:
- Traefik log: Infuse's Latest calls request `fields=…MediaSources,AlternateMediaSources…` on every library (3,958 calls in 48 h) and receive none.
- `Infuse-Direct` traffic seen after the upgrade: UserViews, VirtualFolders, Resume, Seasons — never PlaybackInfo.
- The removed function's own comment: "supplies the two list-level sources Infuse's Direct Mode uses to decide whether a movie or episode has selectable versions."
- We hit the same thing on the AIOStreams Jellyfin layer on 2026-09-09: dropping the second placeholder removed the picker for every Infuse user; two entries restored it.

## What

- `attachListSources` (playback.go): movie and episode rows get the cached playlist when one exists, else two placeholders naming slots 0 and 1. `PlaylistCached` is a map read; no row ever searches.
- `previewItem` takes the request again; `childrenOf` attaches on episode rows.
- Single-item route, resolve-on-open and PlaybackInfo are unchanged.
- Slot 1 with a shorter list: `openPlaySession` → `recoverPlaySessionAfterEviction` wraps to the first playable candidate and redirects, so the second placeholder never strands a play. Documented in docs/jellyfin.md.

## Tests

`TestViewsPageThroughCatalogs` row assertion flipped; new `TestListRowsCarryVersionSignal` (movie, Latest, episode rows; series rows stay empty; cached playlist rendered; zero searches; slot 1 play). On unpatched main:

```
--- FAIL: TestListRowsCarryVersionSignal
server_test.go:1578: movie row: want two placeholder sources with count and display, got … MediaSources:[] … MediaSourceCount:<nil>
```

`go test -count=1 ./pkg/server/jellyfin/` ×3 and `-race`: ok. `go vet`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ECZkfe3SPiUjSEtqS28AHf
