### PR TITLE
fix(jellyfin): carry year and rating on catalog rows

### DIFF
--- a/pkg/server/jellyfin/dto.go
+++ b/pkg/server/jellyfin/dto.go
@@ -301,6 +301,8 @@ func (s *Server) previewItem(preview stremio.MetaPreview, parentID string) (*bas
 	item := s.newItem(id, preview.Name)
 	item.ParentID = parentID
 	item.Overview = preview.Description
+	item.ProductionYear = productionYear(preview.ReleaseInfo)
+	item.CommunityRating = communityRating(preview.IMDBRating)
 	s.setImages(item, id, preview.Poster, preview.Background, "")
 	return item, true
 }

--- a/pkg/server/jellyfin/server_test.go
+++ b/pkg/server/jellyfin/server_test.go
@@ -280,7 +280,7 @@ func testCatalog() *fakeCatalog {
 			"tmdb.trending.movie":  previews("movie", "tt", 45),
 			"tmdb.trending.series": previews("series", "tt", 3),
 			"kitsu.trending.anime": []stremio.MetaPreview{{ID: "kitsu:9", Type: "anime", Name: "Your Name."}},
-			"tmdb.search.movie":    []stremio.MetaPreview{{ID: "tt0111161", Type: "movie", Name: "The Shawshank Redemption"}},
+			"tmdb.search.movie":    []stremio.MetaPreview{{ID: "tt0111161", Type: "movie", Name: "The Shawshank Redemption", ReleaseInfo: "1994", IMDBRating: "9.3"}},
 			"tmdb.search.series":   []stremio.MetaPreview{{ID: "tt0903747", Type: "series", Name: "Breaking Bad"}},
 			"kitsu.search.anime":   nil,
 		},
@@ -849,9 +849,14 @@ func TestSearchRunsTheCarriers(t *testing.T) {
 	}
 	// A Movie-only search leaves the series carriers alone.
 	f.catalog.searches = nil
-	f.do(http.MethodGet, "/jellyfin/Users/u/Items?SearchTerm=shaw&Recursive=true&IncludeItemTypes=Movie", "")
+	var rows queryResult
+	decodeInto(t, f.do(http.MethodGet, "/jellyfin/Users/u/Items?SearchTerm=shaw&Recursive=true&IncludeItemTypes=Movie", ""), &rows)
 	if got := f.catalog.searchSet(); !reflect.DeepEqual(got, map[string]bool{"tmdb.search.movie=shaw": true}) {
 		t.Fatalf("movie-only searches run: %v", got)
+	}
+	// A list row carries the year and rating the grid badges show.
+	if len(rows.Items) != 1 || rows.Items[0].ProductionYear == nil || *rows.Items[0].ProductionYear != 1994 || rows.Items[0].CommunityRating == nil || *rows.Items[0].CommunityRating != 9.3 {
+		t.Fatalf("row year/rating: %+v", rows.Items)
 	}
 	var hints struct {
 		SearchHints      []searchHint

--- a/pkg/server/stremio/handlers_catalog.go
+++ b/pkg/server/stremio/handlers_catalog.go
@@ -233,6 +233,17 @@ func (s *Server) tmdbCatalog(_ context.Context, def CatalogDef, req catalogReque
 			id = fmt.Sprintf("tmdb:%d", res.ID)
 		}
 		preview := MetaPreview{ID: id, Type: def.Type, Name: name, Description: res.Overview}
+		if date := res.ReleaseDate; date != "" || res.FirstAirDate != "" {
+			if date == "" {
+				date = res.FirstAirDate
+			}
+			if len(date) >= 4 {
+				preview.ReleaseInfo = date[:4]
+			}
+		}
+		if res.VoteAverage > 0 {
+			preview.IMDBRating = fmt.Sprintf("%.1f", res.VoteAverage)
+		}
 		if res.PosterPath != "" {
 			preview.Poster = tmdbPosterURL + res.PosterPath
 		}

--- a/pkg/server/stremio/meta_types.go
+++ b/pkg/server/stremio/meta_types.go
@@ -76,6 +76,10 @@ type MetaPreview struct {
 	Poster      string `json:"poster,omitempty"`
 	Background  string `json:"background,omitempty"`
 	Description string `json:"description,omitempty"`
+	// ReleaseInfo and IMDBRating are the row's year and rating; catalog
+	// grids show both, and a row without them shows a blank badge.
+	ReleaseInfo string `json:"releaseInfo,omitempty"`
+	IMDBRating  string `json:"imdbRating,omitempty"`
 }
 
 // CatalogResponse is the /catalog/{type}/{id}.json envelope.

--- a/pkg/services/metadata/tmdb/client.go
+++ b/pkg/services/metadata/tmdb/client.go
@@ -114,17 +114,18 @@ type SearchMultiResponse struct {
 }
 
 type SearchMultiResult struct {
-	ID            int    `json:"id"`
-	Title         string `json:"title"`
-	Name          string `json:"name"`
-	MediaType     string `json:"media_type"`
-	ReleaseDate   string `json:"release_date"`
-	FirstAirDate  string `json:"first_air_date"`
-	OriginalTitle string `json:"original_title"`
-	OriginalName  string `json:"original_name"`
-	PosterPath    string `json:"poster_path"`
-	BackdropPath  string `json:"backdrop_path"`
-	Overview      string `json:"overview"`
+	ID            int     `json:"id"`
+	Title         string  `json:"title"`
+	Name          string  `json:"name"`
+	MediaType     string  `json:"media_type"`
+	ReleaseDate   string  `json:"release_date"`
+	FirstAirDate  string  `json:"first_air_date"`
+	OriginalTitle string  `json:"original_title"`
+	OriginalName  string  `json:"original_name"`
+	PosterPath    string  `json:"poster_path"`
+	BackdropPath  string  `json:"backdrop_path"`
+	Overview      string  `json:"overview"`
+	VoteAverage   float64 `json:"vote_average"`
 }
 
 type ExternalIDsResponse struct {


### PR DESCRIPTION
## What changed and why

Every list row went out without `ProductionYear` or `CommunityRating`,
so grid badges were blank even when the client asked for both in
`Fields`. TMDB listings already return the date and vote average; they
now ride on the preview as `releaseInfo` and `imdbRating` (the same
fields Stremio previews already carry), and the Jellyfin row reads
them.

Split out of #302 per one-change-per-PR.

## How it was verified

`TestSearchRunsTheCarriers`: a search result row carries `ProductionYear
1994` and `CommunityRating 9.3`. `go fmt`, `go vet ./...`,
`go test ./...` clean, `-race` clean.

## Checklist
- [x] `go fmt`, `go vet ./...`, `go test ./...` pass locally
- [x] Title is a Conventional Commit
- [x] One change per PR
- [x] Test added that failed before the fix
- [x] No user-facing setting to document
- [x] No build artifacts staged
