### PR TITLE
fix(persistence): break ties by id when listing search diagnostics

### DIFF
--- a/pkg/core/persistence/search_diagnostics.go
+++ b/pkg/core/persistence/search_diagnostics.go
@@ -115,7 +115,7 @@ func (m *StateManager) ListSearchDiagnostics(opts ListSearchDiagnosticsOptions) 
 		query += ` AND content_id = ?`
 		args = append(args, opts.ContentID)
 	}
-	query += ` ORDER BY created_at DESC LIMIT ?`
+	query += ` ORDER BY created_at DESC, id DESC LIMIT ?`
 	args = append(args, limit)
 
 	rows, err := m.db.Query(query, args...)

--- a/pkg/core/persistence/search_diagnostics_test.go
+++ b/pkg/core/persistence/search_diagnostics_test.go
@@ -3,6 +3,7 @@ package persistence
 import (
 	"fmt"
 	"testing"
+	"time"
 )
 
 func TestSearchDiagnosticsRoundTrip(t *testing.T) {
@@ -56,8 +57,14 @@ func TestSearchDiagnosticsEmptyPayloadIsDropped(t *testing.T) {
 
 func TestSearchDiagnosticsPruneKeepsNewestRows(t *testing.T) {
 	mgr := newTestStateManager(t)
+	// A fixed timestamp for every row deliberately ties them all: a fast
+	// insert loop routinely lands several hundred rows in the same
+	// millisecond in real use, so ordering must not depend on the clock
+	// resolving them, only on insertion (id) order.
+	same := time.Unix(1700000000, 0)
 	for i := 0; i < searchDiagnosticsKeepRows+25; i++ {
 		mgr.RecordSearchDiagnostic(SearchDiagnostic{
+			CreatedAt:   same,
 			ContentType: "movie",
 			ContentID:   fmt.Sprintf("tt%d", i),
 			Payload:     `{}`,


### PR DESCRIPTION
## What changed and why

`ListSearchDiagnostics` ordered rows by `created_at DESC` alone.
`RecordSearchDiagnostic` stamps millisecond resolution, and a busy
server (or a fast test loop) can insert far more than one diagnostic
per millisecond, so ties were broken by SQLite in whatever order the
query plan happened to produce -- not newest-first, and not guaranteed
stable between calls. The pruning query right below it already orders
by `id DESC` for exactly this reason ("ids are monotonic"); the listing
query now does too.

## How it was verified

`TestSearchDiagnosticsPruneKeepsNewestRows` stamped every row with
`time.Now()` in a tight loop, which occasionally (on fast hardware)
produced enough same-millisecond rows to flip the observed order --
an intermittent, hard-to-reproduce failure. Rewrote it to stamp every
row with the *same* timestamp, which ties them all and makes the bug
100% reproducible without the fix:

```
newest row = tt25, want tt524
```

With `id DESC` added as the tiebreaker, the same test passes
deterministically. `bash build.sh` equivalent run locally: `go fmt`,
`go vet ./...`, `go test ./...` and `go test -race ./pkg/core/persistence/...`
all clean.

## Checklist
- [x] `go fmt`, `go vet ./...`, `go test ./...` all pass locally
- [x] Title is a Conventional Commit
- [x] One change per PR
- [x] Test added that failed before the fix (deterministically, not by luck)
- [x] No user-facing behavior/setting to document
- [x] No build artifacts staged
