### PR TITLE
fix(jellyfin): refuse an oversized image before writing any header

### DIFF
--- a/pkg/server/jellyfin/images.go
+++ b/pkg/server/jellyfin/images.go
@@ -1,6 +1,7 @@
 package jellyfin
 
 import (
+	"bytes"
 	"crypto/sha1"
 	"encoding/hex"
 	"io"
@@ -282,15 +283,19 @@ func (s *Server) relayImage(w http.ResponseWriter, rq *request, rawURL, kind str
 		http.Error(w, "bad gateway", http.StatusBadGateway)
 		return
 	}
+	length := int64(-1)
 	if cl := resp.Header.Get("Content-Length"); cl != "" {
-		if n, err := strconv.ParseInt(cl, 10, 64); err == nil && n > maxImageBody {
-			// Refused before a header is written: a Content-Length promising
-			// more than the cap would otherwise reach the client alongside a
-			// body truncated well short of it.
-			logger.Debug("Jellyfin image relay refused", "url", target, "length", n)
-			http.Error(w, "bad gateway", http.StatusBadGateway)
-			return
+		if n, err := strconv.ParseInt(cl, 10, 64); err == nil {
+			length = n
 		}
+	}
+	if length > maxImageBody {
+		// Refused before a header is written: a Content-Length promising
+		// more than the cap would otherwise reach the client alongside a
+		// body truncated well short of it.
+		logger.Debug("Jellyfin image relay refused", "url", target, "length", length)
+		http.Error(w, "bad gateway", http.StatusBadGateway)
+		return
 	}
 	ct, ok := relayableImageType(resp.Header.Get("Content-Type"))
 	if !ok {
@@ -302,10 +307,29 @@ func (s *Server) relayImage(w http.ResponseWriter, rq *request, rawURL, kind str
 		http.Error(w, "bad gateway", http.StatusBadGateway)
 		return
 	}
-	w.Header().Set("Content-Type", ct)
-	if cl := resp.Header.Get("Content-Length"); cl != "" {
-		w.Header().Set("Content-Length", cl)
+	var body io.Reader = resp.Body
+	if length < 0 {
+		// No Content-Length: the cap can only be enforced by reading. Read to
+		// the cap plus one byte before any header is written, so an oversized
+		// body is refused outright instead of cut off mid-image behind a 200 —
+		// a client cannot tell a truncated JPEG from a whole one. Bounded by
+		// the cap, and rare: CDNs send a length for a static file.
+		buf, err := io.ReadAll(io.LimitReader(resp.Body, maxImageBody+1))
+		if err != nil {
+			logger.Debug("Jellyfin image relay failed", "url", target, "err", err)
+			http.Error(w, "bad gateway", http.StatusBadGateway)
+			return
+		}
+		if len(buf) > maxImageBody {
+			logger.Debug("Jellyfin image relay refused", "url", target, "length", ">"+strconv.Itoa(maxImageBody))
+			http.Error(w, "bad gateway", http.StatusBadGateway)
+			return
+		}
+		length = int64(len(buf))
+		body = bytes.NewReader(buf)
 	}
+	w.Header().Set("Content-Type", ct)
+	w.Header().Set("Content-Length", strconv.FormatInt(length, 10))
 	if etag := resp.Header.Get("ETag"); etag != "" {
 		w.Header().Set("ETag", etag)
 	}
@@ -317,10 +341,9 @@ func (s *Server) relayImage(w http.ResponseWriter, rq *request, rawURL, kind str
 	if rq.Method == http.MethodHead {
 		return
 	}
-	written, _ := io.Copy(w, io.LimitReader(resp.Body, maxImageBody)) // write errors ignored: the client went away
-	if written == maxImageBody {
-		logger.Debug("Jellyfin image relay body truncated", "url", target, "limit", maxImageBody)
-	}
+	// A declared length is enforced by net/http on the upstream side: the body
+	// ends at Content-Length whatever the CDN sends after it.
+	io.Copy(w, body) // write errors ignored: the client went away
 }
 
 // rewriteImageSize points a TMDB image at a size proportional to how large

--- a/pkg/server/jellyfin/images_relay_test.go
+++ b/pkg/server/jellyfin/images_relay_test.go
@@ -1,6 +1,12 @@
 package jellyfin
 
-import "testing"
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+)
 
 // An image relay serves the upstream's bytes from this server's own origin, so
 // the upstream must not get to pick a content type the browser will execute.
@@ -25,5 +31,46 @@ func TestRelayableImageType(t *testing.T) {
 		if ok != tc.ok || got != tc.want {
 			t.Errorf("relayableImageType(%q) = (%q, %v), want (%q, %v)", tc.raw, got, ok, tc.want, tc.ok)
 		}
+	}
+}
+
+// An upstream that sends no Content-Length can only be capped by reading.
+// A body past the cap used to be cut off behind a 200 -- a truncated JPEG a
+// client cannot tell from a whole one. It is refused before any header goes
+// out; one under the cap is served whole, with the length it turned out to be.
+func TestImageRelayUnknownLengthBody(t *testing.T) {
+	small := strings.Repeat("x", 4096)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/jpeg")
+		w.Header().Set("Transfer-Encoding", "chunked") // no Content-Length
+		if strings.Contains(r.URL.Path, "huge") {
+			chunk := []byte(strings.Repeat("y", 1<<20))
+			for sent := 0; sent <= maxImageBody; sent += len(chunk) {
+				w.Write(chunk)
+			}
+			return
+		}
+		w.Write([]byte(small))
+	}))
+	defer upstream.Close()
+	f := newFixture()
+	movie, _ := itemIDFor("movie", "tt0111161")
+
+	f.catalog.metas["movie/tt0111161"].Background = upstream.URL + "/huge.jpg"
+	rec := f.do(http.MethodGet, "/jellyfin/Items/"+movie.encode()+"/Images/Backdrop", "")
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("oversized unknown-length body: %d, want 502", rec.Code)
+	}
+	if rec.Header().Get("Content-Type") == "image/jpeg" || strings.Contains(rec.Body.String(), "yyyy") {
+		t.Fatalf("oversized unknown-length body leaked: %+v %d bytes", rec.Header(), rec.Body.Len())
+	}
+
+	f.catalog.metas["movie/tt0111161"].Background = upstream.URL + "/small.jpg"
+	rec = f.do(http.MethodGet, "/jellyfin/Items/"+movie.encode()+"/Images/Backdrop", "")
+	if rec.Code != http.StatusOK || rec.Body.String() != small {
+		t.Fatalf("unknown-length body under the cap: %d %d bytes", rec.Code, rec.Body.Len())
+	}
+	if cl := rec.Header().Get("Content-Length"); cl != strconv.Itoa(len(small)) {
+		t.Fatalf("unknown-length body served without its length: %q", cl)
 	}
 }


### PR DESCRIPTION
## What changed and why

An upstream with no Content-Length could only be capped by reading, and
the relay copied straight to the client with `io.LimitReader`: a body
past the cap was cut off mid-stream behind an already-sent 200, leaving
a truncated JPEG a client cannot tell from a whole one. It now reads to
the cap plus one byte before writing anything, refuses outright on an
oversized body, and serves an under-cap body whole with its real
Content-Length rather than whatever the upstream happened to send.

Split out of #303 (which bundled three unrelated relay fixes) per
one-change-per-PR.

## How it was verified

`TestImageRelayUnknownLengthBody`: an unknown-length body past the cap
is refused with 502 and never appears in the response; one under the
cap is served whole with the correct `Content-Length`. `go fmt`,
`go vet ./...`, `go test ./...` clean, `-race` clean.

## Checklist
- [x] `go fmt`, `go vet ./...`, `go test ./...` pass locally
- [x] Title is a Conventional Commit
- [x] One change per PR
- [x] Test added that failed before the fix
- [x] No user-facing setting to document
- [x] No build artifacts staged
