### PR TITLE
test(ffprobe): isolate PATH in the custom-path lookup test

### DIFF
--- a/pkg/media/ffprobe/ffprobe_test.go
+++ b/pkg/media/ffprobe/ffprobe_test.go
@@ -29,6 +29,10 @@ func TestFFprobeDownloadURL(t *testing.T) {
 }
 
 func TestFindFFprobeBinaryCustomPath(t *testing.T) {
+	// A missing custom path must not silently resolve to whatever ffprobe
+	// happens to be on PATH -- which many developer machines have (Homebrew,
+	// apt, ...) even though CI does not, which is why this only failed there.
+	t.Setenv("PATH", "")
 	_, ok := FindFFprobeBinary("non_existent_binary_path_xyz")
 	if ok {
 		t.Fatal("expected false for non-existent binary path")


### PR DESCRIPTION
## What changed and why

`TestFindFFprobeBinaryCustomPath` passes a non-existent custom path and
asserts `FindFFprobeBinary` returns false. But the function deliberately
falls back to PATH lookup when the custom path fails -- so the test only
ever passed on a machine with no `ffprobe` reachable at all. Any dev
machine with ffmpeg installed (Homebrew on macOS, apt on a dev container,
...) resolves the real binary via `exec.LookPath("ffprobe")` and fails
this test, even though the code is behaving exactly as documented. CI's
clean containers never installed ffprobe, so it never showed up there.

## How it was verified

Reproduced locally: `which ffprobe` → `/opt/homebrew/bin/ffprobe`, and
the unpatched test fails with `expected false for non-existent binary
path`. `t.Setenv("PATH", "")` for the duration of the test removes the
fallback the test isn't trying to exercise; passed 3/3 runs afterward,
plus `-race`. `go vet ./...` and the full `go build`/`go test ./...`
pipeline also clean.

## Checklist
- [x] `go fmt`, `go vet ./...`, `go test ./...` all pass locally
- [x] Title is a Conventional Commit
- [x] One change per PR
- [x] Test-only change; no new behavior to test-for-a-test
- [x] No user-facing behavior/setting to document
- [x] No build artifacts staged
