### PR TITLE
fix(jellyfin): give each episode its own runtime

### DIFF
--- a/pkg/server/jellyfin/dto.go
+++ b/pkg/server/jellyfin/dto.go
@@ -179,6 +179,16 @@ func runtimeTicks(runtime string) *int64 {
 }
 
 // productionYear reads the leading year of "2019" or "2019-2023".
+// episodeRuntimeTicks prefers the episode's own length over the series
+// average: a finale or a special is rarely the average, and the client's
+// scrubber and "time left" read this number.
+func episodeRuntimeTicks(video stremio.MetaVideo, meta *stremio.MetaObject) *int64 {
+	if video.Runtime > 0 {
+		return int64Ptr(int64(video.Runtime) * 60 * ticksPerSecond)
+	}
+	return runtimeTicks(meta.Runtime)
+}
+
 func productionYear(releaseInfo string) *int {
 	if m := leadingYear.FindString(releaseInfo); m != "" {
 		y, _ := strconv.Atoi(m)
@@ -461,7 +471,7 @@ func (s *Server) episodeItem(seriesID itemID, meta *stremio.MetaObject, video st
 		SeasonName:        "Season " + strconv.Itoa(video.Season),
 		PremiereDate:      premiereDate(video.Released),
 		ProviderIDs:       providerIDs(id),
-		RunTimeTicks:      runtimeTicks(meta.Runtime),
+		RunTimeTicks:      episodeRuntimeTicks(video, meta),
 	}
 	if video.Season == 0 {
 		item.SeasonName = "Specials"

--- a/pkg/server/jellyfin/server_test.go
+++ b/pkg/server/jellyfin/server_test.go
@@ -263,7 +263,7 @@ func testCatalog() *fakeCatalog {
 		ID: "tt0903747", Type: "series", Name: "Breaking Bad", Poster: "https://img.test/bb.jpg", Background: cdn + "/bb-bg.jpg",
 		ReleaseInfo: "2008-2013", Released: "2008-01-20T00:00:00.000Z", Runtime: "49 min",
 		Videos: []stremio.MetaVideo{
-			{ID: "tt0903747:1:1", Title: "Pilot", Season: 1, Episode: 1, Released: "2008-01-20T00:00:00.000Z", Thumbnail: cdn + "/bb-s1e1.jpg"},
+			{ID: "tt0903747:1:1", Title: "Pilot", Season: 1, Episode: 1, Released: "2008-01-20T00:00:00.000Z", Thumbnail: cdn + "/bb-s1e1.jpg", Runtime: 58},
 			{ID: "tt0903747:1:2", Title: "Cat's in the Bag...", Season: 1, Episode: 2},
 			{ID: "tt0903747:2:1", Title: "Seven Thirty-Seven", Season: 2, Episode: 1},
 			{ID: "tt0903747:0:1", Title: "Minisode", Season: 0, Episode: 1},
@@ -798,6 +798,14 @@ func TestSeriesSeasonsAndEpisodes(t *testing.T) {
 	decodeInto(t, f.do(http.MethodGet, "/jellyfin/Shows/"+series.encode()+"/Episodes?SeasonId="+seasons.Items[0].ID, ""), &episodes)
 	if len(episodes.Items) != 2 || episodes.Items[0].Name != "Pilot" || *episodes.Items[0].IndexNumber != 1 || *episodes.Items[0].ParentIndexNumber != 1 {
 		t.Fatalf("episodes: %+v", episodes.Items)
+	}
+	// The pilot carries its own 58-minute runtime; the second episode has
+	// none and inherits the series average of 49.
+	if got := episodes.Items[0].RunTimeTicks; got == nil || *got != 58*60*ticksPerSecond {
+		t.Fatalf("episode 1 runtime = %v, want the episode's own 58 min", got)
+	}
+	if got := episodes.Items[1].RunTimeTicks; got == nil || *got != 49*60*ticksPerSecond {
+		t.Fatalf("episode 2 runtime = %v, want the series average 49 min", got)
 	}
 	ep := episodes.Items[0]
 	if ep.SeriesName != "Breaking Bad" || ep.SeasonID != seasons.Items[0].ID || ep.SeriesPrimaryImageTag == "" || ep.RunTimeTicks == nil || ep.UserData == nil {

--- a/pkg/server/stremio/handlers_meta.go
+++ b/pkg/server/stremio/handlers_meta.go
@@ -457,6 +457,7 @@ func (s *Server) buildSeriesMetaFromTVDB(ctx context.Context, profile *config.Me
 			Episode:   ep.Number,
 			Overview:  ep.Overview,
 			Thumbnail: ep.Image,
+			Runtime:   ep.Runtime,
 		}
 		if ep.Aired != "" {
 			video.Released = ep.Aired + "T00:00:00.000Z"
@@ -551,6 +552,7 @@ func (s *Server) buildSeriesMetaFromTMDB(ctx context.Context, profile *config.Me
 				Season:   n,
 				Episode:  ep.EpisodeNumber,
 				Overview: ep.Overview,
+				Runtime:  ep.Runtime,
 			}
 			if ep.AirDate != "" {
 				video.Released = ep.AirDate + "T00:00:00.000Z"

--- a/pkg/server/stremio/handlers_meta_test.go
+++ b/pkg/server/stremio/handlers_meta_test.go
@@ -330,7 +330,7 @@ func tvdbStubHandler() http.HandlerFunc {
 		case r.URL.Path == "/series/121361/episodes/default":
 			_, _ = w.Write([]byte(`{"status": "success", "data": {"episodes": [
 				{"seasonNumber": 1, "number": 1, "name": "Winter Is Coming (TVDB)",
-				 "aired": "2011-04-17", "image": "https://artworks.thetvdb.com/e1.jpg"},
+				 "aired": "2011-04-17", "image": "https://artworks.thetvdb.com/e1.jpg", "runtime": 62},
 				{"seasonNumber": 0, "number": 1, "name": "Special", "aired": "2011-01-01"}
 			]}, "links": {"next": null}}`))
 		default:
@@ -403,6 +403,9 @@ func TestBuildSeriesMetaTVDBPrimary(t *testing.T) {
 	}
 	if ep.Thumbnail != "https://artworks.thetvdb.com/e1.jpg" {
 		t.Fatalf("thumbnail = %q, want TVDB's episode image", ep.Thumbnail)
+	}
+	if ep.Runtime != 62 {
+		t.Fatalf("runtime = %d, want the episode's own 62 min from TVDB", ep.Runtime)
 	}
 	// Details-panel enrichment: actors only, ended-run year range, trailer id.
 	if len(meta.Cast) != 2 || meta.Cast[0] != "Emilia Clarke" || meta.Cast[1] != "Kit Harington" {

--- a/pkg/server/stremio/meta_types.go
+++ b/pkg/server/stremio/meta_types.go
@@ -12,6 +12,9 @@ type MetaVideo struct {
 	Released  string `json:"released,omitempty"` // ISO 8601
 	Overview  string `json:"overview,omitempty"`
 	Thumbnail string `json:"thumbnail,omitempty"`
+	// Runtime is the episode's own length in minutes when the provider has
+	// one; 0 means unknown and callers fall back to the series average.
+	Runtime int `json:"runtime,omitempty"`
 }
 
 // MetaObject is a Stremio meta resource object. Cast, Director, Writer,

--- a/pkg/services/metadata/tmdb/client.go
+++ b/pkg/services/metadata/tmdb/client.go
@@ -593,6 +593,7 @@ type TVEpisodeInfo struct {
 	Overview      string `json:"overview"`
 	AirDate       string `json:"air_date"`
 	StillPath     string `json:"still_path"`
+	Runtime       int    `json:"runtime"` // minutes, 0 when TMDB has none
 }
 
 func (c *Client) GetMovieTitle(imdbID string, tmdbID string) (string, error) {

--- a/pkg/services/metadata/tvdb/client.go
+++ b/pkg/services/metadata/tvdb/client.go
@@ -634,6 +634,7 @@ type Episode struct {
 	Aired        string `json:"aired"`
 	Overview     string `json:"overview"`
 	Image        string `json:"image"`
+	Runtime      int    `json:"runtime"` // minutes, 0 when TVDB has none
 }
 
 type seriesEpisodesResponse struct {


### PR DESCRIPTION
## What changed and why

Every episode carried the series average runtime: nine Squid Game
episodes all reported 59:00 regardless of the episode's own length. TVDB
and TMDB both send a per-episode runtime, so it now rides on `MetaVideo`
and the episode item prefers it, falling back to the series average
when the provider has none.

Split out of #302 (which bundled five unrelated fixes) per one-change-
per-PR.

## How it was verified

`TestSeriesSeasonsAndEpisodes`: the pilot carries its own 58-minute
runtime; an episode with no per-episode runtime inherits the series
average of 49. `go fmt`, `go vet ./...`, `go test ./...` (full repo)
all clean, `-race` clean.

## Checklist
- [x] `go fmt`, `go vet ./...`, `go test ./...` pass locally
- [x] Title is a Conventional Commit
- [x] One change per PR
- [x] Test added that failed before the fix
- [x] No user-facing setting to document
- [x] No build artifacts staged
