### PR TITLE
fix(jellyfin): answer an unfetchable poster URL 404, not a redirect

### DIFF
--- a/pkg/server/jellyfin/images.go
+++ b/pkg/server/jellyfin/images.go
@@ -253,9 +253,12 @@ func relayableImageType(raw string) (string, bool) {
 func (s *Server) relayImage(w http.ResponseWriter, rq *request, rawURL, kind string) {
 	u, err := url.Parse(rawURL)
 	if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
-		// Nothing here to fetch on the client's behalf; the redirect is the
-		// only path left for a scheme this layer cannot relay.
-		http.Redirect(w, rq.Request, rawURL, http.StatusFound)
+		// Nothing here to fetch on the client's behalf, and a redirect is
+		// exactly what this relay exists to avoid: the clients that need
+		// relaying would not follow it either. A miss, not a gateway
+		// failure -- the image simply isn't reachable this way.
+		logger.Debug("Jellyfin image relay skipped", "url", rawURL, "reason", "not an http(s) url")
+		http.NotFound(w, rq.Request)
 		return
 	}
 	target := rewriteImageSize(rawURL, kind)

--- a/pkg/server/jellyfin/images_relay_test.go
+++ b/pkg/server/jellyfin/images_relay_test.go
@@ -1,6 +1,9 @@
 package jellyfin
 
-import "testing"
+import (
+	"net/http"
+	"testing"
+)
 
 // An image relay serves the upstream's bytes from this server's own origin, so
 // the upstream must not get to pick a content type the browser will execute.
@@ -24,6 +27,21 @@ func TestRelayableImageType(t *testing.T) {
 		got, ok := relayableImageType(tc.raw)
 		if ok != tc.ok || got != tc.want {
 			t.Errorf("relayableImageType(%q) = (%q, %v), want (%q, %v)", tc.raw, got, ok, tc.want, tc.ok)
+		}
+	}
+}
+
+// A poster URL this layer cannot fetch used to be answered with a redirect to
+// it -- the one response the relay exists to avoid. It is a miss like any
+// other, not a gateway failure.
+func TestImageRelayUnfetchableURLIsNotFoundNotRedirect(t *testing.T) {
+	for _, raw := range []string{"ftp://cdn.example/poster.jpg", "poster.jpg", "://bad"} {
+		f := newFixture()
+		f.catalog.metas["movie/tt0111161"].Poster = raw
+		movie, _ := itemIDFor("movie", "tt0111161")
+		rec := f.do(http.MethodGet, "/jellyfin/Items/"+movie.encode()+"/Images/Primary", "")
+		if rec.Code != http.StatusNotFound || rec.Header().Get("Location") != "" {
+			t.Fatalf("%q: %d location=%q, want 404 and no redirect", raw, rec.Code, rec.Header().Get("Location"))
 		}
 	}
 }


### PR DESCRIPTION
## What changed and why

A poster URL this layer cannot relay (a scheme other than http/https,
or one that fails to parse) was answered with a 302 to it — the one
response the image relay exists to avoid, since it exists specifically
because Infuse and other clients do not follow redirects for artwork.
It is now a plain miss, matching every other way an image can turn out
to be unavailable.

Split out of #303 (which bundled three unrelated relay fixes) per
one-change-per-PR.

## How it was verified

`TestImageRelayUnfetchableURLIsNotFoundNotRedirect`: an ftp URL, a
relative path, and a malformed URL all answer 404 with no `Location`
header. `go fmt`, `go vet ./...`, `go test ./...` clean, `-race` clean.

## Checklist
- [x] `go fmt`, `go vet ./...`, `go test ./...` pass locally
- [x] Title is a Conventional Commit
- [x] One change per PR
- [x] Test added that failed before the fix
- [x] No user-facing setting to document
- [x] No build artifacts staged
