### PR TITLE
fix(meta): list season 0 specials after the numbered seasons

### DIFF
--- a/pkg/server/stremio/handlers_meta.go
+++ b/pkg/server/stremio/handlers_meta.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -446,8 +447,8 @@ func (s *Server) buildSeriesMetaFromTVDB(ctx context.Context, profile *config.Me
 	}
 	overlay := s.tvmazeEpisodeOverlay(ctx, profile, rid.imdbID, tvdbID)
 	for _, ep := range episodes {
-		// Season 0 is specials; out of scope for the videos array.
-		if ep.SeasonNumber < 1 || ep.Number < 1 {
+		// Season 0 is specials: listed, ordered after the numbered seasons.
+		if ep.SeasonNumber < 0 || ep.Number < 1 {
 			continue
 		}
 		video := MetaVideo{
@@ -464,7 +465,16 @@ func (s *Server) buildSeriesMetaFromTVDB(ctx context.Context, profile *config.Me
 		applyTVMazeOverlay(&video, overlay)
 		meta.Videos = append(meta.Videos, video)
 	}
+	specialsLast(meta.Videos)
 	return meta, nil
+}
+
+// specialsLast keeps the provider's episode order but moves season 0 to the
+// end, so a client walking the list sees the numbered seasons first.
+func specialsLast(videos []MetaVideo) {
+	sort.SliceStable(videos, func(i, j int) bool {
+		return videos[i].Season != 0 && videos[j].Season == 0
+	})
 }
 
 func (s *Server) buildSeriesMetaFromTMDB(ctx context.Context, profile *config.MetadataProfileConfig, contentType string, rid *resolvedMetaID) (*MetaObject, error) {
@@ -491,11 +501,18 @@ func (s *Server) buildSeriesMetaFromTMDB(ctx context.Context, profile *config.Me
 	}
 
 	var seasonNumbers []int
+	hasSpecials := false
 	for _, si := range details.Seasons {
-		// Season 0 is specials; out of scope for the videos array.
-		if si.SeasonNumber >= 1 {
+		switch {
+		case si.SeasonNumber >= 1:
 			seasonNumbers = append(seasonNumbers, si.SeasonNumber)
+		case si.SeasonNumber == 0:
+			hasSpecials = true
 		}
+	}
+	// Season 0 is specials: fetched with the rest, listed after them.
+	if hasSpecials {
+		seasonNumbers = append(seasonNumbers, 0)
 	}
 	_, seasons, err := rt.tmdbClient.GetTVDetailsWithSeasons(rid.tmdbID, seasonNumbers, profile.EffectiveLanguage())
 	if err != nil {

--- a/pkg/server/stremio/handlers_meta_test.go
+++ b/pkg/server/stremio/handlers_meta_test.go
@@ -206,6 +206,9 @@ func TestBuildSeriesMetaWithTVMazeOverlay(t *testing.T) {
 					 "overview": "Ned Stark...", "air_date": "2011-04-17", "still_path": "/e1.jpg"},
 					{"episode_number": 2, "season_number": 1, "name": "The Kingsroad",
 					 "air_date": "2011-04-24"}
+				]},
+				"season/0": {"season_number": 0, "episodes": [
+					{"episode_number": 1, "season_number": 0, "name": "Inside Game of Thrones", "air_date": "2010-12-05"}
 				]}
 			}`))
 		default:
@@ -234,8 +237,11 @@ func TestBuildSeriesMetaWithTVMazeOverlay(t *testing.T) {
 	if meta.Name != "Game of Thrones" || meta.ID != "tt0944947" {
 		t.Fatalf("meta = %+v", meta)
 	}
-	if len(meta.Videos) != 2 {
-		t.Fatalf("videos = %d, want 2 (specials excluded)", len(meta.Videos))
+	if len(meta.Videos) != 3 {
+		t.Fatalf("videos = %d, want 3 (season 1, then the special)", len(meta.Videos))
+	}
+	if sp := meta.Videos[2]; sp.ID != "tt0944947:0:1" || sp.Season != 0 {
+		t.Fatalf("videos[2] = %+v, want the season-0 special listed last", sp)
 	}
 	ep1 := meta.Videos[0]
 	if ep1.ID != "tt0944947:1:1" {
@@ -390,8 +396,11 @@ func TestBuildSeriesMetaTVDBPrimary(t *testing.T) {
 	if meta.Poster != "https://artworks.thetvdb.com/got.jpg" || meta.Background != "https://artworks.thetvdb.com/got-fanart.jpg" {
 		t.Fatalf("artwork = %q / %q", meta.Poster, meta.Background)
 	}
-	if len(meta.Videos) != 1 {
-		t.Fatalf("videos = %d, want 1 (specials excluded)", len(meta.Videos))
+	if len(meta.Videos) != 2 {
+		t.Fatalf("videos = %d, want 2 (season 1, then the special)", len(meta.Videos))
+	}
+	if sp := meta.Videos[1]; sp.ID != "tt0944947:0:1" || sp.Season != 0 || sp.Title != "Special" {
+		t.Fatalf("videos[1] = %+v, want the season-0 special listed last", sp)
 	}
 	ep := meta.Videos[0]
 	if ep.ID != "tt0944947:1:1" {


### PR DESCRIPTION
## What changed and why

Both series builders skipped season 0, so no client ever saw a
Specials folder even though the Jellyfin layer already renders one.
Specials now ride in the videos array after the numbered seasons, on
the TVDB and TMDB paths alike.

Split out of #302 per one-change-per-PR.

## How it was verified

`TestBuildSeriesMetaWithTVMazeOverlay` (TMDB path) and
`TestBuildSeriesMetaTVDBPrimary` (TVDB path): the season-0 special is
now present and ordered last. `go fmt`, `go vet ./...`, `go test ./...`
clean, `-race` clean.

## Checklist
- [x] `go fmt`, `go vet ./...`, `go test ./...` pass locally
- [x] Title is a Conventional Commit
- [x] One change per PR
- [x] Test added that failed before the fix
- [x] No user-facing setting to document
- [x] No build artifacts staged
