### PR TITLE
fix(jellyfin): fall back to provider artwork when the overlay is missing

### DIFF
--- a/docs/jellyfin.md
+++ b/docs/jellyfin.md
@@ -61,7 +61,10 @@ stream never sees another's.
 - **Images** — posters and backdrops are fetched from the provider's CDN and
   relayed by StreamNZB, because some clients (Infuse) do not follow redirects
   for artwork. TMDB images are requested at bounded sizes (backdrops 1280px
-  wide, posters 780px) and sent with a one-day cache header.
+  wide, posters 780px) and sent with a one-day cache header. A poster the
+  advertised URL cannot supply — a `poster_url_pattern` overlay with no image
+  for that title, typically — falls back to Metahub's poster for the IMDb id;
+  an image nobody has is a 404, never a redirect.
 - **Playback** — pressing play searches, ranks and returns every candidate
   release as a *media source*, best first. The client's media-source picker is
   therefore the stream list, and switching source is switching release. Each

--- a/pkg/server/jellyfin/images.go
+++ b/pkg/server/jellyfin/images.go
@@ -1,8 +1,10 @@
 package jellyfin
 
 import (
+	"bytes"
 	"crypto/sha1"
 	"encoding/hex"
+	"fmt"
 	"io"
 	"mime"
 	"net"
@@ -123,9 +125,10 @@ func (s *Server) serveImages(w http.ResponseWriter, rq *request) bool {
 	} else {
 		return false
 	}
+	fallbacks := s.imageFallbacks(rawID, kind)
 	if tag := rq.param("tag"); tag != "" {
 		if url, ok := s.images.urlFor(tag); ok {
-			s.relayImage(w, rq, url, kind)
+			s.relayImage(w, rq, kind, append([]string{url}, fallbacks...)...)
 			return true
 		}
 	}
@@ -135,16 +138,45 @@ func (s *Server) serveImages(w http.ResponseWriter, rq *request) bool {
 	// — and the resolve path below cannot help them, because an image is
 	// fetched by an image loader that sends no credentials.
 	if url, ok := s.itemImageURL(rawID, kind); ok {
-		s.relayImage(w, rq, url, kind)
+		s.relayImage(w, rq, kind, append([]string{url}, fallbacks...)...)
 		return true
 	}
 	url := s.resolveImage(rq, rawID, kind)
 	if url == "" {
-		http.NotFound(w, rq.Request)
+		if len(fallbacks) == 0 {
+			http.NotFound(w, rq.Request)
+			return true
+		}
+		s.relayImage(w, rq, kind, fallbacks...)
 		return true
 	}
-	s.relayImage(w, rq, url, kind)
+	s.relayImage(w, rq, kind, append([]string{url}, fallbacks...)...)
 	return true
+}
+
+// posterFallbackURL is where a poster comes from when the advertised one
+// cannot be fetched. The advertised URL may be a profile's poster overlay
+// (poster_url_pattern), which replaces the provider's poster before this layer
+// sees it, so the original is not available to fall back on; Metahub serves a
+// poster for any IMDb id without credentials — the same CDN the meta builder
+// already uses for logos — and is the one poster source reachable from an id
+// alone. A format string taking the IMDb id; a variable so tests can point it
+// at a local server.
+var posterFallbackURL = "https://images.metahub.space/poster/medium/%s/img"
+
+// imageFallbacks lists the URLs to try when an item's advertised image cannot
+// be relayed: today only a Metahub poster for the Primary image of an
+// IMDb-keyed movie or series. Episodes are left out — their Primary is a
+// still, and a series poster in its place would be wrong rather than missing.
+func (s *Server) imageFallbacks(rawID, kind string) []string {
+	if strings.ToLower(strings.TrimSpace(kind)) != "primary" {
+		return nil
+	}
+	id, err := decodeItemID(rawID)
+	if err != nil || id.Scheme != schemeIMDb || (id.Kind != kindMovie && id.Kind != kindSeries) {
+		return nil
+	}
+	return []string{fmt.Sprintf(posterFallbackURL, id.baseStremioID())}
 }
 
 // itemImageURL is the URL this item's document advertised for a kind, if one
@@ -247,16 +279,58 @@ func relayableImageType(raw string) (string, bool) {
 	return mediaType, true
 }
 
-// relayImage fetches url and streams it back as the response, instead of
-// redirecting the client to it: Infuse and some other clients ignore a 302
-// on an artwork request and are left with a blank image.
-func (s *Server) relayImage(w http.ResponseWriter, rq *request, rawURL, kind string) {
+// relayOutcome is what one attempt to relay a URL came to.
+type relayOutcome int
+
+const (
+	// relayServed: the response has been written; nothing more to do.
+	relayServed relayOutcome = iota
+	// relayMissing: the upstream has no such image (404, or a URL this layer
+	// cannot fetch). The next candidate may.
+	relayMissing
+	// relayFailed: the upstream misbehaved — unreachable, an error status, a
+	// body past the cap, a type that is not an image. The next candidate may
+	// still succeed, but if none does the client is told the gateway failed.
+	relayFailed
+)
+
+// relayImage fetches the first of urls that answers and streams it back as
+// the response, instead of redirecting the client to it: Infuse and some
+// other clients ignore a 302 on an artwork request and are left with a blank
+// image. Later urls are fallbacks, tried only when an earlier one is missing
+// or fails; when none serves, the client gets a 502 if any upstream failed
+// and a 404 when every one of them simply had no image.
+func (s *Server) relayImage(w http.ResponseWriter, rq *request, kind string, urls ...string) {
+	failed := false
+	for _, rawURL := range urls {
+		if rq.Context().Err() != nil {
+			// The client went away; no fallback is worth fetching for it.
+			return
+		}
+		switch s.relayOnce(w, rq, rawURL, kind) {
+		case relayServed:
+			return
+		case relayFailed:
+			failed = true
+		}
+	}
+	if failed {
+		http.Error(w, "bad gateway", http.StatusBadGateway)
+		return
+	}
+	http.NotFound(w, rq.Request)
+}
+
+// relayOnce attempts to relay one URL. It writes to w only when it serves the
+// image, so a failed attempt leaves the response untouched for the next.
+func (s *Server) relayOnce(w http.ResponseWriter, rq *request, rawURL, kind string) relayOutcome {
 	u, err := url.Parse(rawURL)
 	if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
-		// Nothing here to fetch on the client's behalf; the redirect is the
-		// only path left for a scheme this layer cannot relay.
-		http.Redirect(w, rq.Request, rawURL, http.StatusFound)
-		return
+		// Nothing here to fetch on the client's behalf, and a redirect is
+		// exactly what this relay exists to avoid: the clients that need
+		// relaying would not follow it either.
+		logger.Debug("Jellyfin image relay skipped", "url", rawURL, "reason", "not an http(s) url")
+		return relayMissing
 	}
 	target := rewriteImageSize(rawURL, kind)
 	// A GET is sent even for a HEAD request: some CDNs answer HEAD with the
@@ -264,8 +338,7 @@ func (s *Server) relayImage(w http.ResponseWriter, rq *request, rawURL, kind str
 	req, err := http.NewRequestWithContext(rq.Context(), http.MethodGet, target, nil)
 	if err != nil {
 		logger.Debug("Jellyfin image relay failed", "url", target, "err", err)
-		http.Error(w, "bad gateway", http.StatusBadGateway)
-		return
+		return relayFailed
 	}
 	resp, err := imageClient.Do(req)
 	if err != nil {
@@ -273,24 +346,29 @@ func (s *Server) relayImage(w http.ResponseWriter, rq *request, rawURL, kind str
 		// passed above, so the fetch dies with it instead of running to
 		// completion for no one.
 		logger.Debug("Jellyfin image relay failed", "url", target, "err", err)
-		http.Error(w, "bad gateway", http.StatusBadGateway)
-		return
+		return relayFailed
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		logger.Debug("Jellyfin image relay missing", "url", target)
+		return relayMissing
+	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		logger.Debug("Jellyfin image relay failed", "url", target, "status", resp.StatusCode)
-		http.Error(w, "bad gateway", http.StatusBadGateway)
-		return
+		return relayFailed
 	}
+	length := int64(-1)
 	if cl := resp.Header.Get("Content-Length"); cl != "" {
-		if n, err := strconv.ParseInt(cl, 10, 64); err == nil && n > maxImageBody {
-			// Refused before a header is written: a Content-Length promising
-			// more than the cap would otherwise reach the client alongside a
-			// body truncated well short of it.
-			logger.Debug("Jellyfin image relay refused", "url", target, "length", n)
-			http.Error(w, "bad gateway", http.StatusBadGateway)
-			return
+		if n, err := strconv.ParseInt(cl, 10, 64); err == nil {
+			length = n
 		}
+	}
+	if length > maxImageBody {
+		// Refused before a header is written: a Content-Length promising
+		// more than the cap would otherwise reach the client alongside a
+		// body truncated well short of it.
+		logger.Debug("Jellyfin image relay refused", "url", target, "length", length)
+		return relayFailed
 	}
 	ct, ok := relayableImageType(resp.Header.Get("Content-Type"))
 	if !ok {
@@ -299,13 +377,29 @@ func (s *Server) relayImage(w http.ResponseWriter, rq *request, rawURL, kind str
 		// which is exactly what an image relay must not do — image/svg+xml
 		// carries script, text/html plainly so.
 		logger.Debug("Jellyfin image relay refused", "url", target, "type", resp.Header.Get("Content-Type"))
-		http.Error(w, "bad gateway", http.StatusBadGateway)
-		return
+		return relayFailed
+	}
+	var body io.Reader = resp.Body
+	if length < 0 {
+		// No Content-Length: the cap can only be enforced by reading. Read to
+		// the cap plus one byte before any header is written, so an oversized
+		// body is refused outright instead of cut off mid-image behind a 200 —
+		// a client cannot tell a truncated JPEG from a whole one. Bounded by
+		// the cap, and rare: CDNs send a length for a static file.
+		buf, err := io.ReadAll(io.LimitReader(resp.Body, maxImageBody+1))
+		if err != nil {
+			logger.Debug("Jellyfin image relay failed", "url", target, "err", err)
+			return relayFailed
+		}
+		if len(buf) > maxImageBody {
+			logger.Debug("Jellyfin image relay refused", "url", target, "length", ">"+strconv.Itoa(maxImageBody))
+			return relayFailed
+		}
+		length = int64(len(buf))
+		body = bytes.NewReader(buf)
 	}
 	w.Header().Set("Content-Type", ct)
-	if cl := resp.Header.Get("Content-Length"); cl != "" {
-		w.Header().Set("Content-Length", cl)
-	}
+	w.Header().Set("Content-Length", strconv.FormatInt(length, 10))
 	if etag := resp.Header.Get("ETag"); etag != "" {
 		w.Header().Set("ETag", etag)
 	}
@@ -315,12 +409,12 @@ func (s *Server) relayImage(w http.ResponseWriter, rq *request, rawURL, kind str
 	w.Header().Set("Cache-Control", "public, max-age=86400")
 	w.WriteHeader(http.StatusOK)
 	if rq.Method == http.MethodHead {
-		return
+		return relayServed
 	}
-	written, _ := io.Copy(w, io.LimitReader(resp.Body, maxImageBody)) // write errors ignored: the client went away
-	if written == maxImageBody {
-		logger.Debug("Jellyfin image relay body truncated", "url", target, "limit", maxImageBody)
-	}
+	// A declared length is enforced by net/http on the upstream side: the body
+	// ends at Content-Length whatever the CDN sends after it.
+	io.Copy(w, body) // write errors ignored: the client went away
+	return relayServed
 }
 
 // rewriteImageSize points a TMDB image at a size proportional to how large

--- a/pkg/server/jellyfin/images_relay_test.go
+++ b/pkg/server/jellyfin/images_relay_test.go
@@ -1,6 +1,12 @@
 package jellyfin
 
-import "testing"
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+)
 
 // An image relay serves the upstream's bytes from this server's own origin, so
 // the upstream must not get to pick a content type the browser will execute.
@@ -25,5 +31,132 @@ func TestRelayableImageType(t *testing.T) {
 		if ok != tc.ok || got != tc.want {
 			t.Errorf("relayableImageType(%q) = (%q, %v), want (%q, %v)", tc.raw, got, ok, tc.want, tc.ok)
 		}
+	}
+}
+
+// The poster fallback is a real CDN in production; tests must never reach it.
+// It is pointed at the test CDN's always-404 path so a relay that exhausts its
+// candidates ends the way it would with no fallback, and a test that wants a
+// serving fallback swaps in a served path for its own duration.
+func init() {
+	posterFallbackURL = testCDNServer().URL + "/fallback-missing/%s"
+}
+
+func withPosterFallback(t *testing.T, pattern string) {
+	t.Helper()
+	prev := posterFallbackURL
+	posterFallbackURL = pattern
+	t.Cleanup(func() { posterFallbackURL = prev })
+}
+
+// A profile's poster overlay (poster_url_pattern) replaces the provider poster
+// before this layer sees it, so when the overlay has no image for a title the
+// relay would answer 502 and the title lost its artwork entirely. The relay
+// now falls back to a poster reachable from the IMDb id alone.
+func TestImageRelayOverlayMissingFallsBackToIMDbPoster(t *testing.T) {
+	f := newFixture()
+	cdn := testCDNServer().URL
+	withPosterFallback(t, cdn+"/fallback/%s")
+	f.catalog.metas["movie/tt0111161"].Poster = cdn + "/overlay-missing/tt0111161.jpg"
+	movie, _ := itemIDFor("movie", "tt0111161")
+	rec := f.do(http.MethodGet, "/jellyfin/Items/"+movie.encode()+"/Images/Primary", "")
+	if rec.Code != http.StatusOK || rec.Body.String() != "/fallback/tt0111161" {
+		t.Fatalf("overlay missing: %d %q, want 200 /fallback/tt0111161", rec.Code, rec.Body.String())
+	}
+	if cl := rec.Header().Get("Content-Length"); cl != strconv.Itoa(len("/fallback/tt0111161")) {
+		t.Fatalf("fallback content-length: %q", cl)
+	}
+}
+
+// Only a Primary poster of an IMDb-keyed movie or series has a fallback. An
+// episode's Primary is a still and a backdrop has no id-keyed source, so those
+// stay a plain miss.
+func TestImageRelayFallbackOnlyForIMDbPosters(t *testing.T) {
+	f := newFixture()
+	cdn := testCDNServer().URL
+	withPosterFallback(t, cdn+"/fallback/%s")
+	f.catalog.metas["movie/tt0111161"].Background = cdn + "/bg-missing.jpg"
+	movie, _ := itemIDFor("movie", "tt0111161")
+	if rec := f.do(http.MethodGet, "/jellyfin/Items/"+movie.encode()+"/Images/Backdrop", ""); rec.Code != http.StatusNotFound {
+		t.Fatalf("backdrop missing with a poster fallback configured: %d", rec.Code)
+	}
+	series, _ := itemIDFor("series", "tt0903747")
+	meta := f.catalog.metas["series/tt0903747"]
+	for i := range meta.Videos {
+		if meta.Videos[i].Season == 1 && meta.Videos[i].Episode == 1 {
+			meta.Videos[i].Thumbnail = cdn + "/still-missing.jpg"
+		}
+	}
+	ep := series.episode(1, 1)
+	if rec := f.do(http.MethodGet, "/jellyfin/Items/"+ep.encode()+"/Images/Primary", ""); rec.Code != http.StatusNotFound {
+		t.Fatalf("episode still missing: %d", rec.Code)
+	}
+}
+
+// When neither the advertised poster nor the fallback has an image, the
+// answer is a plain 404 — not a 502, which is for an upstream that failed,
+// and never a redirect, which the clients that need relaying ignore.
+func TestImageRelayAllMissingIsNotFound(t *testing.T) {
+	f := newFixture()
+	f.catalog.metas["movie/tt0111161"].Poster = testCDNServer().URL + "/overlay-missing/tt0111161.jpg"
+	movie, _ := itemIDFor("movie", "tt0111161")
+	rec := f.do(http.MethodGet, "/jellyfin/Items/"+movie.encode()+"/Images/Primary", "")
+	if rec.Code != http.StatusNotFound || rec.Header().Get("Location") != "" {
+		t.Fatalf("all missing: %d location=%q", rec.Code, rec.Header().Get("Location"))
+	}
+}
+
+// A poster URL this layer cannot fetch used to be answered with a redirect to
+// it — the one response the relay exists to avoid. It is a miss like any other.
+func TestImageRelayUnfetchableURLIsNotFoundNotRedirect(t *testing.T) {
+	f := newFixture()
+	for _, raw := range []string{"ftp://cdn.example/poster.jpg", "poster.jpg", "://bad"} {
+		f.catalog.metas["movie/tt0111161"].Poster = raw
+		movie, _ := itemIDFor("movie", "tt0111161")
+		rec := f.do(http.MethodGet, "/jellyfin/Items/"+movie.encode()+"/Images/Primary", "")
+		if rec.Code != http.StatusNotFound || rec.Header().Get("Location") != "" {
+			t.Fatalf("%q: %d location=%q, want 404 and no redirect", raw, rec.Code, rec.Header().Get("Location"))
+		}
+	}
+}
+
+// An upstream that sends no Content-Length can only be capped by reading.
+// A body past the cap used to be cut off behind a 200 — a truncated JPEG a
+// client cannot tell from a whole one. It is refused before any header goes
+// out; one under the cap is served whole, with the length it turned out to be.
+func TestImageRelayUnknownLengthBody(t *testing.T) {
+	small := strings.Repeat("x", 4096)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/jpeg")
+		w.Header().Set("Transfer-Encoding", "chunked") // no Content-Length
+		if strings.Contains(r.URL.Path, "huge") {
+			chunk := []byte(strings.Repeat("y", 1<<20))
+			for sent := 0; sent <= maxImageBody; sent += len(chunk) {
+				w.Write(chunk)
+			}
+			return
+		}
+		w.Write([]byte(small))
+	}))
+	defer upstream.Close()
+	f := newFixture()
+	movie, _ := itemIDFor("movie", "tt0111161")
+
+	f.catalog.metas["movie/tt0111161"].Background = upstream.URL + "/huge.jpg"
+	rec := f.do(http.MethodGet, "/jellyfin/Items/"+movie.encode()+"/Images/Backdrop", "")
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("oversized unknown-length body: %d, want 502", rec.Code)
+	}
+	if rec.Header().Get("Content-Type") == "image/jpeg" || strings.Contains(rec.Body.String(), "yyyy") {
+		t.Fatalf("oversized unknown-length body leaked: %+v %d bytes", rec.Header(), rec.Body.Len())
+	}
+
+	f.catalog.metas["movie/tt0111161"].Background = upstream.URL + "/small.jpg"
+	rec = f.do(http.MethodGet, "/jellyfin/Items/"+movie.encode()+"/Images/Backdrop", "")
+	if rec.Code != http.StatusOK || rec.Body.String() != small {
+		t.Fatalf("unknown-length body under the cap: %d %d bytes", rec.Code, rec.Body.Len())
+	}
+	if cl := rec.Header().Get("Content-Length"); cl != strconv.Itoa(len(small)) {
+		t.Fatalf("unknown-length body served without its length: %q", cl)
 	}
 }

