### PR TITLE
fix(kitsu): prefer English titles when the display language is English

### DIFF
--- a/pkg/server/stremio/handlers_catalog.go
+++ b/pkg/server/stremio/handlers_catalog.go
@@ -373,7 +373,7 @@ func (s *Server) kitsuCatalog(ctx context.Context, def CatalogDef, req catalogRe
 		previews = append(previews, MetaPreview{
 			ID:          "kitsu:" + item.ID,
 			Type:        "anime",
-			Name:        item.CanonicalTitle,
+			Name:        kitsu.DisplayTitle(req.Profile.EffectiveLanguage(), item.EnglishTitle, item.CanonicalTitle),
 			Poster:      item.PosterImage,
 			Background:  item.CoverImage,
 			Description: item.Synopsis,
@@ -901,7 +901,7 @@ func (s *Server) fillPreviewFromMetadata(ctx context.Context, preview *MetaPrevi
 	rt := s.runtime()
 	if kitsuID, ok := strings.CutPrefix(preview.ID, "kitsu:"); ok {
 		if animeMeta, err := s.kitsuClient.GetAnimeMeta(ctx, kitsuID); err == nil && animeMeta.CanonicalTitle != "" {
-			preview.Name = animeMeta.CanonicalTitle
+			preview.Name = kitsu.DisplayTitle(lang, animeMeta.EnglishTitle, animeMeta.CanonicalTitle)
 			preview.Poster = animeMeta.PosterImage
 			preview.Background = animeMeta.CoverImage
 		}

--- a/pkg/server/stremio/handlers_catalog.go
+++ b/pkg/server/stremio/handlers_catalog.go
@@ -364,7 +364,7 @@ func (s *Server) kitsuCatalog(ctx context.Context, def CatalogDef, req catalogRe
 	cap, capped := capForProfile(req.Profile)
 	previews := make([]MetaPreview, 0, len(listings))
 	for _, item := range listings {
-		if item.ID == "" || item.CanonicalTitle == "" {
+		if item.ID == "" || (item.CanonicalTitle == "" && item.EnglishTitle == "") {
 			continue
 		}
 		if capped && !cap.Allows(certification.NormalizeKitsu(item.AgeRating, item.Nsfw)) {

--- a/pkg/server/stremio/handlers_meta.go
+++ b/pkg/server/stremio/handlers_meta.go
@@ -15,6 +15,7 @@ import (
 	"streamnzb/pkg/core/logger"
 	"streamnzb/pkg/search/query"
 	"streamnzb/pkg/services/metadata/certification"
+	"streamnzb/pkg/services/metadata/kitsu"
 	"streamnzb/pkg/services/metadata/tmdb"
 	"streamnzb/pkg/services/metadata/tvdb"
 	"streamnzb/pkg/services/metadata/tvmaze"
@@ -682,10 +683,7 @@ func (s *Server) buildAnimeMeta(ctx context.Context, profile *config.MetadataPro
 	if err := certGateMeta(profile, certAge, certKnown); err != nil {
 		return nil, err
 	}
-	name := animeMeta.CanonicalTitle
-	if name == "" {
-		name = animeMeta.EnglishTitle
-	}
+	name := kitsu.DisplayTitle(profile.EffectiveLanguage(), animeMeta.EnglishTitle, animeMeta.CanonicalTitle)
 	meta := &MetaObject{
 		ID:          rid.canonicalID,
 		Type:        seriesMetaType(contentType),
@@ -715,7 +713,7 @@ func (s *Server) buildAnimeMeta(ctx context.Context, profile *config.MetadataPro
 			if ep.Number <= 0 {
 				continue
 			}
-			title := ep.CanonicalTitle
+			title := kitsu.DisplayTitle(profile.EffectiveLanguage(), ep.EnglishTitle, ep.CanonicalTitle)
 			if title == "" {
 				title = fmt.Sprintf("Episode %d", ep.Number)
 			}

--- a/pkg/server/stremio/handlers_meta_test.go
+++ b/pkg/server/stremio/handlers_meta_test.go
@@ -300,6 +300,48 @@ func TestBuildAnimeMeta(t *testing.T) {
 	}
 }
 
+func TestBuildAnimeMetaPrefersEnglishTitle(t *testing.T) {
+	kitsuStub := func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/episodes"):
+			_, _ = w.Write([]byte(`{"data": [
+				{"attributes": {"canonicalTitle": "Toubousha Miku", "titles": {"en": "The Runaway"}, "number": 1}}
+			]}`))
+		case strings.Contains(r.URL.Path, "/anime/1"):
+			_, _ = w.Write([]byte(`{"data": {"id": "1", "attributes": {
+				"canonicalTitle": "Shingeki no Kyojin", "titles": {"en": "Attack on Titan"},
+				"synopsis": "Humanity fights titans.", "showType": "TV"
+			}}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}
+	srv := metaTestServer(t, nil, nil, kitsuStub)
+
+	// English (default) profile: English title wins for both the series name
+	// and the episode title.
+	meta, err := srv.buildMeta(context.Background(), &config.MetadataProfileConfig{}, "anime", "kitsu:1")
+	if err != nil {
+		t.Fatalf("buildMeta: %v", err)
+	}
+	if meta.Name != "Attack on Titan" {
+		t.Fatalf("meta.Name = %q, want English title", meta.Name)
+	}
+	if len(meta.Videos) != 1 || meta.Videos[0].Title != "The Runaway" {
+		t.Fatalf("videos = %+v, want English episode title", meta.Videos)
+	}
+
+	// A non-English profile has nothing else to translate to, so it keeps
+	// Kitsu's canonical (romaji) title.
+	deMeta, err := srv.buildMeta(context.Background(), &config.MetadataProfileConfig{Language: "de-DE"}, "anime", "kitsu:1")
+	if err != nil {
+		t.Fatalf("buildMeta (de-DE): %v", err)
+	}
+	if deMeta.Name != "Shingeki no Kyojin" {
+		t.Fatalf("meta.Name (de-DE) = %q, want canonical title", deMeta.Name)
+	}
+}
+
 // tvdbStubHandler serves the TVDB endpoints the series meta path needs:
 // login, remoteid resolution from imdb, extended details, and episodes.
 func tvdbStubHandler() http.HandlerFunc {

--- a/pkg/services/metadata/kitsu/kitsu.go
+++ b/pkg/services/metadata/kitsu/kitsu.go
@@ -14,6 +14,21 @@ import (
 	"streamnzb/pkg/services/metadata/metacache"
 )
 
+// DisplayTitle picks the title to show a viewer: the English title when the
+// profile's display language is English or unset (Kitsu has no other
+// translations, so any other language keeps the canonical title). Falls back
+// to whichever of the two is non-empty.
+func DisplayTitle(lang, english, canonical string) string {
+	isEnglish := lang == "" || strings.EqualFold(lang, "en") || strings.EqualFold(lang, "en-US")
+	if isEnglish && english != "" {
+		return english
+	}
+	if canonical != "" {
+		return canonical
+	}
+	return english
+}
+
 type AnimeDetails struct {
 	ID             string   `json:"id"`
 	CanonicalTitle string   `json:"canonical_title"`
@@ -274,6 +289,7 @@ func (c *Client) GetAnimeMeta(ctx context.Context, kitsuID string) (*AnimeMeta, 
 type EpisodeInfo struct {
 	Number         int
 	CanonicalTitle string
+	EnglishTitle   string
 	Synopsis       string
 	Airdate        string
 	Thumbnail      string
@@ -291,10 +307,13 @@ type episodesAPIResponse struct {
 	Data []struct {
 		Attributes struct {
 			CanonicalTitle string `json:"canonicalTitle"`
-			Synopsis       string `json:"synopsis"`
-			Number         int    `json:"number"`
-			Airdate        string `json:"airdate"`
-			Thumbnail      struct {
+			Titles         struct {
+				EN string `json:"en"`
+			} `json:"titles"`
+			Synopsis  string `json:"synopsis"`
+			Number    int    `json:"number"`
+			Airdate   string `json:"airdate"`
+			Thumbnail struct {
 				Original string `json:"original"`
 			} `json:"thumbnail"`
 		} `json:"attributes"`
@@ -328,6 +347,7 @@ func (c *Client) GetAnimeEpisodes(ctx context.Context, kitsuID string) ([]Episod
 			episodes = append(episodes, EpisodeInfo{
 				Number:         ep.Attributes.Number,
 				CanonicalTitle: strings.TrimSpace(ep.Attributes.CanonicalTitle),
+				EnglishTitle:   strings.TrimSpace(ep.Attributes.Titles.EN),
 				Synopsis:       strings.TrimSpace(ep.Attributes.Synopsis),
 				Airdate:        ep.Attributes.Airdate,
 				Thumbnail:      ep.Attributes.Thumbnail.Original,
@@ -347,6 +367,7 @@ const listingCacheTTL = 3 * time.Hour
 type AnimeListing struct {
 	ID             string
 	CanonicalTitle string
+	EnglishTitle   string
 	Synopsis       string
 	PosterImage    string
 	CoverImage     string
@@ -359,10 +380,13 @@ type listingAPIResponse struct {
 		ID         string `json:"id"`
 		Attributes struct {
 			CanonicalTitle string `json:"canonicalTitle"`
-			Synopsis       string `json:"synopsis"`
-			AgeRating      string `json:"ageRating"`
-			Nsfw           bool   `json:"nsfw"`
-			PosterImage    struct {
+			Titles         struct {
+				EN string `json:"en"`
+			} `json:"titles"`
+			Synopsis    string `json:"synopsis"`
+			AgeRating   string `json:"ageRating"`
+			Nsfw        bool   `json:"nsfw"`
+			PosterImage struct {
 				Medium   string `json:"medium"`
 				Original string `json:"original"`
 			} `json:"posterImage"`
@@ -423,6 +447,7 @@ func (c *Client) getListing(ctx context.Context, path string) ([]AnimeListing, e
 		listings = append(listings, AnimeListing{
 			ID:             item.ID,
 			CanonicalTitle: strings.TrimSpace(item.Attributes.CanonicalTitle),
+			EnglishTitle:   strings.TrimSpace(item.Attributes.Titles.EN),
 			Synopsis:       strings.TrimSpace(item.Attributes.Synopsis),
 			PosterImage:    poster,
 			CoverImage:     item.Attributes.CoverImage.Original,

--- a/pkg/services/metadata/kitsu/kitsu_test.go
+++ b/pkg/services/metadata/kitsu/kitsu_test.go
@@ -66,3 +66,85 @@ func TestKitsuClientGetAnimeDetailsWithMappings(t *testing.T) {
 		t.Fatalf("expected IMDbID tt0168366, got %s", details.IMDbID)
 	}
 }
+
+func TestDisplayTitle(t *testing.T) {
+	cases := []struct {
+		name      string
+		lang      string
+		english   string
+		canonical string
+		want      string
+	}{
+		{"empty language prefers English", "", "Attack on Titan", "Shingeki no Kyojin", "Attack on Titan"},
+		{"en prefers English", "en", "Attack on Titan", "Shingeki no Kyojin", "Attack on Titan"},
+		{"en-US prefers English", "en-US", "Attack on Titan", "Shingeki no Kyojin", "Attack on Titan"},
+		{"non-English keeps canonical", "de-DE", "Attack on Titan", "Shingeki no Kyojin", "Shingeki no Kyojin"},
+		{"English requested but missing falls back to canonical", "en", "", "Shingeki no Kyojin", "Shingeki no Kyojin"},
+		{"neither carries a canonical falls back to English", "de-DE", "Attack on Titan", "", "Attack on Titan"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := DisplayTitle(tc.lang, tc.english, tc.canonical)
+			if got != tc.want {
+				t.Fatalf("DisplayTitle(%q, %q, %q) = %q, want %q", tc.lang, tc.english, tc.canonical, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGetAnimeEpisodesDecodesEnglishTitle(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data": [
+			{"attributes": {"canonicalTitle": "Toubousha Miku", "titles": {"en": "The Runaway"},
+			 "number": 1, "airdate": "2013-04-06"}}
+		]}`))
+	}))
+	defer ts.Close()
+
+	client := NewClient(ts.Client())
+	client.BaseURL = ts.URL
+
+	episodes, err := client.GetAnimeEpisodes(context.Background(), "1")
+	if err != nil {
+		t.Fatalf("GetAnimeEpisodes failed: %v", err)
+	}
+	if len(episodes) != 1 {
+		t.Fatalf("episodes = %d, want 1", len(episodes))
+	}
+	if episodes[0].CanonicalTitle != "Toubousha Miku" {
+		t.Fatalf("CanonicalTitle = %q", episodes[0].CanonicalTitle)
+	}
+	if episodes[0].EnglishTitle != "The Runaway" {
+		t.Fatalf("EnglishTitle = %q, want %q", episodes[0].EnglishTitle, "The Runaway")
+	}
+}
+
+func TestGetAnimeListingDecodesEnglishTitle(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data": [
+			{"id": "42", "attributes": {"canonicalTitle": "Shingeki no Kyojin", "titles": {"en": "Attack on Titan"},
+			 "synopsis": "Humanity fights titans.", "ageRating": "R",
+			 "posterImage": {"original": "https://img/poster.jpg"}}}
+		]}`))
+	}))
+	defer ts.Close()
+
+	client := NewClient(ts.Client())
+	client.BaseURL = ts.URL
+
+	listings, err := client.GetAnimeListing(context.Background(), "trending", 0)
+	if err != nil {
+		t.Fatalf("GetAnimeListing failed: %v", err)
+	}
+	if len(listings) != 1 {
+		t.Fatalf("listings = %d, want 1", len(listings))
+	}
+	if listings[0].CanonicalTitle != "Shingeki no Kyojin" {
+		t.Fatalf("CanonicalTitle = %q", listings[0].CanonicalTitle)
+	}
+	if listings[0].EnglishTitle != "Attack on Titan" {
+		t.Fatalf("EnglishTitle = %q, want %q", listings[0].EnglishTitle, "Attack on Titan")
+	}
+}


### PR DESCRIPTION
## Why

Every anime title is Kitsu's `canonicalTitle` (romaji), regardless of the
profile's display language. Live on a default (English) profile:

- Trending Anime rows: "Boku no Hero Academia", "Super no Ura de Yani Suu
  Futari" instead of their English names
- Episode titles: Kitsu's raw Japanese `canonicalTitle` per episode

Kitsu's `titles.en` was already decoded onto `AnimeMeta.EnglishTitle` for
meta detail (`GetAnimeMeta`), but `buildAnimeMeta` never preferred it over
`CanonicalTitle`. Episode (`GetAnimeEpisodes`) and listing
(`GetAnimeListing`/`SearchAnime`/kids) requests never decoded `titles.en`
at all.

## What

- `kitsu.DisplayTitle(lang, english, canonical)`: returns the English title
  when the language is English or unset (Kitsu carries no other
  translations), else the canonical title, with a same-field fallback if
  the preferred one is empty.
- `EpisodeInfo` and `AnimeListing` now decode `titles.en` alongside
  `canonicalTitle`.
- Every anime title call site uses the helper: `buildAnimeMeta` (series
  name), episode titles in the same function, `kitsuCatalog` (catalog
  rows), and `fillPreviewFromMetadata` (continue-watching/latest rows).

## Tests

`kitsu` package: `TestDisplayTitle` (table), `TestGetAnimeEpisodesDecodesEnglishTitle`,
`TestGetAnimeListingDecodesEnglishTitle`. `stremio` package:
`TestBuildAnimeMetaPrefersEnglishTitle` (English profile gets the English
series name and episode title; a `de-DE` profile keeps canonical, since
Kitsu has nothing else to offer it).

Proven failing on unpatched `main`:
```
pkg/services/metadata/kitsu/kitsu_test.go:87:11: undefined: DisplayTitle
pkg/services/metadata/kitsu/kitsu_test.go:118:17: episodes[0].EnglishTitle undefined
pkg/services/metadata/kitsu/kitsu_test.go:147:17: listings[0].EnglishTitle undefined
--- FAIL: TestBuildAnimeMetaPrefersEnglishTitle
    handlers_meta_test.go:328: meta.Name = "Shingeki no Kyojin", want English title
```

`go test -count=1 ./pkg/services/metadata/kitsu/... ./pkg/server/stremio/... ./pkg/server/jellyfin/...`
green x3, `go vet` clean, `gofmt -l` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ECZkfe3SPiUjSEtqS28AHf


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Catalog listings, series metadata, and episode metadata now display titles based on the selected profile language.
  - English profiles use available English titles, while other languages continue to use canonical titles.
  - Titles fall back to canonical or English values when a localized title is unavailable.

- **Bug Fixes**
  - Improved title consistency across catalog previews, series pages, and episode details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->