### PR TITLE
fix(jellyfin): episode runtime, specials, TVDB rating, unaired episodes, row year/rating

### DIFF
--- a/pkg/server/jellyfin/dto.go
+++ b/pkg/server/jellyfin/dto.go
@@ -179,6 +179,16 @@ func runtimeTicks(runtime string) *int64 {
 }
 
 // productionYear reads the leading year of "2019" or "2019-2023".
+// episodeRuntimeTicks prefers the episode's own length over the series
+// average: a finale or a special is rarely the average, and the client's
+// scrubber and "time left" read this number.
+func episodeRuntimeTicks(video stremio.MetaVideo, meta *stremio.MetaObject) *int64 {
+	if video.Runtime > 0 {
+		return int64Ptr(int64(video.Runtime) * 60 * ticksPerSecond)
+	}
+	return runtimeTicks(meta.Runtime)
+}
+
 func productionYear(releaseInfo string) *int {
 	if m := leadingYear.FindString(releaseInfo); m != "" {
 		y, _ := strconv.Atoi(m)
@@ -461,7 +471,7 @@ func (s *Server) episodeItem(seriesID itemID, meta *stremio.MetaObject, video st
 		SeasonName:        "Season " + strconv.Itoa(video.Season),
 		PremiereDate:      premiereDate(video.Released),
 		ProviderIDs:       providerIDs(id),
-		RunTimeTicks:      runtimeTicks(meta.Runtime),
+		RunTimeTicks:      episodeRuntimeTicks(video, meta),
 	}
 	if video.Season == 0 {
 		item.SeasonName = "Specials"

--- a/pkg/server/jellyfin/dto.go
+++ b/pkg/server/jellyfin/dto.go
@@ -329,6 +329,8 @@ func (s *Server) previewItem(preview stremio.MetaPreview, parentID string) (*bas
 	item := s.newItem(id, preview.Name)
 	item.ParentID = parentID
 	item.Overview = preview.Description
+	item.ProductionYear = productionYear(preview.ReleaseInfo)
+	item.CommunityRating = communityRating(preview.IMDBRating)
 	s.setImages(item, id, preview.Poster, preview.Background, "")
 	return item, true
 }

--- a/pkg/server/jellyfin/dto.go
+++ b/pkg/server/jellyfin/dto.go
@@ -197,6 +197,24 @@ func productionYear(releaseInfo string) *int {
 	return nil
 }
 
+// now is the clock unaired reads; tests pin it.
+var now = time.Now
+
+// unaired reports whether an episode's release date lies in the future. An
+// unknown date is not unaired: the provider may simply not have one.
+func unaired(released string) bool {
+	released = strings.TrimSpace(released)
+	if released == "" {
+		return false
+	}
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, "2006-01-02"} {
+		if t, err := time.Parse(layout, released); err == nil {
+			return t.After(now())
+		}
+	}
+	return false
+}
+
 // premiereDate normalises an ISO date to Jellyfin's timestamp form.
 func premiereDate(released string) string {
 	released = strings.TrimSpace(released)
@@ -475,6 +493,12 @@ func (s *Server) episodeItem(seriesID itemID, meta *stremio.MetaObject, video st
 	}
 	if video.Season == 0 {
 		item.SeasonName = "Specials"
+	}
+	// An episode that has not aired yet has nothing to play. Jellyfin marks
+	// its own unaired entries Virtual, and clients grey those out instead of
+	// offering a play button that ends in "no compatible stream".
+	if unaired(video.Released) {
+		item.LocationType = "Virtual"
 	}
 	// The episode still is its Primary image; the series poster and backdrop
 	// ride along as the parent's for the clients that show them.

--- a/pkg/server/jellyfin/server_test.go
+++ b/pkg/server/jellyfin/server_test.go
@@ -265,7 +265,7 @@ func testCatalog() *fakeCatalog {
 		Videos: []stremio.MetaVideo{
 			{ID: "tt0903747:1:1", Title: "Pilot", Season: 1, Episode: 1, Released: "2008-01-20T00:00:00.000Z", Thumbnail: cdn + "/bb-s1e1.jpg", Runtime: 58},
 			{ID: "tt0903747:1:2", Title: "Cat's in the Bag...", Season: 1, Episode: 2},
-			{ID: "tt0903747:2:1", Title: "Seven Thirty-Seven", Season: 2, Episode: 1},
+			{ID: "tt0903747:2:1", Title: "Seven Thirty-Seven", Season: 2, Episode: 1, Released: "2099-01-01T00:00:00.000Z"},
 			{ID: "tt0903747:0:1", Title: "Minisode", Season: 0, Episode: 1},
 		},
 	}
@@ -806,6 +806,15 @@ func TestSeriesSeasonsAndEpisodes(t *testing.T) {
 	}
 	if got := episodes.Items[1].RunTimeTicks; got == nil || *got != 49*60*ticksPerSecond {
 		t.Fatalf("episode 2 runtime = %v, want the series average 49 min", got)
+	}
+	if episodes.Items[0].LocationType != "FileSystem" {
+		t.Fatalf("aired episode LocationType = %q, want FileSystem", episodes.Items[0].LocationType)
+	}
+	// Season 2's only episode airs in 2099: listed, but Virtual.
+	var future queryResult
+	decodeInto(t, f.do(http.MethodGet, "/jellyfin/Shows/"+series.encode()+"/Episodes?SeasonId="+seasons.Items[1].ID, ""), &future)
+	if len(future.Items) != 1 || future.Items[0].LocationType != "Virtual" {
+		t.Fatalf("unaired episode: %+v, want LocationType Virtual", future.Items)
 	}
 	ep := episodes.Items[0]
 	if ep.SeriesName != "Breaking Bad" || ep.SeasonID != seasons.Items[0].ID || ep.SeriesPrimaryImageTag == "" || ep.RunTimeTicks == nil || ep.UserData == nil {

--- a/pkg/server/jellyfin/server_test.go
+++ b/pkg/server/jellyfin/server_test.go
@@ -263,7 +263,7 @@ func testCatalog() *fakeCatalog {
 		ID: "tt0903747", Type: "series", Name: "Breaking Bad", Poster: "https://img.test/bb.jpg", Background: cdn + "/bb-bg.jpg",
 		ReleaseInfo: "2008-2013", Released: "2008-01-20T00:00:00.000Z", Runtime: "49 min",
 		Videos: []stremio.MetaVideo{
-			{ID: "tt0903747:1:1", Title: "Pilot", Season: 1, Episode: 1, Released: "2008-01-20T00:00:00.000Z", Thumbnail: cdn + "/bb-s1e1.jpg"},
+			{ID: "tt0903747:1:1", Title: "Pilot", Season: 1, Episode: 1, Released: "2008-01-20T00:00:00.000Z", Thumbnail: cdn + "/bb-s1e1.jpg", Runtime: 58},
 			{ID: "tt0903747:1:2", Title: "Cat's in the Bag...", Season: 1, Episode: 2},
 			{ID: "tt0903747:2:1", Title: "Seven Thirty-Seven", Season: 2, Episode: 1},
 			{ID: "tt0903747:0:1", Title: "Minisode", Season: 0, Episode: 1},
@@ -798,6 +798,14 @@ func TestSeriesSeasonsAndEpisodes(t *testing.T) {
 	decodeInto(t, f.do(http.MethodGet, "/jellyfin/Shows/"+series.encode()+"/Episodes?SeasonId="+seasons.Items[0].ID, ""), &episodes)
 	if len(episodes.Items) != 2 || episodes.Items[0].Name != "Pilot" || *episodes.Items[0].IndexNumber != 1 || *episodes.Items[0].ParentIndexNumber != 1 {
 		t.Fatalf("episodes: %+v", episodes.Items)
+	}
+	// The pilot carries its own 58-minute runtime; the second episode has
+	// none and inherits the series average of 49.
+	if got := episodes.Items[0].RunTimeTicks; got == nil || *got != 58*60*ticksPerSecond {
+		t.Fatalf("episode 1 runtime = %v, want the episode's own 58 min", got)
+	}
+	if got := episodes.Items[1].RunTimeTicks; got == nil || *got != 49*60*ticksPerSecond {
+		t.Fatalf("episode 2 runtime = %v, want the series average 49 min", got)
 	}
 	ep := episodes.Items[0]
 	if ep.SeriesName != "Breaking Bad" || ep.SeasonID != seasons.Items[0].ID || ep.SeriesPrimaryImageTag == "" || ep.RunTimeTicks == nil || ep.UserData == nil {

--- a/pkg/server/jellyfin/server_test.go
+++ b/pkg/server/jellyfin/server_test.go
@@ -280,7 +280,7 @@ func testCatalog() *fakeCatalog {
 			"tmdb.trending.movie":  previews("movie", "tt", 45),
 			"tmdb.trending.series": previews("series", "tt", 3),
 			"kitsu.trending.anime": []stremio.MetaPreview{{ID: "kitsu:9", Type: "anime", Name: "Your Name."}},
-			"tmdb.search.movie":    []stremio.MetaPreview{{ID: "tt0111161", Type: "movie", Name: "The Shawshank Redemption"}},
+			"tmdb.search.movie":    []stremio.MetaPreview{{ID: "tt0111161", Type: "movie", Name: "The Shawshank Redemption", ReleaseInfo: "1994", IMDBRating: "9.3"}},
 			"tmdb.search.series":   []stremio.MetaPreview{{ID: "tt0903747", Type: "series", Name: "Breaking Bad"}},
 			"kitsu.search.anime":   nil,
 		},
@@ -866,9 +866,14 @@ func TestSearchRunsTheCarriers(t *testing.T) {
 	}
 	// A Movie-only search leaves the series carriers alone.
 	f.catalog.searches = nil
-	f.do(http.MethodGet, "/jellyfin/Users/u/Items?SearchTerm=shaw&Recursive=true&IncludeItemTypes=Movie", "")
+	var rows queryResult
+	decodeInto(t, f.do(http.MethodGet, "/jellyfin/Users/u/Items?SearchTerm=shaw&Recursive=true&IncludeItemTypes=Movie", ""), &rows)
 	if got := f.catalog.searchSet(); !reflect.DeepEqual(got, map[string]bool{"tmdb.search.movie=shaw": true}) {
 		t.Fatalf("movie-only searches run: %v", got)
+	}
+	// A list row carries the year and rating the grid badges show.
+	if len(rows.Items) != 1 || rows.Items[0].ProductionYear == nil || *rows.Items[0].ProductionYear != 1994 || rows.Items[0].CommunityRating == nil || *rows.Items[0].CommunityRating != 9.3 {
+		t.Fatalf("row year/rating: %+v", rows.Items)
 	}
 	var hints struct {
 		SearchHints      []searchHint

--- a/pkg/server/stremio/handlers_catalog.go
+++ b/pkg/server/stremio/handlers_catalog.go
@@ -233,6 +233,17 @@ func (s *Server) tmdbCatalog(_ context.Context, def CatalogDef, req catalogReque
 			id = fmt.Sprintf("tmdb:%d", res.ID)
 		}
 		preview := MetaPreview{ID: id, Type: def.Type, Name: name, Description: res.Overview}
+		if date := res.ReleaseDate; date != "" || res.FirstAirDate != "" {
+			if date == "" {
+				date = res.FirstAirDate
+			}
+			if len(date) >= 4 {
+				preview.ReleaseInfo = date[:4]
+			}
+		}
+		if res.VoteAverage > 0 {
+			preview.IMDBRating = fmt.Sprintf("%.1f", res.VoteAverage)
+		}
 		if res.PosterPath != "" {
 			preview.Poster = tmdbPosterURL + res.PosterPath
 		}

--- a/pkg/server/stremio/handlers_meta.go
+++ b/pkg/server/stremio/handlers_meta.go
@@ -423,6 +423,16 @@ func (s *Server) buildSeriesMetaFromTVDB(ctx context.Context, profile *config.Me
 	if ext.AverageRuntime > 0 {
 		meta.Runtime = fmt.Sprintf("%d min", ext.AverageRuntime)
 	}
+	// TVDB's "score" is a popularity rank, not a 0-10 rating, so the rating
+	// comes from TMDB when the id is known; a TVDB-only series stays unrated
+	// rather than carrying a number on the wrong scale.
+	if rid.tmdbID > 0 && rt.tmdbClient != nil {
+		if details, _, err := rt.tmdbClient.GetTVDetailsWithSeasons(rid.tmdbID, nil, profile.EffectiveLanguage()); err == nil && details.VoteAverage > 0 {
+			meta.IMDBRating = fmt.Sprintf("%.1f", details.VoteAverage)
+		} else if err != nil {
+			logger.Debug("TMDB rating lookup for TVDB series failed", "tmdb_id", rid.tmdbID, "err", err)
+		}
+	}
 	// The canonical id stays as requested; the fallback logo CDN needs imdb.
 	if rid.imdbID == "" {
 		rid.imdbID = ext.IMDbID()

--- a/pkg/server/stremio/handlers_meta.go
+++ b/pkg/server/stremio/handlers_meta.go
@@ -457,6 +457,7 @@ func (s *Server) buildSeriesMetaFromTVDB(ctx context.Context, profile *config.Me
 			Episode:   ep.Number,
 			Overview:  ep.Overview,
 			Thumbnail: ep.Image,
+			Runtime:   ep.Runtime,
 		}
 		if ep.Aired != "" {
 			video.Released = ep.Aired + "T00:00:00.000Z"
@@ -551,6 +552,7 @@ func (s *Server) buildSeriesMetaFromTMDB(ctx context.Context, profile *config.Me
 				Season:   n,
 				Episode:  ep.EpisodeNumber,
 				Overview: ep.Overview,
+				Runtime:  ep.Runtime,
 			}
 			if ep.AirDate != "" {
 				video.Released = ep.AirDate + "T00:00:00.000Z"

--- a/pkg/server/stremio/handlers_meta.go
+++ b/pkg/server/stremio/handlers_meta.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -446,8 +447,8 @@ func (s *Server) buildSeriesMetaFromTVDB(ctx context.Context, profile *config.Me
 	}
 	overlay := s.tvmazeEpisodeOverlay(ctx, profile, rid.imdbID, tvdbID)
 	for _, ep := range episodes {
-		// Season 0 is specials; out of scope for the videos array.
-		if ep.SeasonNumber < 1 || ep.Number < 1 {
+		// Season 0 is specials: listed, ordered after the numbered seasons.
+		if ep.SeasonNumber < 0 || ep.Number < 1 {
 			continue
 		}
 		video := MetaVideo{
@@ -465,7 +466,16 @@ func (s *Server) buildSeriesMetaFromTVDB(ctx context.Context, profile *config.Me
 		applyTVMazeOverlay(&video, overlay)
 		meta.Videos = append(meta.Videos, video)
 	}
+	specialsLast(meta.Videos)
 	return meta, nil
+}
+
+// specialsLast keeps the provider's episode order but moves season 0 to the
+// end, so a client walking the list sees the numbered seasons first.
+func specialsLast(videos []MetaVideo) {
+	sort.SliceStable(videos, func(i, j int) bool {
+		return videos[i].Season != 0 && videos[j].Season == 0
+	})
 }
 
 func (s *Server) buildSeriesMetaFromTMDB(ctx context.Context, profile *config.MetadataProfileConfig, contentType string, rid *resolvedMetaID) (*MetaObject, error) {
@@ -492,11 +502,18 @@ func (s *Server) buildSeriesMetaFromTMDB(ctx context.Context, profile *config.Me
 	}
 
 	var seasonNumbers []int
+	hasSpecials := false
 	for _, si := range details.Seasons {
-		// Season 0 is specials; out of scope for the videos array.
-		if si.SeasonNumber >= 1 {
+		switch {
+		case si.SeasonNumber >= 1:
 			seasonNumbers = append(seasonNumbers, si.SeasonNumber)
+		case si.SeasonNumber == 0:
+			hasSpecials = true
 		}
+	}
+	// Season 0 is specials: fetched with the rest, listed after them.
+	if hasSpecials {
+		seasonNumbers = append(seasonNumbers, 0)
 	}
 	_, seasons, err := rt.tmdbClient.GetTVDetailsWithSeasons(rid.tmdbID, seasonNumbers, profile.EffectiveLanguage())
 	if err != nil {

--- a/pkg/server/stremio/handlers_meta_test.go
+++ b/pkg/server/stremio/handlers_meta_test.go
@@ -365,11 +365,15 @@ func withTVDBStub(t *testing.T, srv *Server, handler http.HandlerFunc) {
 // from TVDB (resolved from the imdb id), with TVMaze still owning air dates.
 func TestBuildSeriesMetaTVDBPrimary(t *testing.T) {
 	tmdbStub := func(w http.ResponseWriter, r *http.Request) {
-		if strings.Contains(r.URL.Path, "/find/") {
+		switch {
+		case strings.Contains(r.URL.Path, "/find/"):
 			_, _ = w.Write([]byte(`{"tv_results": [{"id": 1399}]}`))
-			return
+		case strings.HasSuffix(r.URL.Path, "/tv/1399"):
+			// Only the rating is read from here on the TVDB path.
+			_, _ = w.Write([]byte(`{"id": 1399, "name": "Game of Thrones", "vote_average": 8.4}`))
+		default:
+			http.NotFound(w, r)
 		}
-		http.NotFound(w, r)
 	}
 	tvmazeStub := func(w http.ResponseWriter, r *http.Request) {
 		switch {
@@ -428,6 +432,10 @@ func TestBuildSeriesMetaTVDBPrimary(t *testing.T) {
 	}
 	if meta.ReleaseInfo != "2011-2019" {
 		t.Fatalf("releaseInfo = %q, want the ended-run year range", meta.ReleaseInfo)
+	}
+	// TVDB has no 0-10 rating; the TMDB vote average fills it in.
+	if meta.IMDBRating != "8.4" {
+		t.Fatalf("imdbRating = %q, want TMDB's 8.4 on the TVDB path", meta.IMDBRating)
 	}
 	if len(meta.Trailers) != 1 || meta.Trailers[0].Source != "KPLWWIOCOOQ" {
 		t.Fatalf("trailers = %v", meta.Trailers)

--- a/pkg/server/stremio/handlers_meta_test.go
+++ b/pkg/server/stremio/handlers_meta_test.go
@@ -330,7 +330,7 @@ func tvdbStubHandler() http.HandlerFunc {
 		case r.URL.Path == "/series/121361/episodes/default":
 			_, _ = w.Write([]byte(`{"status": "success", "data": {"episodes": [
 				{"seasonNumber": 1, "number": 1, "name": "Winter Is Coming (TVDB)",
-				 "aired": "2011-04-17", "image": "https://artworks.thetvdb.com/e1.jpg"},
+				 "aired": "2011-04-17", "image": "https://artworks.thetvdb.com/e1.jpg", "runtime": 62},
 				{"seasonNumber": 0, "number": 1, "name": "Special", "aired": "2011-01-01"}
 			]}, "links": {"next": null}}`))
 		default:
@@ -403,6 +403,9 @@ func TestBuildSeriesMetaTVDBPrimary(t *testing.T) {
 	}
 	if ep.Thumbnail != "https://artworks.thetvdb.com/e1.jpg" {
 		t.Fatalf("thumbnail = %q, want TVDB's episode image", ep.Thumbnail)
+	}
+	if ep.Runtime != 62 {
+		t.Fatalf("runtime = %d, want the episode's own 62 min from TVDB", ep.Runtime)
 	}
 	// Details-panel enrichment: actors only, ended-run year range, trailer id.
 	if len(meta.Cast) != 2 || meta.Cast[0] != "Emilia Clarke" || meta.Cast[1] != "Kit Harington" {

--- a/pkg/server/stremio/handlers_meta_test.go
+++ b/pkg/server/stremio/handlers_meta_test.go
@@ -206,6 +206,9 @@ func TestBuildSeriesMetaWithTVMazeOverlay(t *testing.T) {
 					 "overview": "Ned Stark...", "air_date": "2011-04-17", "still_path": "/e1.jpg"},
 					{"episode_number": 2, "season_number": 1, "name": "The Kingsroad",
 					 "air_date": "2011-04-24"}
+				]},
+				"season/0": {"season_number": 0, "episodes": [
+					{"episode_number": 1, "season_number": 0, "name": "Inside Game of Thrones", "air_date": "2010-12-05"}
 				]}
 			}`))
 		default:
@@ -234,8 +237,11 @@ func TestBuildSeriesMetaWithTVMazeOverlay(t *testing.T) {
 	if meta.Name != "Game of Thrones" || meta.ID != "tt0944947" {
 		t.Fatalf("meta = %+v", meta)
 	}
-	if len(meta.Videos) != 2 {
-		t.Fatalf("videos = %d, want 2 (specials excluded)", len(meta.Videos))
+	if len(meta.Videos) != 3 {
+		t.Fatalf("videos = %d, want 3 (season 1, then the special)", len(meta.Videos))
+	}
+	if sp := meta.Videos[2]; sp.ID != "tt0944947:0:1" || sp.Season != 0 {
+		t.Fatalf("videos[2] = %+v, want the season-0 special listed last", sp)
 	}
 	ep1 := meta.Videos[0]
 	if ep1.ID != "tt0944947:1:1" {
@@ -390,8 +396,11 @@ func TestBuildSeriesMetaTVDBPrimary(t *testing.T) {
 	if meta.Poster != "https://artworks.thetvdb.com/got.jpg" || meta.Background != "https://artworks.thetvdb.com/got-fanart.jpg" {
 		t.Fatalf("artwork = %q / %q", meta.Poster, meta.Background)
 	}
-	if len(meta.Videos) != 1 {
-		t.Fatalf("videos = %d, want 1 (specials excluded)", len(meta.Videos))
+	if len(meta.Videos) != 2 {
+		t.Fatalf("videos = %d, want 2 (season 1, then the special)", len(meta.Videos))
+	}
+	if sp := meta.Videos[1]; sp.ID != "tt0944947:0:1" || sp.Season != 0 || sp.Title != "Special" {
+		t.Fatalf("videos[1] = %+v, want the season-0 special listed last", sp)
 	}
 	ep := meta.Videos[0]
 	if ep.ID != "tt0944947:1:1" {

--- a/pkg/server/stremio/meta_types.go
+++ b/pkg/server/stremio/meta_types.go
@@ -12,6 +12,9 @@ type MetaVideo struct {
 	Released  string `json:"released,omitempty"` // ISO 8601
 	Overview  string `json:"overview,omitempty"`
 	Thumbnail string `json:"thumbnail,omitempty"`
+	// Runtime is the episode's own length in minutes when the provider has
+	// one; 0 means unknown and callers fall back to the series average.
+	Runtime int `json:"runtime,omitempty"`
 }
 
 // MetaObject is a Stremio meta resource object. Cast, Director, Writer,

--- a/pkg/server/stremio/meta_types.go
+++ b/pkg/server/stremio/meta_types.go
@@ -79,6 +79,10 @@ type MetaPreview struct {
 	Poster      string `json:"poster,omitempty"`
 	Background  string `json:"background,omitempty"`
 	Description string `json:"description,omitempty"`
+	// ReleaseInfo and IMDBRating are the row's year and rating; catalog
+	// grids show both, and a row without them shows a blank badge.
+	ReleaseInfo string `json:"releaseInfo,omitempty"`
+	IMDBRating  string `json:"imdbRating,omitempty"`
 }
 
 // CatalogResponse is the /catalog/{type}/{id}.json envelope.

--- a/pkg/services/metadata/tmdb/client.go
+++ b/pkg/services/metadata/tmdb/client.go
@@ -593,6 +593,7 @@ type TVEpisodeInfo struct {
 	Overview      string `json:"overview"`
 	AirDate       string `json:"air_date"`
 	StillPath     string `json:"still_path"`
+	Runtime       int    `json:"runtime"` // minutes, 0 when TMDB has none
 }
 
 func (c *Client) GetMovieTitle(imdbID string, tmdbID string) (string, error) {

--- a/pkg/services/metadata/tmdb/client.go
+++ b/pkg/services/metadata/tmdb/client.go
@@ -114,17 +114,18 @@ type SearchMultiResponse struct {
 }
 
 type SearchMultiResult struct {
-	ID            int    `json:"id"`
-	Title         string `json:"title"`
-	Name          string `json:"name"`
-	MediaType     string `json:"media_type"`
-	ReleaseDate   string `json:"release_date"`
-	FirstAirDate  string `json:"first_air_date"`
-	OriginalTitle string `json:"original_title"`
-	OriginalName  string `json:"original_name"`
-	PosterPath    string `json:"poster_path"`
-	BackdropPath  string `json:"backdrop_path"`
-	Overview      string `json:"overview"`
+	ID            int     `json:"id"`
+	Title         string  `json:"title"`
+	Name          string  `json:"name"`
+	MediaType     string  `json:"media_type"`
+	ReleaseDate   string  `json:"release_date"`
+	FirstAirDate  string  `json:"first_air_date"`
+	OriginalTitle string  `json:"original_title"`
+	OriginalName  string  `json:"original_name"`
+	PosterPath    string  `json:"poster_path"`
+	BackdropPath  string  `json:"backdrop_path"`
+	Overview      string  `json:"overview"`
+	VoteAverage   float64 `json:"vote_average"`
 }
 
 type ExternalIDsResponse struct {

--- a/pkg/services/metadata/tvdb/client.go
+++ b/pkg/services/metadata/tvdb/client.go
@@ -634,6 +634,7 @@ type Episode struct {
 	Aired        string `json:"aired"`
 	Overview     string `json:"overview"`
 	Image        string `json:"image"`
+	Runtime      int    `json:"runtime"` // minutes, 0 when TVDB has none
 }
 
 type seriesEpisodesResponse struct {


### PR DESCRIPTION
Five series/episode metadata gaps, each its own commit so they can be taken separately. All measured live on `53144c6` through the Jellyfin API and on the Stremio meta route.

**1. Per-episode runtime** — every episode carried the series average (Squid Game S1: nine episodes, all 59:00). TVDB and TMDB both send `runtime` per episode; it now rides on `MetaVideo.Runtime` and `episodeItem` prefers it, falling back to the series average.

**2. Season 0 / Specials** — both series builders skipped season 0, so no client ever saw a Specials folder although `seasonItem`/`videosOf` already render one. Specials are now in the videos array, after the numbered seasons, on both the TVDB and TMDB paths.

**3. TVDB-path rating** — `buildSeriesMetaFromTVDB` never set a rating, so TVDB-sourced shows had no stars while TMDB-sourced ones did. TVDB's `score` is a popularity rank, not 0-10, so the TMDB `vote_average` fills it in when the TMDB id is known (cached details call); a TVDB-only series stays unrated rather than mis-scaled.

**4. Unaired episodes** — an episode with a future air date was listed like any other and resolved to zero sources (Lanterns S1 "TBA" → PlaybackInfo `NoCompatibleStream`). Jellyfin marks its own unaired entries `LocationType: Virtual` and clients grey them out; the layer now does the same. Unknown dates are left alone.

**5. Row year/rating** — list rows had no `ProductionYear`/`CommunityRating` even with both in `Fields`, so grid badges were blank. TMDB listings already return the date and vote average; they ride on the preview as `releaseInfo`/`imdbRating` (standard Stremio preview fields) and the Jellyfin row reads them.

**Tests** — each commit adds a case that fails on `53144c6` with the wiring removed:
```
server_test.go:805: episode 1 runtime = 0x5456f62e020, want the episode's own 58 min
handlers_meta_test.go:400: videos = 1, want 2 (season 1, then the special)
handlers_meta_test.go:438: imdbRating = "", want TMDB's 8.4 on the TVDB path
server_test.go:817: unaired episode: [...], want LocationType Virtual
server_test.go:876: row year/rating: [...]
```
`go test -count=1` on `pkg/server/jellyfin`, `pkg/server/stremio`, `pkg/services/metadata/{tvdb,tmdb}` green three times; `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ECZkfe3SPiUjSEtqS28AHf
