### PR TITLE
fix(jellyfin): mark unaired episodes Virtual

### DIFF
--- a/pkg/server/jellyfin/dto.go
+++ b/pkg/server/jellyfin/dto.go
@@ -187,6 +187,24 @@ func productionYear(releaseInfo string) *int {
 	return nil
 }
 
+// now is the clock unaired reads; tests pin it.
+var now = time.Now
+
+// unaired reports whether an episode's release date lies in the future. An
+// unknown date is not unaired: the provider may simply not have one.
+func unaired(released string) bool {
+	released = strings.TrimSpace(released)
+	if released == "" {
+		return false
+	}
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, "2006-01-02"} {
+		if t, err := time.Parse(layout, released); err == nil {
+			return t.After(now())
+		}
+	}
+	return false
+}
+
 // premiereDate normalises an ISO date to Jellyfin's timestamp form.
 func premiereDate(released string) string {
 	released = strings.TrimSpace(released)
@@ -465,6 +483,12 @@ func (s *Server) episodeItem(seriesID itemID, meta *stremio.MetaObject, video st
 	}
 	if video.Season == 0 {
 		item.SeasonName = "Specials"
+	}
+	// An episode that has not aired yet has nothing to play. Jellyfin marks
+	// its own unaired entries Virtual, and clients grey those out instead of
+	// offering a play button that ends in "no compatible stream".
+	if unaired(video.Released) {
+		item.LocationType = "Virtual"
 	}
 	// The episode still is its Primary image; the series poster and backdrop
 	// ride along as the parent's for the clients that show them.

--- a/pkg/server/jellyfin/server_test.go
+++ b/pkg/server/jellyfin/server_test.go
@@ -265,7 +265,7 @@ func testCatalog() *fakeCatalog {
 		Videos: []stremio.MetaVideo{
 			{ID: "tt0903747:1:1", Title: "Pilot", Season: 1, Episode: 1, Released: "2008-01-20T00:00:00.000Z", Thumbnail: cdn + "/bb-s1e1.jpg"},
 			{ID: "tt0903747:1:2", Title: "Cat's in the Bag...", Season: 1, Episode: 2},
-			{ID: "tt0903747:2:1", Title: "Seven Thirty-Seven", Season: 2, Episode: 1},
+			{ID: "tt0903747:2:1", Title: "Seven Thirty-Seven", Season: 2, Episode: 1, Released: "2099-01-01T00:00:00.000Z"},
 			{ID: "tt0903747:0:1", Title: "Minisode", Season: 0, Episode: 1},
 		},
 	}
@@ -798,6 +798,15 @@ func TestSeriesSeasonsAndEpisodes(t *testing.T) {
 	decodeInto(t, f.do(http.MethodGet, "/jellyfin/Shows/"+series.encode()+"/Episodes?SeasonId="+seasons.Items[0].ID, ""), &episodes)
 	if len(episodes.Items) != 2 || episodes.Items[0].Name != "Pilot" || *episodes.Items[0].IndexNumber != 1 || *episodes.Items[0].ParentIndexNumber != 1 {
 		t.Fatalf("episodes: %+v", episodes.Items)
+	}
+	if episodes.Items[0].LocationType != "FileSystem" {
+		t.Fatalf("aired episode LocationType = %q, want FileSystem", episodes.Items[0].LocationType)
+	}
+	// Season 2's only episode airs in 2099: listed, but Virtual.
+	var future queryResult
+	decodeInto(t, f.do(http.MethodGet, "/jellyfin/Shows/"+series.encode()+"/Episodes?SeasonId="+seasons.Items[1].ID, ""), &future)
+	if len(future.Items) != 1 || future.Items[0].LocationType != "Virtual" {
+		t.Fatalf("unaired episode: %+v, want LocationType Virtual", future.Items)
 	}
 	ep := episodes.Items[0]
 	if ep.SeriesName != "Breaking Bad" || ep.SeasonID != seasons.Items[0].ID || ep.SeriesPrimaryImageTag == "" || ep.RunTimeTicks == nil || ep.UserData == nil {


### PR DESCRIPTION
## What changed and why

An episode with a future air date was listed like any other and
resolved to zero sources, so a client offered a play button that ended
in `NoCompatibleStream`. Jellyfin marks its own unaired entries
`Virtual` and clients grey those out; the layer now does the same.
Unknown dates are left alone.

Split out of #302 per one-change-per-PR.

## How it was verified

`TestSeriesSeasonsAndEpisodes`: an aired episode keeps `LocationType`
`FileSystem`; an episode airing in 2099 is listed with `LocationType`
`Virtual`. `go fmt`, `go vet ./...`, `go test ./...` clean, `-race`
clean.

## Checklist
- [x] `go fmt`, `go vet ./...`, `go test ./...` pass locally
- [x] Title is a Conventional Commit
- [x] One change per PR
- [x] Test added that failed before the fix
- [x] No user-facing setting to document
- [x] No build artifacts staged
