### PR TITLE
fix(jellyfin): do not end a library on a short provider page

### DIFF
--- a/pkg/server/jellyfin/items.go
+++ b/pkg/server/jellyfin/items.go
@@ -268,6 +268,13 @@ func page(items []*baseItem, start, limit int, open bool) queryResult {
 // in fixed buckets, so the request is mapped onto whole buckets and sliced;
 // a client whose page size is a multiple of the bucket lands exactly on
 // bucket edges, which is what every known client does.
+//
+// Positions are the addon's, not the row count served: a bucket comes back
+// short whenever the provider had rows the addon could not identify, so a
+// page may carry fewer rows than asked while the catalog goes on. Only an
+// empty bucket ends the catalog. When the last bucket in range is short the
+// next one is probed for that answer, so a true last page still reports an
+// exact total.
 func (s *Server) catalogPage(rq *request, def stremio.CatalogDef, start, limit int) queryResult {
 	result := emptyResult()
 	result.StartIndex = start
@@ -277,33 +284,57 @@ func (s *Server) catalogPage(rq *request, def stremio.CatalogDef, start, limit i
 	}
 	bucket := stremio.CatalogPageSize
 	firstPage, lastPage := start/bucket, (start+limit-1)/bucket
-	var rows []stremio.MetaPreview
-	short := false
+	parent := viewID(def.ID)
+	ended := false
 	for p := firstPage; p <= lastPage; p++ {
 		metas, err := s.opts.Catalog.Catalog(rq.Context(), rq.stream, def.ID, def.Type, "", p*bucket)
 		if err != nil {
 			logger.Debug("Jellyfin catalog page failed", "catalog", def.ID, "skip", p*bucket, "err", err)
-			short = true
+			ended = true
 			break
 		}
-		rows = append(rows, metas...)
-		if len(metas) < bucket || !def.SupportsSkip {
-			short = true
+		if len(metas) == 0 {
+			ended = true
 			break
 		}
-	}
-	offset := start - firstPage*bucket
-	parent := viewID(def.ID)
-	for i := offset; i < len(rows) && len(result.Items) < limit; i++ {
-		if item, ok := s.previewItem(rows[i], parent); ok {
-			result.Items = append(result.Items, item)
+		// Row j of bucket p sits at position p*bucket+j whatever the bucket
+		// lost, so a window is the same rows on every visit.
+		for j, preview := range metas {
+			pos := p*bucket + j
+			if pos < start || pos >= start+limit {
+				continue
+			}
+			if item, ok := s.previewItem(preview, parent); ok {
+				result.Items = append(result.Items, item)
+			}
+		}
+		if !def.SupportsSkip {
+			ended = true
+			break
+		}
+		if p == lastPage && len(metas) < bucket {
+			ended = s.catalogEndsAt(rq, def, (p+1)*bucket)
 		}
 	}
 	result.TotalRecordCount = start + len(result.Items)
-	if !short {
-		result.TotalRecordCount += bucket
+	if !ended {
+		// Open-ended, as page() reports it: past the window the client
+		// asked for, so a page thinned by dropped rows still reads as
+		// "more to come" rather than as the last one.
+		result.TotalRecordCount = start + limit + bucket
 	}
 	return result
+}
+
+// catalogEndsAt reports whether the bucket at skip is empty, which is the
+// only signal the addon gives that a catalog is exhausted.
+func (s *Server) catalogEndsAt(rq *request, def stremio.CatalogDef, skip int) bool {
+	metas, err := s.opts.Catalog.Catalog(rq.Context(), rq.stream, def.ID, def.Type, "", skip)
+	if err != nil {
+		logger.Debug("Jellyfin catalog page failed", "catalog", def.ID, "skip", skip, "err", err)
+		return true
+	}
+	return len(metas) == 0
 }
 
 // allItems is the listing without a folder — "everything of this type",

--- a/pkg/server/jellyfin/server_test.go
+++ b/pkg/server/jellyfin/server_test.go
@@ -72,6 +72,10 @@ type fakeCatalog struct {
 	playlistCalls int
 	served        []servedPlay
 	disabled      bool
+	// drop thins a bucket the way the addon does when a provider row has
+	// no id it can use: skip → rows removed from the end of that bucket.
+	drop         map[int]int
+	catalogCalls []int
 }
 
 // releaseCaps is what ffprobe measured on the candidate that played: a
@@ -108,6 +112,7 @@ func (f *fakeCatalog) Catalog(_ context.Context, _ *auth.Stream, catalogID, _, s
 		f.searches = append(f.searches, catalogID+"="+search)
 		return f.rows[catalogID], nil
 	}
+	f.catalogCalls = append(f.catalogCalls, skip)
 	rows := f.rows[catalogID]
 	if skip >= len(rows) {
 		return nil, nil
@@ -115,6 +120,9 @@ func (f *fakeCatalog) Catalog(_ context.Context, _ *auth.Stream, catalogID, _, s
 	rows = rows[skip:]
 	if len(rows) > stremio.CatalogPageSize {
 		rows = rows[:stremio.CatalogPageSize]
+	}
+	if n := f.drop[skip]; n > 0 && n <= len(rows) {
+		rows = rows[:len(rows)-n]
 	}
 	return rows, nil
 }
@@ -450,6 +458,55 @@ func TestTokenFormsAndCaseInsensitivity(t *testing.T) {
 	decodeInto(t, f.do(http.MethodGet, "/jellyfin/Items?PARENTID="+view+"&LIMIT=5", ""), &result)
 	if len(result.Items) != 5 {
 		t.Fatalf("upper-cased query: %d items", len(result.Items))
+	}
+}
+
+// A provider bucket comes back short whenever the addon drops rows it cannot
+// identify. That is not the end of the catalog: the client must be told to
+// keep paging, and the addon's positions must be kept so the next page
+// neither repeats nor skips rows.
+func TestShortBucketDoesNotEndCatalog(t *testing.T) {
+	f := newFixture()
+	f.catalog.rows["tmdb.trending.movie"] = previews("movie", "tt", 120)
+	f.catalog.drop = map[int]int{0: 2, 40: 1}
+	view := viewID("tmdb.trending.movie")
+	var result queryResult
+	decodeInto(t, f.do(http.MethodGet, "/jellyfin/Users/u/Items?ParentId="+view+"&StartIndex=0&Limit=100", ""), &result)
+	if len(result.Items) != 97 || result.Items[0].Name != "Title 1" || result.Items[96].Name != "Title 100" {
+		t.Fatalf("first page: %d items (want 97: 18+20+19+20+20), first %q last %q", len(result.Items), result.Items[0].Name, result.Items[len(result.Items)-1].Name)
+	}
+	if result.TotalRecordCount <= 100 {
+		t.Fatalf("a thinned page must still read as more to come: total %d", result.TotalRecordCount)
+	}
+	// The client steps by its own page size, so the next page starts at the
+	// addon's position 100, not at row 97: no repeat, no gap.
+	decodeInto(t, f.do(http.MethodGet, "/jellyfin/Users/u/Items?ParentId="+view+"&StartIndex=100&Limit=100", ""), &result)
+	if len(result.Items) != 20 || result.Items[0].Name != "Title 101" || result.Items[19].Name != "Title 120" {
+		t.Fatalf("second page: %d items, first %q", len(result.Items), result.Items[0].Name)
+	}
+	if result.TotalRecordCount != 120 {
+		t.Fatalf("an empty bucket ends the catalog with an exact total: got %d", result.TotalRecordCount)
+	}
+	// A short LAST bucket is probed, so a true last page is exact too.
+	f.catalog.drop = map[int]int{100: 3}
+	decodeInto(t, f.do(http.MethodGet, "/jellyfin/Users/u/Items?ParentId="+view+"&StartIndex=100&Limit=20", ""), &result)
+	if len(result.Items) != 17 || result.TotalRecordCount != 117 {
+		t.Fatalf("short last page: %d items, total %d", len(result.Items), result.TotalRecordCount)
+	}
+	// Page-sized requests walk the same rows without duplicates.
+	f.catalog.drop = map[int]int{0: 2, 40: 1}
+	seen := map[string]bool{}
+	for start := 0; start < 120; start += 30 {
+		decodeInto(t, f.do(http.MethodGet, fmt.Sprintf("/jellyfin/Users/u/Items?ParentId=%s&StartIndex=%d&Limit=30", view, start), ""), &result)
+		for _, item := range result.Items {
+			if seen[item.Name] {
+				t.Fatalf("row %q served twice", item.Name)
+			}
+			seen[item.Name] = true
+		}
+	}
+	if len(seen) != 117 {
+		t.Fatalf("walked %d distinct rows, want 117", len(seen))
 	}
 }
 

--- a/pkg/server/stremio/handlers_catalog.go
+++ b/pkg/server/stremio/handlers_catalog.go
@@ -166,6 +166,11 @@ func (s *Server) serveCatalog(ctx context.Context, def CatalogDef, req catalogRe
 }
 
 func (s *Server) buildCatalog(ctx context.Context, def CatalogDef, req catalogRequest) ([]MetaPreview, error) {
+	if req.Skip > 0 && req.Search == "" && !def.SupportsSkip {
+		// A catalog without paging has only its first page; answering a
+		// skip with the first page again would repeat it.
+		return nil, nil
+	}
 	switch def.Provider {
 	case "tmdb":
 		return s.tmdbCatalog(ctx, def, req)

--- a/pkg/services/metadata/kitsu/kitsu.go
+++ b/pkg/services/metadata/kitsu/kitsu.go
@@ -379,6 +379,11 @@ type listingAPIResponse struct {
 func (c *Client) GetAnimeListing(ctx context.Context, kind string, offset int) ([]AnimeListing, error) {
 	switch kind {
 	case "trending":
+		if offset > 0 {
+			// The trending feed is a fixed top 20 with no paging; a later
+			// page is empty, not the same twenty again.
+			return nil, nil
+		}
 		return c.getListing(ctx, "/trending/anime?limit=20")
 	case "top_rated":
 		return c.getListing(ctx, fmt.Sprintf("/anime?sort=-averageRating&page[limit]=20&page[offset]=%d", offset))

--- a/pkg/services/metadata/kitsu/listing_skip_test.go
+++ b/pkg/services/metadata/kitsu/listing_skip_test.go
@@ -1,0 +1,38 @@
+package kitsu
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+)
+
+// The trending feed is a fixed top 20 upstream; asking past it must answer
+// empty without a request, not the same twenty again.
+func TestTrendingListingHasOnePage(t *testing.T) {
+	var hits atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		if r.URL.Path != "/trending/anime" {
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+		w.Write([]byte(`{"data":[{"id":"1","type":"anime","attributes":{"canonicalTitle":"One"}}]}`))
+	}))
+	defer ts.Close()
+	client := NewClient(ts.Client())
+	client.BaseURL = ts.URL
+
+	first, err := client.GetAnimeListing(context.Background(), "trending", 0)
+	if err != nil || len(first) != 1 {
+		t.Fatalf("first page: %v, %d rows", err, len(first))
+	}
+	second, err := client.GetAnimeListing(context.Background(), "trending", 20)
+	if err != nil || len(second) != 0 {
+		t.Fatalf("second page must be empty: %v, %d rows", err, len(second))
+	}
+	if hits.Load() != 1 {
+		t.Fatalf("a skipped trending page must not hit Kitsu: %d requests", hits.Load())
+	}
+}


### PR DESCRIPTION
## Why

Measured on a live instance (main @ 53144c6), Jellyfin route vs Stremio route for the same stream and catalog:

| Catalog | Infuse gets | Stremio gets |
|---|---|---|
| Trending Series (`Limit=100`) | 18 rows, `TotalRecordCount` 18 | 20 / 19 / 20 / 19 … per page, every page |
| Trending Anime (`skip=20`) | — | the same 20 ids as page 0 |

`tmdbCatalog` drops rows without a resolvable IMDb id, so a provider bucket is routinely 18 or 19 instead of 20. `catalogPage` treated any short bucket as the end of the catalog and reported a final total, so the client stopped. Which libraries collapse depends on which TMDB rows lack a mapping that day, which is why users report it as "movies/shows missing for some people".

## What

- `pkg/server/jellyfin/items.go` `catalogPage`: rows keep the addon's positions (`p*bucket+j`), so a window is the same rows on every visit and pages never repeat or skip. Only an **empty** bucket ends a catalog. When the last bucket in range is short, the next bucket is probed once so a true last page still reports an exact total (the existing `45 rows → total 45` test is unchanged). An open-ended page reports `start+limit+bucket`, the same convention as `page()`, so a thinned page is not mistaken for the last one.
- `pkg/server/stremio/handlers_catalog.go` `buildCatalog`: a catalog without `SupportsSkip` answers `skip>0` empty instead of repeating page one.
- `pkg/services/metadata/kitsu/kitsu.go`: the trending feed is a fixed top 20 upstream, so an offset past it returns empty without a request.

## Tests

`TestShortBucketDoesNotEndCatalog` (buckets of 18/20/19/20/20, `Limit=100`, then page 2, a short last page, and a full walk at `Limit=30` asserting 117 distinct rows with no repeats). On unpatched main:

```
--- FAIL: TestShortBucketDoesNotEndCatalog
    server_test.go:476: first page: 18 items (want 97: 18+20+19+20+20)
--- FAIL: TestTrendingListingHasOnePage
    listing_skip_test.go:33: second page must be empty: <nil>, 1 rows
```

Patched: `go test -race -count=1 ./pkg/server/jellyfin/ ./pkg/server/stremio/ ./pkg/services/metadata/kitsu/` green, three runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ECZkfe3SPiUjSEtqS28AHf
