### PR TITLE
fix(search): stop the attempt editor from deleting rows it was asked …

### DIFF
--- a/docs/search-queries.md
+++ b/docs/search-queries.md
@@ -10,7 +10,7 @@ stop**, and one description of what a matching release **must look like**.
 | Field | Meaning |
 |---|---|
 | **Name** | Unique identifier; streams reference it. Fixed after creation. |
-| **Attempts** | The questions the request asks indexers, in order — one indexer query per row. Each row has an **Address** and, for TV, a **Target**; Title rows also carry a language and whether to put the year in the query. Presets (*Balanced*, *Precise*, *Broad*) fill in a sensible list; drag rows to reorder. |
+| **Attempts** | The questions the request asks indexers, in order — one indexer query per row. Each row has an **Address** and, for TV, a **Target**; Title rows also carry a language and whether to put the year in the query. Presets (*Balanced*, *Precise*, *Broad*) fill in a sensible list; drag rows to reorder. Two rows asking exactly the same question are one wasted round trip rather than a fallback: the repeat is marked *same as #n* and the request will not save until it is changed or removed. |
 | **When to stop** | **Stop at first hit** walks the rows in order and stops at the first one that matched anything. **Stop after enough hits** keeps walking until the rows asked so far have matched at least **Minimum hits** distinct releases between them. **Run every attempt** asks every row every time and merges the results. |
 | **Minimum hits** | The threshold for *Stop after enough hits* (default 10). Counts releases that passed validation, with the same release listed by several indexers counted once; everything found on the way is kept. |
 | **Ordering** *(TV)* | **As listed** runs the rows as written. **Season first once it has aired** moves the Season rows to the front once every episode of the requested season has aired — a finished season is where the season pack lives, an airing one is where the single episode does. |
@@ -31,8 +31,9 @@ An attempt's **Address** is how it asks:
 Its **Target** is what it asks for, on TV: **Episode** (`S01E04` /
 `season=`+`ep=`), **Season** (`S01` / `season=`), **Series** (the title alone),
 or **Absolute** — the anime absolute episode number (`One Piece 63`), for
