### PR TITLE
fix(jellyfin): do not end a library on a short provider page

### DIFF
--- a/pkg/server/jellyfin/items.go
+++ b/pkg/server/jellyfin/items.go
@@ -268,6 +268,13 @@ func page(items []*baseItem, start, limit int, open bool) queryResult {
 // in fixed buckets, so the request is mapped onto whole buckets and sliced;
 // a client whose page size is a multiple of the bucket lands exactly on
 // bucket edges, which is what every known client does.
+//
+// Positions are the addon's, not the row count served: a bucket comes back
+// short whenever the provider had rows the addon could not identify, so a
+// page may carry fewer rows than asked while the catalog goes on. Only an
+// empty bucket ends the catalog. When the last bucket in range is short the
+// next one is probed for that answer, so a true last page still reports an
+// exact total.
 func (s *Server) catalogPage(rq *request, def stremio.CatalogDef, start, limit int) queryResult {
 	result := emptyResult()
 	result.StartIndex = start
@@ -277,33 +284,57 @@ func (s *Server) catalogPage(rq *request, def stremio.CatalogDef, start, limit i
 	}
 	bucket := stremio.CatalogPageSize
 	firstPage, lastPage := start/bucket, (start+limit-1)/bucket
-	var rows []stremio.MetaPreview
-	short := false
+	parent := viewID(def.ID)
+	ended := false
 	for p := firstPage; p <= lastPage; p++ {
 		metas, err := s.opts.Catalog.Catalog(rq.Context(), rq.stream, def.ID, def.Type, "", p*bucket)
 		if err != nil {
 			logger.Debug("Jellyfin catalog page failed", "catalog", def.ID, "skip", p*bucket, "err", err)
-			short = true
+			ended = true
 			break
 		}
-		rows = append(rows, metas...)
-		if len(metas) < bucket || !def.SupportsSkip {
-			short = true
+		if len(metas) == 0 {
+			ended = true
 			break
 		}
-	}
-	offset := start - firstPage*bucket
-	parent := viewID(def.ID)
-	for i := offset; i < len(rows) && len(result.Items) < limit; i++ {
-		if item, ok := s.previewItem(rows[i], parent); ok {
-			result.Items = append(result.Items, item)
+		// Row j of bucket p sits at position p*bucket+j whatever the bucket
+		// lost, so a window is the same rows on every visit.
+		for j, preview := range metas {
+			pos := p*bucket + j
+			if pos < start || pos >= start+limit {
+				continue
+			}
+			if item, ok := s.previewItem(preview, parent); ok {
+				result.Items = append(result.Items, item)
+			}
+		}
+		if !def.SupportsSkip {
+			ended = true
+			break
+		}
+		if p == lastPage && len(metas) < bucket {
+			ended = s.catalogEndsAt(rq, def, (p+1)*bucket)
 		}
 	}
 	result.TotalRecordCount = start + len(result.Items)
-	if !short {
-		result.TotalRecordCount += bucket
+	if !ended {
+		// Open-ended, as page() reports it: past the window the client
+		// asked for, so a page thinned by dropped rows still reads as
+		// "more to come" rather than as the last one.
+		result.TotalRecordCount = start + limit + bucket
 	}
 	return result
+}
+
+// catalogEndsAt reports whether the bucket at skip is empty, which is the
+// only signal the addon gives that a catalog is exhausted.
+func (s *Server) catalogEndsAt(rq *request, def stremio.CatalogDef, skip int) bool {
+	metas, err := s.opts.Catalog.Catalog(rq.Context(), rq.stream, def.ID, def.Type, "", skip)
+	if err != nil {
+		logger.Debug("Jellyfin catalog page failed", "catalog", def.ID, "skip", skip, "err", err)
+		return true
+	}
+	return len(metas) == 0
 }
 
 // allItems is the listing without a folder — "everything of this type",

--- a/pkg/server/jellyfin/server_test.go
+++ b/pkg/server/jellyfin/server_test.go
@@ -72,6 +72,10 @@ type fakeCatalog struct {
 	playlistCalls int
 	served        []servedPlay
 	disabled      bool
+	// drop thins a bucket the way the addon does when a provider row has
+	// no id it can use: skip → rows removed from the end of that bucket.
+	drop         map[int]int
+	catalogCalls []int
 }
 
 // releaseCaps is what ffprobe measured on the candidate that played: a
@@ -108,6 +112,7 @@ func (f *fakeCatalog) Catalog(_ context.Context, _ *auth.Stream, catalogID, _, s
 		f.searches = append(f.searches, catalogID+"="+search)
 		return f.rows[catalogID], nil
 	}
+	f.catalogCalls = append(f.catalogCalls, skip)
 	rows := f.rows[catalogID]
 	if skip >= len(rows) {
 		return nil, nil
@@ -115,6 +120,9 @@ func (f *fakeCatalog) Catalog(_ context.Context, _ *auth.Stream, catalogID, _, s
 	rows = rows[skip:]
 	if len(rows) > stremio.CatalogPageSize {
 		rows = rows[:stremio.CatalogPageSize]
+	}
+	if n := f.drop[skip]; n > 0 && n <= len(rows) {
+		rows = rows[:len(rows)-n]
 	}
 	return rows, nil
 }
@@ -450,6 +458,55 @@ func TestTokenFormsAndCaseInsensitivity(t *testing.T) {
 	decodeInto(t, f.do(http.MethodGet, "/jellyfin/Items?PARENTID="+view+"&LIMIT=5", ""), &result)
 	if len(result.Items) != 5 {
 		t.Fatalf("upper-cased query: %d items", len(result.Items))
+	}
+}
+
+// A provider bucket comes back short whenever the addon drops rows it cannot
+// identify. That is not the end of the catalog: the client must be told to
+// keep paging, and the addon's positions must be kept so the next page
+// neither repeats nor skips rows.
+func TestShortBucketDoesNotEndCatalog(t *testing.T) {
+	f := newFixture()
+	f.catalog.rows["tmdb.trending.movie"] = previews("movie", "tt", 120)
+	f.catalog.drop = map[int]int{0: 2, 40: 1}
+	view := viewID("tmdb.trending.movie")
+	var result queryResult
+	decodeInto(t, f.do(http.MethodGet, "/jellyfin/Users/u/Items?ParentId="+view+"&StartIndex=0&Limit=100", ""), &result)
+	if len(result.Items) != 97 || result.Items[0].Name != "Title 1" || result.Items[96].Name != "Title 100" {
+		t.Fatalf("first page: %d items (want 97: 18+20+19+20+20), first %q last %q", len(result.Items), result.Items[0].Name, result.Items[len(result.Items)-1].Name)
+	}
+	if result.TotalRecordCount <= 100 {
+		t.Fatalf("a thinned page must still read as more to come: total %d", result.TotalRecordCount)
+	}
+	// The client steps by its own page size, so the next page starts at the
+	// addon's position 100, not at row 97: no repeat, no gap.
+	decodeInto(t, f.do(http.MethodGet, "/jellyfin/Users/u/Items?ParentId="+view+"&StartIndex=100&Limit=100", ""), &result)
+	if len(result.Items) != 20 || result.Items[0].Name != "Title 101" || result.Items[19].Name != "Title 120" {
+		t.Fatalf("second page: %d items, first %q", len(result.Items), result.Items[0].Name)
+	}
+	if result.TotalRecordCount != 120 {
+		t.Fatalf("an empty bucket ends the catalog with an exact total: got %d", result.TotalRecordCount)
+	}
+	// A short LAST bucket is probed, so a true last page is exact too.
+	f.catalog.drop = map[int]int{100: 3}
+	decodeInto(t, f.do(http.MethodGet, "/jellyfin/Users/u/Items?ParentId="+view+"&StartIndex=100&Limit=20", ""), &result)
+	if len(result.Items) != 17 || result.TotalRecordCount != 117 {
+		t.Fatalf("short last page: %d items, total %d", len(result.Items), result.TotalRecordCount)
+	}
+	// Page-sized requests walk the same rows without duplicates.
+	f.catalog.drop = map[int]int{0: 2, 40: 1}
+	seen := map[string]bool{}
+	for start := 0; start < 120; start += 30 {
+		decodeInto(t, f.do(http.MethodGet, fmt.Sprintf("/jellyfin/Users/u/Items?ParentId=%s&StartIndex=%d&Limit=30", view, start), ""), &result)
+		for _, item := range result.Items {
+			if seen[item.Name] {
+				t.Fatalf("row %q served twice", item.Name)
+			}
+			seen[item.Name] = true
+		}
+	}
+	if len(seen) != 117 {
+		t.Fatalf("walked %d distinct rows, want 117", len(seen))
 	}
 }
 


### PR DESCRIPTION
## What changed and why

A provider bucket comes back short whenever the addon drops a row it
cannot identify (routinely: a TMDB row with no resolvable IMDb id).
`catalogPage` read a short bucket as the end of the catalog, so viewing
"Trending Series" in Jellyfin capped at 18 of 120 titles while Stremio
users saw every page of the same catalog. Rows now keep the addon's own
position (`p*bucket+j`), so a window is the same rows on every visit;
only an empty bucket ends the catalog, and a short *last* bucket in
range probes the next one once so a true last page still reports an
exact total.

Split out of #301 (which bundled this with an unrelated Kitsu fix) per
one-change-per-PR; the Kitsu trending-skip fix is now its own PR.

## How it was verified

`TestShortBucketDoesNotEndCatalog`: buckets of 18/20/19/20/20 rows at
Limit=100 return 97 items with a "more to come" total; page two returns
the remaining 20 with an exact total of 120; a short *last* bucket
reports an exact total of 117; walking the whole catalog in 30-row pages
visits all 117 distinct rows with no repeats and no gaps. `go fmt`,
`go vet ./...`, `go test ./...` clean, `-race` clean.

## Checklist
- [x] `go fmt`, `go vet ./...`, `go test ./...` pass locally
- [x] Title is a Conventional Commit
- [x] One change per PR
- [x] Test added that failed before the fix
- [x] No user-facing setting to document
- [x] No build artifacts staged
