### PR TITLE
fix(meta): rate TVDB-sourced series from TMDB's vote average

### DIFF
--- a/pkg/server/stremio/handlers_meta.go
+++ b/pkg/server/stremio/handlers_meta.go
@@ -422,6 +422,16 @@ func (s *Server) buildSeriesMetaFromTVDB(ctx context.Context, profile *config.Me
 	if ext.AverageRuntime > 0 {
 		meta.Runtime = fmt.Sprintf("%d min", ext.AverageRuntime)
 	}
+	// TVDB's "score" is a popularity rank, not a 0-10 rating, so the rating
+	// comes from TMDB when the id is known; a TVDB-only series stays unrated
+	// rather than carrying a number on the wrong scale.
+	if rid.tmdbID > 0 && rt.tmdbClient != nil {
+		if details, _, err := rt.tmdbClient.GetTVDetailsWithSeasons(rid.tmdbID, nil, profile.EffectiveLanguage()); err == nil && details.VoteAverage > 0 {
+			meta.IMDBRating = fmt.Sprintf("%.1f", details.VoteAverage)
+		} else if err != nil {
+			logger.Debug("TMDB rating lookup for TVDB series failed", "tmdb_id", rid.tmdbID, "err", err)
+		}
+	}
 	// The canonical id stays as requested; the fallback logo CDN needs imdb.
 	if rid.imdbID == "" {
 		rid.imdbID = ext.IMDbID()

--- a/pkg/server/stremio/handlers_meta_test.go
+++ b/pkg/server/stremio/handlers_meta_test.go
@@ -359,11 +359,15 @@ func withTVDBStub(t *testing.T, srv *Server, handler http.HandlerFunc) {
 // from TVDB (resolved from the imdb id), with TVMaze still owning air dates.
 func TestBuildSeriesMetaTVDBPrimary(t *testing.T) {
 	tmdbStub := func(w http.ResponseWriter, r *http.Request) {
-		if strings.Contains(r.URL.Path, "/find/") {
+		switch {
+		case strings.Contains(r.URL.Path, "/find/"):
 			_, _ = w.Write([]byte(`{"tv_results": [{"id": 1399}]}`))
-			return
+		case strings.HasSuffix(r.URL.Path, "/tv/1399"):
+			// Only the rating is read from here on the TVDB path.
+			_, _ = w.Write([]byte(`{"id": 1399, "name": "Game of Thrones", "vote_average": 8.4}`))
+		default:
+			http.NotFound(w, r)
 		}
-		http.NotFound(w, r)
 	}
 	tvmazeStub := func(w http.ResponseWriter, r *http.Request) {
 		switch {
@@ -416,6 +420,10 @@ func TestBuildSeriesMetaTVDBPrimary(t *testing.T) {
 	}
 	if meta.ReleaseInfo != "2011-2019" {
 		t.Fatalf("releaseInfo = %q, want the ended-run year range", meta.ReleaseInfo)
+	}
+	// TVDB has no 0-10 rating; the TMDB vote average fills it in.
+	if meta.IMDBRating != "8.4" {
+		t.Fatalf("imdbRating = %q, want TMDB's 8.4 on the TVDB path", meta.IMDBRating)
 	}
 	if len(meta.Trailers) != 1 || meta.Trailers[0].Source != "KPLWWIOCOOQ" {
 		t.Fatalf("trailers = %v", meta.Trailers)


### PR DESCRIPTION
## What changed and why

Series built from TVDB never carried a rating, so TMDB-sourced shows
had stars and TVDB-sourced ones did not. TVDB's `score` is a
popularity rank, not a 0-10 rating, so the TMDB vote average fills it
in when the TMDB id is known; a TVDB-only series stays unrated rather
than mis-scaled.

Split out of #302 per one-change-per-PR. Adds one cached TMDB `/tv/{id}`
call per TVDB-series detail view (series details + season data are not
requested, so it is a single lightweight lookup); flagging this cost
explicitly in case a different tradeoff is preferred.

## How it was verified

`TestBuildSeriesMetaTVDBPrimary`: `meta.IMDBRating` is `"8.4"` from
TMDB's vote average on the TVDB path. `go fmt`, `go vet ./...`,
`go test ./...` clean, `-race` clean.

## Checklist
- [x] `go fmt`, `go vet ./...`, `go test ./...` pass locally
- [x] Title is a Conventional Commit
- [x] One change per PR
- [x] Test added that failed before the fix
- [x] No user-facing setting to document
- [x] No build artifacts staged