-indexers that number that way. Absolute rows are skipped outright for anything
-that is not anime, and a row whose target the content cannot supply (an Episode
+indexers that number that way. Absolute is a Title-only question — an ID search
+has no absolute number to name — so switching an Absolute row to ID moves it to
+Episode. Absolute rows are skipped outright for anything that is not anime, and a row whose target the content cannot supply (an Episode
 row for a season-only request) drops to the next narrower target rather than
 being skipped.
 

--- a/frontend/src/components/SearchQuerySettings.jsx
+++ b/frontend/src/components/SearchQuerySettings.jsx
@@ -22,12 +22,14 @@ import {
   STOP_ENOUGH_HITS,
   STOP_OPTIONS,
   TARGET_ABSOLUTE,
+  TARGET_EPISODE,
   TARGET_OPTIONS,
   attemptKey,
   attemptLabel,
   attemptsInRunOrder,
-  defaultAttempt,
+  duplicateAttemptSources,
   isSeriesKind,
+  nextAttempt,
   normalizeAddress,
   normalizeAttempt,
   normalizeAttempts,
@@ -37,6 +39,7 @@ import {
   normalizeTarget,
   planPresets,
   presetPlan,
+  settleAttempts,
 } from "@/lib/searchPlan"
 import { SortableList, SortableRow } from "@/components/SortableList"
 import { moveItem } from "@/lib/lists"
@@ -241,7 +244,10 @@ function normalizeDraft(kind, draft) {
   const value = draft || {}
   return {
     name: (value.name || '').trim(),
-    attempts: normalizeAttempts(value.attempts, kind),
+    // Settled but not deduped: the editor has to be able to show a row that
+    // repeats another one, or an edit that produces one looks like the row
+    // being deleted.
+    attempts: settleAttempts(value.attempts, kind),
     stop: normalizeStop(value.stop),
     min_hits: normalizeMinHits(value.stop, value.min_hits),
     order: isSeriesKind(kind) ? normalizeOrder(value.order) : undefined,
@@ -252,11 +258,15 @@ function normalizeDraft(kind, draft) {
 }
 
 function persistableDraft(kind, draft) {
-  return normalizeDraft(kind, draft)
+  const next = normalizeDraft(kind, draft)
+  // Two attempts asking the same question are one wasted round trip; saving
+  // one of each matches what the backend would keep anyway.
+  next.attempts = normalizeAttempts(next.attempts, kind)
+  return next
 }
 
 function comparableQuerySignature(kind, draft) {
-  const value = normalizeDraft(kind, draft)
+  const value = persistableDraft(kind, draft)
   return JSON.stringify({
     attempts: value.attempts,
     stop: value.stop,
@@ -482,12 +492,21 @@ const attemptSelectClass = "h-8 rounded-md border border-input bg-background px-
 // AttemptRow is one question in the plan. Everything it needs is on the row —
 // address, target, and for a title attempt the language it queries under and
 // whether the year rides along — because that is exactly what gets dispatched.
-function AttemptRow({ kind, index, attempt, onChange, onRemove, canRemove }) {
+function AttemptRow({ kind, index, attempt, onChange, onRemove, canRemove, duplicateOf = -1 }) {
   const address = normalizeAddress(attempt.address)
   const target = normalizeTarget(attempt.target)
   const isTitle = address === ADDRESS_TITLE
   const isSeries = isSeriesKind(kind)
-  const update = (patch) => onChange(normalizeAttempt({ ...attempt, ...patch }, kind))
+  const update = (patch) => {
+    const next = { ...attempt, ...patch }
+    // The absolute number is how anime is named, and an id request cannot ask
+    // under it — the option is disabled for id, so a row switched to id lands
+    // on the episode rather than keeping a target the executor would drop.
+    if (normalizeAddress(next.address) === ADDRESS_ID && normalizeTarget(next.target) === TARGET_ABSOLUTE) {
+      next.target = TARGET_EPISODE
+    }
+    onChange(normalizeAttempt(next, kind))
+  }
 
   return (
     <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
@@ -543,6 +562,18 @@ function AttemptRow({ kind, index, attempt, onChange, onRemove, canRemove }) {
       {isSeries && target === TARGET_ABSOLUTE ? (
         <Badge variant="outline" className="rounded-full px-2 py-0 text-[11px] font-normal text-muted-foreground">anime only</Badge>
       ) : null}
+      {duplicateOf >= 0 ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Badge variant="outline" className="rounded-full border-destructive/50 px-2 py-0 text-[11px] font-normal text-destructive">
+              same as #{duplicateOf + 1}
+            </Badge>
+          </TooltipTrigger>
+          <TooltipContent>
+            This row asks exactly what attempt {duplicateOf + 1} asks. Change or remove it — the same question twice is a wasted round trip, not a fallback.
+          </TooltipContent>
+        </Tooltip>
+      ) : null}
       <Tooltip>
         <TooltipTrigger asChild>
           <Button
@@ -552,6 +583,7 @@ function AttemptRow({ kind, index, attempt, onChange, onRemove, canRemove }) {
             className="ml-auto h-8 w-8 text-muted-foreground hover:text-destructive"
             onClick={onRemove}
             disabled={!canRemove}
+            aria-label={`Remove attempt ${index + 1}`}
           >
             <Trash2 className="h-4 w-4" />
           </Button>
@@ -580,9 +612,12 @@ function AttemptChain({ kind, attempts, order, seasonCompleted = false }) {
   )
 }
 
-function QueryDraftFields({ kind, draft, setDraft, editing = false, fieldErrors = {} }) {
+// Exported for the editor tests, which drive the attempt rows directly rather
+// than through the dialog chrome around them.
+export function QueryDraftFields({ kind, draft, setDraft, editing = false, fieldErrors = {} }) {
   const isSeries = isSeriesKind(kind)
-  const attempts = normalizeAttempts(draft.attempts, kind)
+  const attempts = settleAttempts(draft.attempts, kind)
+  const duplicates = duplicateAttemptSources(attempts, kind)
   const accept = normalizeAccept(kind, draft.accept)
   const stop = normalizeStop(draft.stop)
   const order = normalizeOrder(draft.order)
@@ -661,6 +696,7 @@ function QueryDraftFields({ kind, draft, setDraft, editing = false, fieldErrors 
                     kind={kind}
                     index={index}
                     attempt={attempt}
+                    duplicateOf={duplicates.has(index) ? duplicates.get(index) : -1}
                     canRemove={attempts.length > 1}
                     onChange={(next) => setAttempts(attempts.map((current, at) => (at === index ? next : current)))}
                     onRemove={() => setAttempts(attempts.filter((_, at) => at !== index))}
@@ -677,7 +713,7 @@ function QueryDraftFields({ kind, draft, setDraft, editing = false, fieldErrors 
               type="button"
               variant="outline"
               className="h-8 w-full gap-1.5 border-dashed text-xs font-normal"
-              onClick={() => setAttempts([...attempts, defaultAttempt(kind)])}
+              onClick={() => setAttempts([...attempts, nextAttempt(attempts, kind)])}
             >
               <Plus className="h-3.5 w-3.5" />
               Add attempt
@@ -900,6 +936,7 @@ function QueryDialog({ open, onOpenChange, kind, initialValue, existingNames = [
 
   const handleSave = () => {
     const next = persistableDraft(kind, draft)
+    const duplicateAttempts = duplicateAttemptSources(draft.attempts, kind)
     const limit = Number(next.search_result_limit)
     return dialog.runSave({
       validate: () => {
@@ -909,6 +946,9 @@ function QueryDialog({ open, onOpenChange, kind, initialValue, existingNames = [
         if (duplicateQuery) nextFieldErrors.name = `An identical search request already exists: "${duplicateQueryName}".`
         if (next.attempts.length === 0) {
           nextFieldErrors.attempts = 'Add at least one attempt.'
+        } else if (duplicateAttempts.size > 0) {
+          const [index, source] = duplicateAttempts.entries().next().value
+          nextFieldErrors.attempts = `Attempt ${index + 1} asks exactly what attempt ${source + 1} asks. Change or remove it.`
         }
         if (Number.isNaN(limit) || limit < 0) {
           nextFieldErrors.search_result_limit = 'Limit must be 0 or greater.'

--- a/frontend/src/components/SearchQuerySettings.test.jsx
+++ b/frontend/src/components/SearchQuerySettings.test.jsx
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+import { useState } from 'react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { TooltipProvider } from '@/components/ui/tooltip'
+import { QueryDraftFields } from '@/components/SearchQuerySettings'
+import { presetPlan } from '@/lib/searchPlan'
+
+function Editor({ kind = 'series', plan = presetPlan(kind, 'balanced') }) {
+  const [draft, setDraft] = useState({ name: 'TVQuery01', ...plan })
+  return (
+    <TooltipProvider>
+      <QueryDraftFields kind={kind} draft={draft} setDraft={setDraft} />
+    </TooltipProvider>
+  )
+}
+
+const addressSelects = () => screen.getAllByLabelText(/address$/)
+const targetSelects = () => screen.getAllByLabelText(/target$/)
+
+describe('attempt rows', () => {
+  afterEach(cleanup)
+
+  // The reported bug: on a plan that already asks the default question, "Add
+  // attempt" added a row that was deduped away before it could be rendered,
+  // so the button looked dead.
+  it('adds a row for a question the plan does not already ask', () => {
+    render(<Editor />)
+    expect(addressSelects()).toHaveLength(5)
+
+    fireEvent.click(screen.getByText('Add attempt'))
+
+    expect(addressSelects()).toHaveLength(6)
+    expect(addressSelects()[5].value).toBe('id')
+    expect(targetSelects()[5].value).toBe('series')
+  })
+
+  // The other half: editing a row into one the plan already asks used to make
+  // the row vanish. It stays, and says what it collides with.
+  it('keeps a row that ends up asking what an earlier row asks, and marks it', () => {
+    render(<Editor />)
+    // Row 3 is Title · Episode; switching it to id repeats row 1.
+    fireEvent.change(addressSelects()[2], { target: { value: 'id' } })
+
+    expect(addressSelects()).toHaveLength(5)
+    expect(addressSelects()[2].value).toBe('id')
+    expect(screen.getByText('same as #1')).toBeTruthy()
+  })
+
+  // Row 2 of the preset is Title · Absolute, and an id request cannot ask
+  // under the absolute number — the target select disables that pairing.
+  it('moves an absolute row off the absolute number when it switches to id', () => {
+    render(<Editor />)
+    fireEvent.change(addressSelects()[1], { target: { value: 'id' } })
+
+    expect(targetSelects()[1].value).toBe('episode')
+  })
+
+  it('removes the row it is asked to remove', () => {
+    render(<Editor />)
+    fireEvent.click(screen.getByLabelText('Remove attempt 1'))
+
+    expect(addressSelects()).toHaveLength(4)
+    expect(addressSelects()[0].value).toBe('title')
+  })
+})

--- a/frontend/src/lib/searchPlan.js
+++ b/frontend/src/lib/searchPlan.js
@@ -110,18 +110,49 @@ export function normalizeAttempt(attempt, kind) {
   return next
 }
 
-export function normalizeAttempts(attempts, kind) {
+// settleAttempts settles every attempt and keeps every row. The editor works
+// on this: a row stays where the user put it even when it momentarily asks
+// what another row already asks, so an edit is never answered by the row
+// silently disappearing.
+export function settleAttempts(attempts, kind) {
   const list = Array.isArray(attempts) ? attempts : []
+  return list.map((attempt) => normalizeAttempt(attempt, kind))
+}
+
+// attemptSignature is the question an attempt asks. Two rows sharing one are
+// one wasted indexer round trip, never a fallback — the same identity
+// config.NormalizeSearchAttempts dedupes on.
+export function attemptSignature(attempt, kind) {
+  return JSON.stringify(normalizeAttempt(attempt, kind))
+}
+
+export function normalizeAttempts(attempts, kind) {
   const seen = new Set()
   const out = []
-  for (const attempt of list) {
-    const normalized = normalizeAttempt(attempt, kind)
-    const key = JSON.stringify(normalized)
+  for (const attempt of settleAttempts(attempts, kind)) {
+    const key = attemptSignature(attempt, kind)
     if (seen.has(key)) continue
     seen.add(key)
-    out.push(normalized)
+    out.push(attempt)
   }
   return out
+}
+
+// duplicateAttemptSources maps each row that repeats an earlier question to
+// the row it repeats, for the editor to mark. These are exactly the rows
+// normalizeAttempts drops on the way out.
+export function duplicateAttemptSources(attempts, kind) {
+  const firstSeen = new Map()
+  const duplicates = new Map()
+  settleAttempts(attempts, kind).forEach((attempt, index) => {
+    const key = attemptSignature(attempt, kind)
+    if (firstSeen.has(key)) {
+      duplicates.set(index, firstSeen.get(key))
+      return
+    }
+    firstSeen.set(key, index)
+  })
+  return duplicates
 }
 
 // attemptKey identifies a row for drag reordering. Attempts have no id of
@@ -147,6 +178,28 @@ export function attemptLabel(attempt, kind) {
 
 export function defaultAttempt(kind) {
   return normalizeAttempt({ address: ADDRESS_ID, target: TARGET_EPISODE }, kind)
+}
+
+// The title language a new attempt queries under, matching the presets.
+const DEFAULT_TITLE_LANGUAGE = 'en-US'
+
+// nextAttempt is the attempt "Add attempt" adds: the first question the plan
+// does not already ask, so the new row is one the user sees and the plan runs.
+// A plan that already asks every combination gets the default back — a row the
+// editor marks as a duplicate rather than one that never appears.
+export function nextAttempt(attempts, kind) {
+  const asked = new Set(settleAttempts(attempts, kind).map((attempt) => attemptSignature(attempt, kind)))
+  const targets = isSeriesKind(kind) ? TARGET_OPTIONS.map((option) => option.value) : [undefined]
+  for (const target of targets) {
+    for (const address of [ADDRESS_ID, ADDRESS_TITLE]) {
+      // The absolute number is how anime is named, and an id request cannot
+      // ask under it — the executor drops that pairing.
+      if (address === ADDRESS_ID && target === TARGET_ABSOLUTE) continue
+      const candidate = normalizeAttempt({ address, target, title: DEFAULT_TITLE_LANGUAGE }, kind)
+      if (!asked.has(attemptSignature(candidate, kind))) return candidate
+    }
+  }
+  return defaultAttempt(kind)
 }
 
 // The presets are the stock plans, and the same lists pkg/core/config seeds a

--- a/frontend/src/lib/searchPlan.test.js
+++ b/frontend/src/lib/searchPlan.test.js
@@ -13,6 +13,8 @@ import {
   TARGET_SEASON,
   attemptLabel,
   attemptsInRunOrder,
+  duplicateAttemptSources,
+  nextAttempt,
   normalizeAttempt,
   normalizeAttempts,
   normalizeMinHits,
@@ -20,6 +22,7 @@ import {
   normalizeStop,
   planPresets,
   presetPlan,
+  settleAttempts,
 } from './searchPlan'
 
 const labels = (attempts, kind) => attempts.map((attempt) => attemptLabel(attempt, kind))
@@ -57,6 +60,67 @@ describe('normalizeAttempts', () => {
     expect(labels(attempts, 'series')).toEqual(['ID · Episode', 'Title · Episode', 'Title · Episode'])
     expect(attempts[1].title).toBe('en-US')
     expect(attempts[2].title).toBe('de-DE')
+  })
+})
+
+describe('settleAttempts', () => {
+  it('keeps a row that repeats another, which the editor has to be able to show', () => {
+    const attempts = settleAttempts([
+      { address: 'id', target: 'episode' },
+      { address: 'ID', target: 'EPISODE' },
+    ], 'series')
+    expect(labels(attempts, 'series')).toEqual(['ID · Episode', 'ID · Episode'])
+  })
+})
+
+describe('duplicateAttemptSources', () => {
+  it('points each repeat at the row it repeats', () => {
+    const duplicates = duplicateAttemptSources([
+      { address: 'id', target: 'episode' },
+      { address: 'title', target: 'episode', title: 'en-US' },
+      { address: 'ID', target: 'EPISODE' },
+      { address: 'title', target: 'episode', title: 'de-DE' },
+    ], 'series')
+    expect([...duplicates.entries()]).toEqual([[2, 0]])
+  })
+
+  it('reads an id attempt without its title language, as the executor does', () => {
+    const duplicates = duplicateAttemptSources([
+      { address: 'id', target: 'season', title: 'en-US' },
+      { address: 'id', target: 'season', title: 'de-DE', year: true },
+    ], 'series')
+    expect([...duplicates.entries()]).toEqual([[1, 0]])
+  })
+})
+
+describe('nextAttempt', () => {
+  // The bug this answers: adding an attempt the plan already asks looked like
+  // the button doing nothing at all, because the new row was deduped away.
+  it('adds a question the plan does not already ask', () => {
+    const plan = presetPlan('series', 'balanced')
+    expect(attemptLabel(nextAttempt(plan.attempts, 'series'), 'series')).toBe('ID · Series')
+  })
+
+  it('starts from the narrowest id question on an empty plan', () => {
+    expect(attemptLabel(nextAttempt([], 'series'), 'series')).toBe('ID · Episode')
+    expect(attemptLabel(nextAttempt([], 'movie'), 'movie')).toBe('ID')
+  })
+
+  it('never offers the absolute number to an id request, which cannot ask under it', () => {
+    const asked = [
+      { address: ADDRESS_ID, target: TARGET_EPISODE },
+      { address: ADDRESS_TITLE, target: TARGET_EPISODE, title: 'en-US' },
+      { address: ADDRESS_ID, target: TARGET_SEASON },
+      { address: ADDRESS_TITLE, target: TARGET_SEASON, title: 'en-US' },
+      { address: ADDRESS_ID, target: 'series' },
+      { address: ADDRESS_TITLE, target: 'series', title: 'en-US' },
+      { address: ADDRESS_TITLE, target: TARGET_ABSOLUTE, title: 'en-US' },
+    ]
+    expect(attemptLabel(nextAttempt(asked, 'series'), 'series')).toBe('ID · Episode')
+  })
+
+  it('falls back to the movie title attempt once the id one is taken', () => {
+    expect(attemptLabel(nextAttempt([{ address: ADDRESS_ID }], 'movie'), 'movie')).toBe('Title')
   })
 })
 


### PR DESCRIPTION
…to edit

The editor rendered its rows from normalizeAttempts, which drops exact duplicates. Every edit that produced a row equal to an earlier one deleted it instead: "Add attempt" appended ID·Episode, which every stock preset already asks, so the button looked dead, and switching a Title row to ID — an ID attempt carries no language and no year — collapsed it onto the preset's first row and the row vanished under the cursor.

The editor now works on settled-but-not-deduped attempts, so a row stays where the user put it. A row that repeats an earlier question is marked "same as #n" and blocks the save rather than disappearing; only what is persisted collapses twins, as the backend does anyway. "Add attempt" adds the first question the plan does not already ask. Switching an Absolute row to ID moves it to Episode, since ID cannot ask under the absolute number and the executor drops that pairing.

Fixes #292

<!--
The PR title becomes the squash commit message and feeds release-please, so it
must be a Conventional Commit describing the behavior change:
  fix(loader): stop zero-filling past the last segment
  feat(jellyfin): expose season art in the items endpoint
See CONTRIBUTING.md for the full requirements.
-->

## What changed and why

<!-- What was broken or missing, and what this does about it. Link the issue if there is one. -->

## How it was verified

<!-- Tests added or changed, and anything you checked by hand (which client, which release, what you saw in streamnzb.log). -->

## Checklist

- [ ] `bash build.sh` (or `build.bat`) finishes with `Build Complete!`
- [ ] Title is a Conventional Commit (`type(scope): behavior change`)
- [ ] One change per PR; no unrelated formatting or drive-by edits
- [ ] New behavior has a test; a bug fix has a test that failed before the fix
- [ ] User-facing changes are documented under `docs/` (and a new page is linked from `docs/README.md` and the README)
- [ ] No build artifacts staged (`streamnzb`, `*.log`, `streamnzb.db*`, `config.json`, `frontend/dist/`, `pkg/server/web/static/`)
