### PR TITLE
fix(kitsu): answer later trending pages empty instead of repeating page one

### DIFF
--- a/pkg/server/stremio/handlers_catalog.go
+++ b/pkg/server/stremio/handlers_catalog.go
@@ -166,6 +166,11 @@ func (s *Server) serveCatalog(ctx context.Context, def CatalogDef, req catalogRe
 }
 
 func (s *Server) buildCatalog(ctx context.Context, def CatalogDef, req catalogRequest) ([]MetaPreview, error) {
+	if req.Skip > 0 && req.Search == "" && !def.SupportsSkip {
+		// A catalog without paging has only its first page; answering a
+		// skip with the first page again would repeat it.
+		return nil, nil
+	}
 	switch def.Provider {
 	case "tmdb":
 		return s.tmdbCatalog(ctx, def, req)

--- a/pkg/services/metadata/kitsu/kitsu.go
+++ b/pkg/services/metadata/kitsu/kitsu.go
@@ -379,6 +379,11 @@ type listingAPIResponse struct {
 func (c *Client) GetAnimeListing(ctx context.Context, kind string, offset int) ([]AnimeListing, error) {
 	switch kind {
 	case "trending":
+		if offset > 0 {
+			// The trending feed is a fixed top 20 with no paging; a later
+			// page is empty, not the same twenty again.
+			return nil, nil
+		}
 		return c.getListing(ctx, "/trending/anime?limit=20")
 	case "top_rated":
 		return c.getListing(ctx, fmt.Sprintf("/anime?sort=-averageRating&page[limit]=20&page[offset]=%d", offset))

--- a/pkg/services/metadata/kitsu/listing_skip_test.go
+++ b/pkg/services/metadata/kitsu/listing_skip_test.go
@@ -1,0 +1,38 @@
+package kitsu
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+)
+
+// The trending feed is a fixed top 20 upstream; asking past it must answer
+// empty without a request, not the same twenty again.
+func TestTrendingListingHasOnePage(t *testing.T) {
+	var hits atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		if r.URL.Path != "/trending/anime" {
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+		w.Write([]byte(`{"data":[{"id":"1","type":"anime","attributes":{"canonicalTitle":"One"}}]}`))
+	}))
+	defer ts.Close()
+	client := NewClient(ts.Client())
+	client.BaseURL = ts.URL
+
+	first, err := client.GetAnimeListing(context.Background(), "trending", 0)
+	if err != nil || len(first) != 1 {
+		t.Fatalf("first page: %v, %d rows", err, len(first))
+	}
+	second, err := client.GetAnimeListing(context.Background(), "trending", 20)
+	if err != nil || len(second) != 0 {
+		t.Fatalf("second page must be empty: %v, %d rows", err, len(second))
+	}
+	if hits.Load() != 1 {
+		t.Fatalf("a skipped trending page must not hit Kitsu: %d requests", hits.Load())
+	}
+}


### PR DESCRIPTION
## What changed and why

Kitsu's trending feed (`/trending/anime`) is a fixed top 20 with no
paging, but `GetAnimeListing` ignored the offset and re-fetched the
same twenty rows for any later page, so the anime library was hard-
capped at 20 titles while telling the client there was more. A skip
past the first page now answers empty without a request; the general
`buildCatalog` dispatch also stops asking a catalog without
`SupportsSkip` for a second page at all (covering the Stremio route
too, and any future catalog with the same shape).

Split out of #301 (which bundled this with an unrelated paging fix) per
one-change-per-PR.

## How it was verified

`TestTrendingListingHasOnePage`: a second page (`offset=20`) returns
empty with zero additional requests to Kitsu. `go fmt`, `go vet ./...`,
`go test ./...` clean, `-race` clean.

## Checklist
- [x] `go fmt`, `go vet ./...`, `go test ./...` pass locally
- [x] Title is a Conventional Commit
- [x] One change per PR
- [x] Test added that failed before the fix
- [x] No user-facing setting to document
- [x] No build artifacts staged