--- a/pkg/server/jellyfin/server_test.go
+++ b/pkg/server/jellyfin/server_test.go
@@ -686,7 +686,9 @@ func TestImageRelayUpstream404(t *testing.T) {
 	f := newFixture()
 	f.catalog.metas["movie/tt0111161"].Poster = testCDNServer().URL + "/missing.jpg"
 	movie, _ := itemIDFor("movie", "tt0111161")
-	if rec := f.do(http.MethodGet, "/jellyfin/Items/"+movie.encode()+"/Images/Primary", ""); rec.Code != http.StatusBadGateway {
+	// A missing image is a miss, not a gateway failure: 404, once the fallback
+	// (pointed at a 404 path in tests) has been tried too.
+	if rec := f.do(http.MethodGet, "/jellyfin/Items/"+movie.encode()+"/Images/Primary", ""); rec.Code != http.StatusNotFound {
 		t.Fatalf("upstream 404: %d", rec.Code)
 	}
 }


### PR DESCRIPTION
Follow-up to #278 (image relay), after auditing it against the Jellyfin layer on `main`.

## Why
- A profile's `poster_url_pattern` overlay replaces the provider poster in the catalog and meta builders before the Jellyfin layer sees it. When the overlay host has no image for a title, the relay answered a bare **502** and the title lost its artwork entirely, although a perfectly good poster exists.
- A poster URL the relay cannot fetch (non-http scheme, malformed) fell back to a **302** to that URL — the one response the relay exists to avoid, since Infuse ignores redirects for artwork.
- An upstream body with no `Content-Length` past the 20 MiB cap was cut off behind a **200**: a truncated JPEG a client cannot tell from a whole one.

## What
- `relayImage` now takes an ordered list of candidates. For the Primary image of an IMDb-keyed movie or series it appends a Metahub poster (`images.metahub.space/poster/medium/{imdb}/img`, the CDN the meta builder already uses for logos, no credentials). Episodes and backdrops get no fallback: a series poster in a still's place would be wrong, not missing.
- Outcomes: served → 200; every candidate missing → **404**; any candidate failed (unreachable, 5xx, oversized, non-image type) → 502. Unfetchable URLs are a miss, never a redirect. Fallbacks are skipped once the client has gone away.
- Unknown-length bodies are read to cap+1 before any header is written; over the cap → 502, under → served whole with its real `Content-Length`. Known-length bodies stream as before.

Trade-off: the original provider poster is not reachable from the relay without changing the Stremio builders (`applyPosterOverlays`, `handlers_meta.go`), so the fallback is id-keyed rather than "the URL the overlay replaced". Happy to switch to carrying the original alongside the overlay if you prefer that shape.

## Tests
New in `images_relay_test.go`: overlay 404 → fallback served with its length; fallback only for IMDb posters (backdrop and episode still stay 404); all missing → 404 with no `Location`; `ftp://`, relative and malformed URLs → 404, no redirect; unknown-length oversized → 502 with nothing leaked, unknown-length small → 200 with `Content-Length`. The fallback pattern is pinned to the test CDN so no test reaches the network. On the unpatched relay these fail as expected:
```
overlay missing: 502 "bad gateway\n", want 200 /fallback/tt0111161
"ftp://cdn.example/poster.jpg": 302 location="ftp://cdn.example/poster.jpg", want 404 and no redirect
oversized unknown-length body: 200, want 502
```
`TestImageRelayUpstream404` now expects 404 instead of 502. `go vet` clean; `go test -count=1 ./pkg/server/jellyfin/` ×3 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ECZkfe3SPiUjSEtqS28AHf
